### PR TITLE
Pause fetch-social-feeds workflow to save Netlify credits

### DIFF
--- a/.github/workflows/fetch-social-feeds.yml
+++ b/.github/workflows/fetch-social-feeds.yml
@@ -1,9 +1,12 @@
 name: Fetch AQI Social Media Feeds (Agent-Reach)
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'  # Every 2 hours
-  workflow_dispatch:        # Manual trigger
+  # PAUSED: Schedule disabled to stop burning Netlify credits.
+  # This workflow was running every 2 hours (12x/day), consuming
+  # build minutes and function invocations. See issue for details.
+  # schedule:
+  #   - cron: '0 */2 * * *'  # Every 2 hours
+  workflow_dispatch:        # Manual trigger only
 
 jobs:
   fetch-feeds:


### PR DESCRIPTION
## Summary\n- Disables the scheduled cron trigger on `fetch-social-feeds.yml` which was running every 2 hours (12x/day)\n- Each run installed Python + tools and POSTed to Netlify functions, burning build minutes and function invocations\n- Manual dispatch (`workflow_dispatch`) remains available for on-demand use\n\n## Test plan\n- [x] Verify workflow file syntax is valid\n- [x] Confirm `workflow_dispatch` trigger is still present for manual runs\n\nhttps://claude.ai/code/session_014JUZUXxjyFBaMzqaGA6nF1