### PR TITLE
Fix translation links to use absolute GitBook URLs

### DIFF
--- a/docs-impactmojo-bn/SUMMARY.md
+++ b/docs-impactmojo-bn/SUMMARY.md
@@ -37,10 +37,10 @@
 
 ## অন্যান্য ভাষা
 
-* [English](../docs-impactmojo/README.md)
-* [हिन्दी (Hindi)](../docs-impactmojo-hi/README.md)
-* [मराठी (Marathi)](../docs-impactmojo-mr/README.md)
-* [தமிழ் (Tamil)](../docs-impactmojo-ta/README.md)
+* [English](https://impactmojo.gitbook.io/impactmojo/)
+* [हिन्दी (Hindi)](https://impactmojo.gitbook.io/impactmojo/hi/)
+* [मराठी (Marathi)](https://impactmojo.gitbook.io/impactmojo/mr/)
+* [தமிழ் (Tamil)](https://impactmojo.gitbook.io/impactmojo/ta/)
 
 ## সম্পর্কে
 

--- a/docs-impactmojo-hi/SUMMARY.md
+++ b/docs-impactmojo-hi/SUMMARY.md
@@ -37,10 +37,10 @@
 
 ## अन्य भाषाएँ
 
-* [English](../docs-impactmojo/README.md)
-* [বাংলা (Bengali)](../docs-impactmojo-bn/README.md)
-* [मराठी (Marathi)](../docs-impactmojo-mr/README.md)
-* [தமிழ் (Tamil)](../docs-impactmojo-ta/README.md)
+* [English](https://impactmojo.gitbook.io/impactmojo/)
+* [বাংলা (Bengali)](https://impactmojo.gitbook.io/impactmojo/bn/)
+* [मराठी (Marathi)](https://impactmojo.gitbook.io/impactmojo/mr/)
+* [தமிழ் (Tamil)](https://impactmojo.gitbook.io/impactmojo/ta/)
 
 ## परिचय
 

--- a/docs-impactmojo-mr/SUMMARY.md
+++ b/docs-impactmojo-mr/SUMMARY.md
@@ -37,10 +37,10 @@
 
 ## इतर भाषा
 
-* [English](../docs-impactmojo/README.md)
-* [हिन्दी (Hindi)](../docs-impactmojo-hi/README.md)
-* [বাংলা (Bengali)](../docs-impactmojo-bn/README.md)
-* [தமிழ் (Tamil)](../docs-impactmojo-ta/README.md)
+* [English](https://impactmojo.gitbook.io/impactmojo/)
+* [हिन्दी (Hindi)](https://impactmojo.gitbook.io/impactmojo/hi/)
+* [বাংলা (Bengali)](https://impactmojo.gitbook.io/impactmojo/bn/)
+* [தமிழ் (Tamil)](https://impactmojo.gitbook.io/impactmojo/ta/)
 
 ## विषयी
 

--- a/docs-impactmojo-ta/SUMMARY.md
+++ b/docs-impactmojo-ta/SUMMARY.md
@@ -37,10 +37,10 @@
 
 ## பிற மொழிகள்
 
-* [English](../docs-impactmojo/README.md)
-* [हिन्दी (Hindi)](../docs-impactmojo-hi/README.md)
-* [বাংলা (Bengali)](../docs-impactmojo-bn/README.md)
-* [मराठी (Marathi)](../docs-impactmojo-mr/README.md)
+* [English](https://impactmojo.gitbook.io/impactmojo/)
+* [हिन्दी (Hindi)](https://impactmojo.gitbook.io/impactmojo/hi/)
+* [বাংলা (Bengali)](https://impactmojo.gitbook.io/impactmojo/bn/)
+* [मराठी (Marathi)](https://impactmojo.gitbook.io/impactmojo/mr/)
 
 ## பற்றி
 

--- a/docs-impactmojo/SUMMARY.md
+++ b/docs-impactmojo/SUMMARY.md
@@ -37,10 +37,10 @@
 
 ## Translations
 
-* [हिन्दी (Hindi)](../docs-impactmojo-hi/README.md)
-* [বাংলা (Bengali)](../docs-impactmojo-bn/README.md)
-* [मराठी (Marathi)](../docs-impactmojo-mr/README.md)
-* [தமிழ் (Tamil)](../docs-impactmojo-ta/README.md)
+* [हिन्दी (Hindi)](https://impactmojo.gitbook.io/impactmojo/hi/)
+* [বাংলা (Bengali)](https://impactmojo.gitbook.io/impactmojo/bn/)
+* [मराठी (Marathi)](https://impactmojo.gitbook.io/impactmojo/mr/)
+* [தமிழ் (Tamil)](https://impactmojo.gitbook.io/impactmojo/ta/)
 
 ## About
 


### PR DESCRIPTION
## Summary
- Replaces broken relative paths (`../docs-impactmojo-hi/`) with absolute GitBook URLs
- GitBook scopes each space to its root folder, so cross-folder relative paths are unreachable
- All 5 SUMMARY.md files now link to `impactmojo.gitbook.io/impactmojo/{lang}/`

## Test plan
- [ ] Verify translation links appear and are clickable in GitBook sidebar
- [ ] Confirm each link opens the correct language version

https://claude.ai/code/session_01T2Ui2cQD777WeV4bR3eA5A