### PR TITLE
Add safeguards to prevent index.html from being wiped

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -51,7 +51,20 @@ if [ -n "$STAGED_FILES" ]; then
   done <<< "$STAGED_FILES"
 fi
 
-# 4. Warn on large files (> 500KB)
+# 4. Block commits that empty or gut index.html (the entire app)
+if echo "$STAGED_FILES" | grep -q '^index\.html$'; then
+  if [ -f "index.html" ]; then
+    LINES=$(git diff --cached --diff-filter=ACMR -- index.html | grep -c '^\-' || true)
+    REMAINING=$(git show :index.html | wc -l)
+    if [ "$REMAINING" -lt 100 ]; then
+      echo -e "${RED}BLOCKED:${NC} index.html has been reduced to $REMAINING lines (the full app is ~13,000 lines)."
+      echo "This would take down www.janvayu.in. If intentional, use: git commit --no-verify"
+      exit 1
+    fi
+  fi
+fi
+
+# 5. Warn on large files (> 500KB)
 while IFS= read -r file; do
   if [ -f "$file" ]; then
     SIZE=$(wc -c < "$file")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
     branches: [main]
 
 jobs:
+  # Guard against accidental deletion/emptying of the main app file
+  guard-index-html:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify index.html is not empty or gutted
+        run: |
+          LINES=$(wc -l < index.html)
+          echo "index.html has $LINES lines"
+          if [ "$LINES" -lt 100 ]; then
+            echo "::error::index.html has only $LINES lines (expected ~13,000). This would take down www.janvayu.in!"
+            exit 1
+          fi
+
   check-links:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- **Pre-commit hook**: Blocks any commit that reduces `index.html` below 100 lines (the full app is ~13,000 lines). Devs can bypass with `--no-verify` if intentional.
- **CI guard job**: New `guard-index-html` job in CI that fails the build if `index.html` is gutted or empty. This catches anything that slips past the hook.

Prevents a repeat of the outage from commit a055282.

## Test plan

- [ ] Try committing an empty `index.html` locally — pre-commit hook should block it
- [ ] Verify CI `guard-index-html` job passes on this PR (index.html has 13,016 lines)

https://claude.ai/code/session_016zpA9UZWYgjPLAhhFX5o51