### PR TITLE
Fix role switcher overlap, add docs page, v25.2 changelog

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 ## User Guide
 
 * [Platform Overview](user-guide/overview.md)
+* [Role-Based Landing Experience](user-guide/role-selector.md)
 * [AQI Dashboard](user-guide/aqi-dashboard.md)
 * [Health Impact Calculator](user-guide/health-calculator.md)
 * [Economic Cost Analysis](user-guide/economic-cost.md)

--- a/docs/user-guide/role-selector.md
+++ b/docs/user-guide/role-selector.md
@@ -1,0 +1,87 @@
+# Role-Based Landing Experience
+
+JanVayu's role selector helps visitors find the most relevant data, tools, and actions based on who they are. Instead of presenting the full 36+ panel dashboard to everyone, the platform guides each visitor to a curated subset.
+
+## How It Works
+
+### First Visit
+
+When a visitor arrives at janvayu.in without a hash fragment (e.g. `#health`), a full-screen overlay presents 10 role cards:
+
+| Role | Key | Example Action |
+|------|-----|----------------|
+| Parent / Family | `parent` | "Should my child go outside?" |
+| Student | `student` | "Explore historical AQI trends" |
+| Researcher | `researcher` | "Access the data archive" |
+| Policymaker | `policymaker` | "Track NCAP mission targets" |
+| Journalist | `journalist` | "Generate an accountability brief" |
+| Citizen / Activist | `activist` | "File an RTI request" |
+| Doctor / Health Worker | `doctor` | "Health risk calculator" |
+| Teacher | `teacher` | "Should school close today?" |
+| NGO / CSO | `ngo` | "Generate an advocacy brief" |
+| Business Owner | `business` | "See the economic impact" |
+
+A "Skip — show me everything" option bypasses the overlay entirely.
+
+### Role Dashboard
+
+After selecting a role, the visitor sees a curated dashboard with:
+
+- **3 action cards** — high-priority tools with direct CTAs (e.g. "Check now →", "Calculate risk →")
+- **6 recommended panels** — the most relevant sections from JanVayu's full panel library
+- An "Explore everything" button to access the complete dashboard
+
+### Role Switcher (Header)
+
+A role switcher button is always visible in the header, next to the language selector and theme toggle. It shows:
+
+- **Before selection**: A generic "Role" label with a user icon
+- **After selection**: The selected role's Sargam icon and short label (e.g. "Parent")
+
+Clicking it opens a dropdown with all 10 roles plus "Show Everything". After first selection, a brief pulse animation and tooltip hint ("Change your role anytime here") draw attention to the switcher.
+
+### Session Persistence
+
+Role selection uses `sessionStorage`, meaning:
+
+- The role persists while navigating within a tab session
+- A new browser tab or revisit shows the overlay fresh
+- Deep links (e.g. `janvayu.in/#health`) bypass the overlay entirely
+
+## Configuration
+
+All role definitions live in the `ROLE_CONFIG` object in `index.html`. Each role has:
+
+```javascript
+{
+    icon: '<span class="si si-home"></span>',  // Sargam Icon HTML
+    label: 'Parent / Family',
+    heading: 'Protect your family from air pollution',
+    description: 'Real-time safety checks, school closure info...',
+    actions: [
+        { icon: '...', panel: 'go-outside', title: '...', desc: '...', cta: 'Check now →' },
+        // 3 action cards total
+    ],
+    panels: [
+        { panel: 'children', title: "Children's Health", desc: '...' },
+        // 6 recommended panels total
+    ]
+}
+```
+
+### Adding a New Role
+
+1. Add a new key to `ROLE_CONFIG` with `icon`, `label`, `heading`, `description`, `actions` (3), and `panels` (6)
+2. Add a corresponding `<div class="role-card">` in the `#roleOverlay` HTML
+3. Add a `data-i18n` attribute for translation support
+
+### Icons
+
+All role and action icons use [Sargam Icons](https://sargamicons.com/) v1.6.7 via CSS mask-image. Icons render as `<span class="si si-{name}"></span>` and inherit colour from their parent element. Available icons are defined as `.si-*` classes in the `<style>` block.
+
+## Design Decisions
+
+- **Why 10 roles?** Covers the primary audiences identified through user feedback — from concerned parents to policy researchers. Each gets a meaningfully different set of panels and actions.
+- **Why sessionStorage over localStorage?** Every new visit is an opportunity to show the value proposition. Returning visitors within a session don't need to re-select.
+- **Why not route-based?** JanVayu is a single `index.html` with hash-based navigation. Role selection is a UX layer on top, not a routing concern.
+- **Why always show the role switcher?** Users who select "Parent" and then want to explore budget data shouldn't feel trapped. The always-visible switcher makes role changes effortless.

--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@ a:hover { color: var(--accent-hover); }
 }
 @media (min-width: 640px) { .logo-tag { display: inline; } }
 
-.header-actions { display: flex; gap: 6px; align-items: center; }
+.header-actions { display: flex; gap: 4px; align-items: center; flex-shrink: 0; }
 .icon-btn {
     width: 34px; height: 34px;
     display: flex; align-items: center; justify-content: center;
@@ -1925,9 +1925,13 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     text-transform: uppercase; letter-spacing: 0.04em;
     background: var(--green-50); color: var(--accent);
     border: 1px solid var(--border); border-radius: 6px;
-    padding: 4px 10px; cursor: pointer; white-space: nowrap;
-    display: flex; align-items: center; gap: 4px;
+    padding: 4px 8px; cursor: pointer; white-space: nowrap;
+    display: flex; align-items: center; gap: 3px;
     transition: all 0.15s ease;
+}
+@media (max-width: 480px) {
+    #roleSwitcherLabel { display: none; }
+    .role-switcher-btn { padding: 4px 6px; }
 }
 [data-theme="dark"] .role-switcher-btn {
     background: rgba(22, 163, 74, 0.1);
@@ -10424,7 +10428,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v25.1 | Updated 23 Mar 2026 | 4 new AI-powered features: Ask JanVayu (AI) &mdash; natural language Q&amp;A in English/Hindi, AI Health Advisory &mdash; personalised guidance with colour-coded risk levels, Ward-Level Accountability Brief (AI) &mdash; structured briefs for councillors/journalists/RWAs, Anomaly Detection Banner &mdash; automatic PM2.5 spike monitoring across 5 metros. All powered by Llama 3.3 70B (open-source) via Groq.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v25.2 | Updated 24 Mar 2026 | Role-based landing page with 10 personas, Sargam Icons, GitBook docs link, AI switched to Llama 3.3 70B via Groq.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -10482,6 +10486,21 @@ Signature: _______________</div>
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v25.2 &mdash; 24 Mar 2026</div>
+                    <strong>Role-based landing page, Sargam Icons, Groq AI migration</strong><br>
+                    &bull; <strong>Role selector overlay:</strong> 10 personas (Parent, Student, Researcher, Policymaker, Journalist, Citizen/Activist, Doctor, Teacher, NGO/CSO, Business Owner) guide visitors to relevant content on first visit<br>
+                    &bull; <strong>Curated role dashboards:</strong> Each role gets 3 action CTAs and 6 recommended panels, solving the &ldquo;too much going on&rdquo; feedback<br>
+                    &bull; <strong>Always-visible role switcher:</strong> Header button lets users change roles anytime; pulse animation and tooltip hint draw attention after selection<br>
+                    &bull; <strong>Session-based persistence:</strong> Role resets on each new visit (sessionStorage) so the overlay greets every visitor fresh<br>
+                    &bull; <strong>Sargam Icons:</strong> All role card and action emojis replaced with verified Sargam Icons v1.6.7 (CSS mask-image), matching the site&rsquo;s existing icon system<br>
+                    &bull; <strong>GitBook link:</strong> Documentation link (si-book icon) added to header next to language selector<br>
+                    &bull; <strong>AI backend migration:</strong> Switched from Google Gemini 2.5 Flash to Llama 3.3 70B (open-source) via Groq free tier &mdash; faster inference, better rate limits, no vendor lock-in<br>
+                    &bull; Removed @google/generative-ai dependency; all 4 Netlify Functions now use Groq&rsquo;s OpenAI-compatible REST API via native fetch<br>
+                    &bull; Deep links (#health, #budget, etc.) bypass role overlay entirely<br>
+                    &bull; Mobile-responsive role grid (2 columns), dark mode compatible
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v25.1 &mdash; 23 Mar 2026</div>


### PR DESCRIPTION
## Summary\n\n- Fix role switcher overlapping other header icons (tighter gap, hide label on mobile)\n- New docs page: `docs/user-guide/role-selector.md` covering the full role-based landing experience\n- v25.2 changelog entry with all changes from this session\n\nhttps://claude.ai/code/session_017rZuMzzkLxuxAVe7xe5W7N