### PR TITLE
Use official AIPC programme name in attribution

### DIFF
--- a/co/index.html
+++ b/co/index.html
@@ -108,7 +108,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/docs-ta/about/license.md
+++ b/docs-ta/about/license.md
@@ -47,6 +47,6 @@ JanVayu அதன் குறியீடு மற்றும் உள்ள
 கல்வி அல்லது கொள்கை வேலையில் JanVayu-ஐ மேற்கோள் காட்ட:
 
 ```
-JanVayu. (2026). India's Citizen Air Quality Platform. MMSF Air Quality Initiative.
+JanVayu. (2026). India's Citizen Air Quality Platform. AirQuality for Janhit by MMSF Fellows, AIPC.
 Retrieved from https://www.janvayu.in
 ```

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -47,6 +47,6 @@ Data integrated into JanVayu from external sources retains the original licence 
 To cite JanVayu in academic or policy work:
 
 ```
-JanVayu. (2026). India's Citizen Air Quality Platform. MMSF Air Quality Initiative. 
+JanVayu. (2026). India's Citizen Air Quality Platform. AirQuality for Janhit by MMSF Fellows, AIPC.
 Retrieved from https://www.janvayu.in
 ```

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- SEO Meta -->
     <meta name="description" content="India's independent citizen-led air quality platform. Live PM2.5 data for 30+ cities, health impact analysis using GEMM models, NCAP budget tracking, policy accountability, and environmental justice reporting. 2 million deaths/year demand action.">
     <meta name="keywords" content="air quality India, AQI Delhi, PM2.5 India, air pollution deaths, NCAP progress, clean air India, JanVayu, जनवायु, pollution accountability, health impact air pollution, CPCB data, WAQI, environmental justice India">
-    <meta name="author" content="JanVayu / MMSF Air Quality Initiative">
+    <meta name="author" content="JanVayu — AirQuality for Janhit by MMSF Fellows, AIPC">
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
     <meta name="theme-color" content="#1a3a2a">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -63,7 +63,7 @@
         },
         "publisher": {
             "@type": "Organization",
-            "name": "MMSF Air Quality Initiative",
+            "name": "AirQuality for Janhit by MMSF Fellows, AIPC",
             "url": "https://www.janvayu.in/"
         }
     }
@@ -99,7 +99,7 @@
         },
         "creator": {
             "@type": "Organization",
-            "name": "MMSF Air Quality Initiative"
+            "name": "AirQuality for Janhit by MMSF Fellows, AIPC"
         },
         "keywords": ["air quality", "PM2.5", "India", "pollution", "NCAP", "health impact", "AQI"]
     }
@@ -3030,7 +3030,7 @@ body {
                 <div>
                     <div class="footer-title">JanVayu &#2332;&#2344;&#2357;&#2366;&#2351;&#2369;</div>
                     <p class="footer-desc">Independent citizen-led air quality monitoring, health impact analysis, and government accountability tracking for India. Clean air is not a privilege, it is a right.</p>
-                    <p class="footer-credits">An initiative of the <a href="#" style="color:rgba(255,255,255,0.5)">MMSF Air Quality Initiative</a>. Data from WAQI, CPCB, WHO, CREA, and <a href="https://urbanemissions.info" target="_blank" style="color:rgba(255,255,255,0.5)">UrbanEmissions.info</a>.</p>
+                    <p class="footer-credits">Part of <strong style="color:rgba(255,255,255,0.7)">AirQuality for Janhit</strong> by <a href="#" style="color:rgba(255,255,255,0.5)">MMSF Fellows, AIPC</a>. Data from WAQI, CPCB, WHO, CREA, and <a href="https://urbanemissions.info" target="_blank" style="color:rgba(255,255,255,0.5)">UrbanEmissions.info</a>.</p>
                 </div>
                 <div>
                     <div class="footer-title">Navigate</div>
@@ -3060,7 +3060,7 @@ body {
                 <p><strong>Compliance:</strong> Published in accordance with the Information Technology Act, 2000 and IT (Intermediary Guidelines and Digital Media Ethics Code) Rules, 2021. Contact: contribute@janvayu.in</p>
             </div>
             <div id="global-last-updated" style="font-size: 0.7rem; color: var(--text-3); margin-bottom: 0.25rem;">Data last refreshed: loading...</div>
-            <div class="footer-bottom">&copy; 2026 JanVayu | MMSF Air Quality Initiative | #AQIForJanHit | Auto-updates: AQI every 10 min | Feeds auto-fetched server-side every 4 hours</div>
+            <div class="footer-bottom">&copy; 2026 JanVayu | AirQuality for Janhit by MMSF Fellows, AIPC | #AQIForJanHit | Auto-updates: AQI every 10 min | Feeds auto-fetched server-side every 4 hours</div>
         </div>
     </footer>
 
@@ -12047,7 +12047,7 @@ Signature: _______________</div>
                         JanVayu exists because clean air is not a privilege, it is a fundamental right. We bridge the gap between government promises and actual air quality outcomes through independent verification, citizen empowerment, and data-driven accountability.
                     </p>
                     <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-top: 1rem;">
-                        This platform is part of the <strong>MMSF Air Quality Initiative</strong> and the broader <strong>#AQIForJanHit</strong> campaign. We use real-time monitoring data, peer-reviewed research, RTI responses, and independent analysis to provide the accountability that India's air quality crisis demands.
+                        This platform is part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> &mdash; the broader <strong>#AQIForJanHit</strong> campaign. We use real-time monitoring data, peer-reviewed research, RTI responses, and independent analysis to provide the accountability that India's air quality crisis demands.
                     </p>
                 </div>
                 <div>

--- a/no2/index.html
+++ b/no2/index.html
@@ -106,7 +106,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/o3/index.html
+++ b/o3/index.html
@@ -106,7 +106,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/pm10/index.html
+++ b/pm10/index.html
@@ -109,7 +109,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/pm25/index.html
+++ b/pm25/index.html
@@ -110,7 +110,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/scripts/build-pollutant-pages.mjs
+++ b/scripts/build-pollutant-pages.mjs
@@ -193,7 +193,8 @@ ${POLLUTANTS.filter(q => q.slug !== p.slug).map(q => `    <a href="/${q.slug}/">
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© ${new Date().getFullYear()} JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>

--- a/so2/index.html
+++ b/so2/index.html
@@ -106,7 +106,8 @@
   </div>
 </div>
 <footer>
-  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
+  <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
+  <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
   <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
 </footer>
 <script>


### PR DESCRIPTION
## Summary

Replace `"MMSF Air Quality Initiative"` with the official programme name **`AirQuality for Janhit by MMSF Fellows, AIPC`** everywhere it appears, per the user's correction.

## Files touched
- `index.html` — 6 spots:
  - `<meta name="author">`
  - 2 × schema.org JSON-LD `Organization` blocks (publisher + creator)
  - Footer credits paragraph
  - Footer bottom strip
  - About panel paragraph
- `docs/about/license.md` and `docs-ta/about/license.md` — the citation block
- `scripts/build-pollutant-pages.mjs` — pollutant-page footer template, plus regenerated `/pm25`, `/pm10`, `/co`, `/no2`, `/so2`, `/o3`

The `#AQIForJanHit` hashtag is preserved as the public-facing campaign tag.

## Test plan
- [ ] Verify "AirQuality for Janhit by MMSF Fellows, AIPC" appears in the footer of janvayu.in after deploy
- [ ] Open the About panel and confirm the line about programme attribution updated
- [ ] Visit `/pm25/` and confirm the new attribution appears in the footer
- [ ] No stale "MMSF Air Quality Initiative" string remains anywhere


---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_