### PR TITLE
Strip emoji + refresh CHANGELOG/Roadmap/docs/blog for v26.4 batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.4.1] - 2026-04-26
+
+### Added — Workshops, Roadmap docs, Programme attribution
+
+- **Workshops panel** at `/#workshops` (under the Action nav). Two side-by-side cards:
+  - "Air Quality workshop with UrbanEmissions" — request form for Dr. Sarath Guttikunda's interactive sessions, including the Air Quality Jeopardy game. Captures audience (Class 9+, college, adult cohort, educators), group size, format, city, preferred dates, notes.
+  - "1-hour JanVayu walkthrough" — booking form that collects three preferred IST slots, group context, attendees, language preference, learning goals.
+  - Both forms run on Netlify Forms (`data-netlify="true"`) with detection stubs and honeypot anti-spam. Inline success message replaces the form on submit.
+- **Programme attribution updated**: every reference to "MMSF Air Quality Initiative" replaced with the official programme name **AirQuality for Janhit by MMSF Fellows, AIPC** in the meta tag, two schema.org JSON-LD blocks, footer credits, footer bottom strip, About panel, citation in `docs/about/license.md` and `docs-ta/about/license.md`, and the per-pollutant SEO page footer.
+- **No-emoji style enforced**: removed decorative emojis introduced this cycle from the dashboard (Near Me button, PWA install banner, solution-recommendation card list, Workshops cards, success messages). Replaced with text labels, dot bullets, or existing `si-*` SVG icons.
+
+## [v26.4.0] - 2026-04-26
+
+### Added — Competitor gap closure (vs. aqi.in / oaq.notf.in)
+
+- **Cigarette-equivalence card** on the dashboard: live PM2.5 → "≈ X cigarettes/day" using the Berkeley Earth coefficient (1 cig ≈ 22 µg/m³·day).
+- **Disease-risk badges** tied to live AQI: asthma flare-up, heart attack/stroke, allergies, respiratory infection, vulnerable groups — colour-coded by AQI band.
+- **Solution-recommendation card**: AQI-gated guidance on N95, purifier, exercise, school closure, and cardiac/lung patient precautions, with cross-links to Purifier Calculator and "Should I go outside?".
+- **"Near Me" geolocation** in the hero: nearest WAQI station via `navigator.geolocation` → `https://api.waqi.info/feed/geo:.../`. Result is injected as a synthetic city option so all dashboard cards reuse the same flow.
+- **City Rankings panel** (`/#rankings`) under the Monitoring nav: Live / Past 7 days / Past 30 days tabs, search, and worst-first/best-first sort. Live tab uses the current WAQI cache; aggregated tabs use accumulating Netlify Blobs snapshots.
+- **Hourly 24-hr scrubbable PM2.5 chart** in the Trends panel: drag the slider to inspect any hour; readout shows µg/m³ + WHO multiple at that time.
+- **Year-over-year city comparison** in the Compare panel: pick a city + month, see 2024/2025/2026 PM2.5 monthly averages with delta percentages.
+- **Per-pollutant SEO pages** at `/pm25`, `/pm10`, `/co`, `/no2`, `/so2`, `/o3` with schema.org JSON-LD, sitemap entries, and live top-10 readings. Built via `scripts/build-pollutant-pages.mjs`.
+- **Leaflet.heat heatmap layer** on the Live Map with a toggle. Marker popups upgraded with cigarette equivalence and a "View on dashboard" jump.
+- **Embeddable widgets** at `/embed/aqi/?city=...&theme=light|dark` and `/embed/rankings/?n=10&order=worst|best` with iframe-friendly headers.
+- **Root PWA**: `manifest.json` + `sw.js` (offline shell + last-known AQI cache). `beforeinstallprompt`-driven install banner with persistent dismissal in `localStorage`.
+- **Sensor.Community integration**: free CC0 community sensors blended into the Hyperlocal panel with a `COMMUNITY` vs `CPCB/WAQI` source badge. Replaces the proposed hardware program.
+
+### Added — Backend functions
+
+- `netlify/functions/rankings.mjs` — live + accumulated daily snapshots in `janvayu-rankings` blob store.
+- `netlify/functions/historical-aqi.mjs` — monthly PM2.5 climatology baseline (CPCB / IQAir 2024 sourced) enriched with snapshot data.
+- `netlify/functions/community-sensors.mjs` — 10-min-cached Sensor.Community pull with EPA breakpoint PM2.5 → AQI conversion.
+
+### Changed
+
+- `generateWidget()` now emits a JanVayu `/embed/aqi` iframe instead of the previous aqicn.org one.
+- `netlify.toml` — `X-Frame-Options: ALLOWALL` for `/embed/*`, `Service-Worker-Allowed: /` header on `/sw.js`, redirects for the six pollutant pages and the two embed widgets.
+- `sitemap.xml` — added the six pollutant page URLs.
+
+### Mobile
+
+- PWA install banner refactored from inline styles to a CSS class set with `flex-shrink: 0` and `white-space: nowrap` on the CTA, plus `@media (max-width: 480px)` layout that respects `env(safe-area-inset-bottom)`. Fixes the "I-n-s-t-a-l-l" letter-per-line wrap reported on Android Chrome.
+
 ## [v25.4.0] - 2026-04-12
 
 ### Added — Blog & Research Updates

--- a/blog/README.md
+++ b/blog/README.md
@@ -10,6 +10,7 @@ Data, research, policy accountability, and what the numbers mean for 1.4 billion
 
 | Date | Post | Topic |
 |------|------|-------|
+| 26 Apr 2026 | [What's New: Cigarette Equivalence, City Rankings, Community Sensors, Workshops](posts/2026-04-26-shipped-this-week.md) | Platform |
 | 12 Apr 2026 | [IQAir 2025: India's Air Got Worse](posts/2026-04-12-iqair-2025-india.md) | Data |
 | 8 Apr 2026 | [The Lancet's Verdict: 1.5 Million Deaths a Year](posts/2026-04-08-lancet-causal-evidence.md) | Research |
 | 5 Apr 2026 | [NCAP at the Finish Line: Has India's Clean Air Programme Worked?](posts/2026-04-05-ncap-deadline.md) | Policy |

--- a/blog/_sidebar.md
+++ b/blog/_sidebar.md
@@ -3,6 +3,7 @@
 - [**JanVayu Blog**](README.md)
 
 - **April 2026**
+  - [What's New: Cigarette Equivalence, City Rankings, Community Sensors, Workshops](posts/2026-04-26-shipped-this-week.md)
   - [IQAir 2025: India's Air Got Worse](posts/2026-04-12-iqair-2025-india.md)
   - [The Lancet's Verdict: 1.5 Million Deaths](posts/2026-04-08-lancet-causal-evidence.md)
   - [NCAP at the Finish Line](posts/2026-04-05-ncap-deadline.md)

--- a/blog/posts/2026-04-26-shipped-this-week.md
+++ b/blog/posts/2026-04-26-shipped-this-week.md
@@ -1,0 +1,98 @@
+# What's New: Cigarette Equivalence, City Rankings, Community Sensors, Workshops
+
+**Published:** 26 April 2026 | **Author:** Team JanVayu | **Reading time:** 5 min
+
+---
+
+JanVayu shipped its largest single update since launch this week. Here is what changed, why, and what each piece is for.
+
+## Why this update
+
+We benchmarked JanVayu against two peers we get asked about often: **aqi.in** (a polished consumer AQI portal) and **oaq.notf.in** (an open hyperlocal sensor platform run by researchers and community organisations). The benchmark surfaced a clear gap: JanVayu was strong on accountability — NCAP tracking, RTI, court orders, citizen voices — and weaker on the fast, visceral, "what is this air doing to me right now" questions that drive most first-time visits.
+
+This update closes that gap, without diluting the accountability mission.
+
+## On the dashboard, you now see
+
+**Cigarettes per day equivalent.** Live PM2.5 converted to a daily smoking equivalent using the Berkeley Earth coefficient (one cigarette ≈ 22 µg/m³ over 24 hours). At 100 µg/m³ — typical for Delhi in winter — that is roughly 4.5 cigarettes a day, every day. Walking past a bus stop in November is hard to wave away once you have that number on screen.
+
+**Disease-risk badges.** Five common harms — asthma flare-ups, heart attack and stroke, allergies, respiratory infection, and risk to children and the elderly — colour-coded by today's AQI band. The mapping comes from the GBD literature; the colours match the AQI gradient so the framing stays internally consistent.
+
+**Solution recommendations.** What to actually do today. At AQI 50, "open windows." At AQI 250, "N95 mandatory outdoors and run a HEPA purifier 24/7." At AQI 450, "treat outdoor air as toxic and create a clean room indoors if needed." The card cross-links to the existing Purifier Calculator and "Should I Go Outside?" panels.
+
+**Near Me.** A button next to the city dropdown that asks for your location and pulls the nearest WAQI monitoring station. We do not store the location. It rides on a synthetic city entry so all the cards on the dashboard refresh together.
+
+## A new City Rankings panel
+
+Live, past 7 days, and past 30 days rankings of Indian cities by PM2.5 — sortable, searchable, with a delta column that will fill in over the coming month as the rankings function accumulates daily snapshots. This is a deliberate pace move. We did not want to ship a leaderboard that sums one snapshot to look like a trend.
+
+## A heatmap on the map, and richer popups
+
+The Live Map now has a heatmap layer toggle. Marker popups show cigarette equivalence and a one-click jump to that city's full dashboard view. The default station markers stay where they were.
+
+## A 24-hour scrubbable trend chart
+
+In the Trends panel, a new card lets you drag a slider across the last 24 hours and see PM2.5 at any specific hour, with the WHO-multiple readout updating live. Useful for understanding how bad your morning commute really was.
+
+## Year-over-year city comparison
+
+In the Compare panel, pick a city and a month and overlay 2024, 2025, and 2026 monthly averages. The data uses a CPCB and IQAir-2024 sourced climatology baseline that is enriched as the rankings function accumulates real readings. Shows whether things are actually getting better.
+
+## Six pollutant pages for search
+
+`/pm25`, `/pm10`, `/co`, `/no2`, `/so2`, `/o3` — standalone, SEO-friendly pages with sources, health effects, the WHO and Indian standards, and the live top-10 most-polluted Indian cities for that pollutant. Built from a single template and fully crawlable. The point is that someone searching "PM2.5 Delhi" finds JanVayu, not just IQAir.
+
+## Free community sensors via Sensor.Community
+
+The Hyperlocal panel now blends CPCB and WAQI stations with **Sensor.Community** — a global, CC0-licensed network of citizen-run low-cost monitors. Each station carries a `COMMUNITY` or `CPCB/WAQI` source badge so you know what you are reading. Treat community sensors as indicative; they are less calibrated than CPCB stations but fill coverage gaps in places that have no official station.
+
+We considered building our own "Host a Monitor" hardware program. This integration gets us the same coverage benefit, today, without the hardware lift. We may still do hardware later, but only if there is a coverage gap that the community network does not solve.
+
+## Embeddable widgets
+
+Two iframe-friendly endpoints:
+
+- `https://www.janvayu.in/embed/aqi/?city=delhi&theme=light` — small live AQI badge, auto-refreshing
+- `https://www.janvayu.in/embed/rankings/?n=10&order=worst` — top-N polluted cities right now
+
+Drop them into your blog, RWA notice board, or newsroom dashboard. Light and dark themes supported.
+
+## A real PWA
+
+JanVayu is now installable on Android, iOS, and desktop. The service worker caches the app shell and last-known AQI, so opening it on the metro with no signal still gives you the most recent reading. Look for the "Install JanVayu" prompt in the bottom corner, or use your browser's Add to Home Screen.
+
+## Workshops
+
+A new **Workshops** page under the Action menu. Two cards:
+
+- **Air Quality workshop with UrbanEmissions** — request a session with Dr. Sarath Guttikunda, who runs the Air Quality Jeopardy game (interactive, tested with school and adult cohorts). Class 9+ students, college, adult cohorts, and educators all welcome.
+- **1-hour JanVayu walkthrough** — book a hands-on session with our team. Set AQI alerts, file an RTI in one sitting, read the NCAP scorecard, find the right purifier. Pick three preferred IST slots; we confirm one. Free, online, English or Hindi.
+
+Both forms run on Netlify Forms. We do not share contact details with anyone other than the workshop facilitator.
+
+## What we deliberately did not do
+
+- **No native iOS or Android app wrapping.** The PWA install path covers about ninety percent of the value, and a Capacitor wrapper adds maintenance cost we cannot justify yet.
+- **No global expansion.** JanVayu is positioned for India. Chasing 190-country coverage would dilute the brand.
+- **No vertical or industry dashboards.** Smart-city, real-estate, hospitality variants are out of scope for a citizen accountability platform.
+
+## Programme attribution updated
+
+You will see "AirQuality for Janhit by MMSF Fellows, AIPC" in the footer, About panel, citation block, and pollutant page footers — the official programme name we are part of. The `#AQIForJanHit` hashtag stays as the public campaign tag.
+
+## What we are looking at next
+
+In rough priority order:
+
+- An NCAP city scorecard upgrade that matches and exceeds NCAP Tracker's depth, with a one-click pre-filled RTI to the responsible CPCB officer for every missed target.
+- A stubble-burning live tracker built on NASA FIRMS, focused on Punjab and Haryana during October and November.
+- A source-apportionment ring per city, using CREA and UrbanEmissions inventory data.
+- A 24 to 72-hour AQI forecast, extending the existing forecast panel.
+- Browser push notifications gated on user-picked AQI thresholds (using the new service worker).
+- An in-browser AQ literacy quiz as a companion to Sharath's Jeopardy game.
+
+If something on this list matters to you — or you spotted a bug — let us know via the [Workshops page](https://www.janvayu.in/#workshops) booking form, or open an issue on the [JanVayu GitHub](https://github.com/JanVayu/JanVayu/issues).
+
+---
+
+*Part of AirQuality for Janhit by MMSF Fellows, AIPC. Code is MIT-licensed; content is CC BY-NC-SA 4.0.*

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,6 +1,6 @@
 # Platform Overview
 
-JanVayu is a single-page web application with 23 sections covering every dimension of India's air quality crisis — from live data to legal accountability.
+JanVayu is a single-page web application with 30+ sections covering every dimension of India's air quality crisis — from live data to legal accountability.
 
 ---
 
@@ -8,29 +8,37 @@ JanVayu is a single-page web application with 23 sections covering every dimensi
 
 | # | Section | What it shows |
 |---|---------|---------------|
-| 1 | **Real-Time AQI Dashboard** | Live PM2.5 and AQI for 30+ cities, auto-refreshed every 10 minutes via WAQI/CPCB |
-| 2 | **Interactive AQI Map** | Leaflet.js map with station-level markers across India |
-| 3 | **Health Impact Calculator** | GEMM model estimates of mortality, disease burden, and life years lost |
-| 4 | **Economic Cost Analysis** | GDP loss, healthcare spending, productivity impact (Lancet 2025, World Bank) |
-| 5 | **Children's Health** | Lung development impacts, school closures, stunting data |
-| 6 | **Indoor Air Quality** | Household pollution from solid fuel cooking, Ujjwala scheme tracking |
-| 7 | **City Comparison** | Real-time AQI rankings across Indian metros |
-| 8 | **Policy Effectiveness** | NCAP targets vs actual outcomes, GRAP stage history |
-| 9 | **Budget Tracker** | NCAP and 15th Finance Commission fund utilisation rates |
-| 10 | **Political Accountability** | MoEFCC spending, state compliance, RTI templates |
-| 11 | **Industrial Sources** | Factory emissions, thermal power plants, brick kilns |
-| 12 | **Clean Air Mission Tracker** | Government promises vs reality |
-| 13 | **Clean Air Wins** | Positive progress — e-bus deployment, city improvements, citizen victories |
-| 14 | **Legal Framework** | Supreme Court orders, NGT rulings, Article 21 right to clean air |
-| 15 | **Take Action** | Advocacy guides, citizen tools, campaign resources |
-| 16 | **Research Library** | Curated reports from CREA, CSE, IQAir, Lancet, World Bank |
-| 17 | **Citizen Voices Archive** | Social media posts, testimonies, viral content from affected communities |
-| 18 | **Accountability Tracker** | Institutional and official responses to pollution episodes |
-| 19 | **Social Media Feeds** | Aggregated Reddit, Twitter/X, Instagram, and news coverage |
-| 20 | **Daily Email Digest** | Subscribers receive a daily AQI summary for their city at 8:00 AM IST |
-| 21 | **AQI Calculator** | Interactive tool to understand AQI breakpoints and health advice |
-| 22 | **RTI Templates** | Ready-to-use Right to Information templates for pollution accountability |
-| 23 | **Cultural Archive** | Satire, memes, art, and cultural responses to the pollution crisis |
+| 1 | **Real-Time AQI Dashboard** | Live PM2.5 and AQI for 30+ cities, auto-refreshed every 10 minutes via WAQI/CPCB. Includes cigarette-equivalence (Berkeley Earth: 1 cig ≈ 22 µg/m³·day), disease-risk badges, and an AQI-band solution-recommendation card |
+| 2 | **"Near Me" geolocation** | One-tap nearest-station lookup via the browser's geolocation API |
+| 3 | **Interactive AQI Map** | Leaflet.js map with station-level markers, a heatmap-layer toggle, and station popups |
+| 4 | **City Rankings** | Live / Past 7 days / Past 30 days rankings of Indian cities, sortable and searchable |
+| 5 | **Hyperlocal panel** | CPCB/WAQI stations blended with free Sensor.Community community sensors, badged by source |
+| 6 | **Health Impact Calculator** | GEMM model estimates of mortality, disease burden, and life years lost |
+| 7 | **Economic Cost Analysis** | GDP loss, healthcare spending, productivity impact (Lancet 2025, World Bank) |
+| 8 | **Children's Health** | Lung development impacts, school closures, stunting data |
+| 9 | **Indoor Air Quality** | Household pollution from solid fuel cooking, Ujjwala scheme tracking |
+| 10 | **City Comparison** | Real-time AQI comparison plus a year-over-year tab (2024/2025/2026 monthly averages) |
+| 11 | **Historical Trends** | Hourly 24-hr scrubbable PM2.5 chart, annual trend line, seasonal pattern, key-events timeline |
+| 12 | **Policy Effectiveness** | NCAP targets vs actual outcomes, GRAP stage history |
+| 13 | **Budget Tracker** | NCAP and 15th Finance Commission fund utilisation rates |
+| 14 | **Political Accountability** | MoEFCC spending, state compliance, RTI templates |
+| 15 | **Industrial Sources** | Factory emissions, thermal power plants, brick kilns |
+| 16 | **Clean Air Mission Tracker** | Government promises vs reality |
+| 17 | **Clean Air Wins** | Positive progress — e-bus deployment, city improvements, citizen victories |
+| 18 | **Legal Framework** | Supreme Court orders, NGT rulings, Article 21 right to clean air |
+| 19 | **Take Action** | Advocacy guides, citizen tools, campaign resources |
+| 20 | **Workshops** | Request an Air Quality workshop with Dr. Sarath Guttikunda (UrbanEmissions) — including the Air Quality Jeopardy game — or book a 1-hour JanVayu walkthrough |
+| 21 | **Research Library** | Curated reports from CREA, CSE, IQAir, Lancet, World Bank |
+| 22 | **Citizen Voices Archive** | Social media posts, testimonies, viral content from affected communities |
+| 23 | **Accountability Tracker** | Institutional and official responses to pollution episodes |
+| 24 | **Social Media Feeds** | Aggregated Reddit, Twitter/X, Instagram, and news coverage |
+| 25 | **Daily Email Digest** | Subscribers receive a daily AQI summary for their city at 8:00 AM IST |
+| 26 | **AQI Calculator** | Interactive tool to understand AQI breakpoints and health advice |
+| 27 | **RTI Templates** | Ready-to-use Right to Information templates for pollution accountability |
+| 28 | **Cultural Archive** | Satire, memes, art, and cultural responses to the pollution crisis |
+| 29 | **Per-pollutant SEO pages** | Standalone pages at `/pm25`, `/pm10`, `/co`, `/no2`, `/so2`, `/o3` with sources, health effects, and live top-10 city readings |
+| 30 | **Embeddable widgets** | `/embed/aqi/?city=...` (live AQI badge) and `/embed/rankings/?n=10` for any external website |
+| 31 | **PWA install** | Installable on Android, iOS, and desktop with offline shell + last-known AQI cache |
 
 ---
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -78,6 +78,27 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 
 ---
 
+## Phase 5.6: Competitor Gap Closure (✅ Completed — v26.4)
+
+Closes specific UX/data gaps against aqi.in (consumer-polished AQI portal) and oaq.notf.in (open hyperlocal sensor platform), without disturbing the accountability-first positioning.
+
+- [x] Cigarette-equivalence card (Berkeley Earth: 1 cig ≈ 22 µg/m³·day)
+- [x] Disease-risk badges tied to live AQI (asthma, heart, allergies, respiratory, vulnerable)
+- [x] Solution-recommendation card (N95, purifier, exercise, school closure)
+- [x] "Near Me" geolocation → nearest WAQI station
+- [x] City Rankings panel (Live / 7d / 30d) with `rankings.mjs` Netlify function
+- [x] Per-pollutant SEO pages (`/pm25`, `/pm10`, `/co`, `/no2`, `/so2`, `/o3`) with schema.org JSON-LD
+- [x] Hourly 24-hr scrubbable PM2.5 chart in the Trends panel
+- [x] Year-over-year city comparison + `historical-aqi.mjs` climatology baseline
+- [x] Leaflet.heat heatmap toggle + richer station popups on the Live Map
+- [x] Embeddable widgets at `/embed/aqi/` and `/embed/rankings/`
+- [x] Root PWA (`manifest.json` + `sw.js` + install banner) with offline shell and last-known AQI cache
+- [x] Sensor.Community community-sensor integration via `community-sensors.mjs` (replaces hardware "Host a Monitor" plan)
+- [x] Workshops panel with Sharath / UrbanEmissions request form and JanVayu walkthrough booking (Netlify Forms)
+- [x] Programme attribution updated to "AirQuality for Janhit by MMSF Fellows, AIPC" everywhere
+
+---
+
 ## Phase 6: Mobile & Performance (🔄 Q2 2026)
 
 **Issues:** [#33](https://github.com/JanVayu/JanVayu/issues/33), [#3](https://github.com/JanVayu/JanVayu/issues/3)
@@ -115,8 +136,22 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 
 ## Phase 9: Community & Scale (2027)
 
-- [ ] PWA with offline support
+- [x] PWA with offline support — shipped in v26.4
 - [ ] WhatsApp bot integration
-- [ ] ML-based AQI forecast
+- [ ] ML-based AQI forecast (extend the existing forecast panel beyond WAQI's 3-day window)
 - [ ] South Asian expansion
-- [ ] Open data API
+- [ ] Open data API (currently we have read-only function endpoints for rankings + community sensors; needs versioning, docs, rate limits)
+
+---
+
+## Phase 10: Next batch — competing with peer accountability platforms (Q3 2026)
+
+Recommended next-build list, drawing on the latest scan of NCAP Tracker (Climate Trends + Respirer Living Sciences), CREA, UrbanEmissions, IQAir, and aqi.in.
+
+- [ ] **NCAP city scorecard upgrade** — match/exceed NCAP Tracker. Per-city met/missed flag, station-level fund utilization, PM2.5 vs target chart, with one-click pre-filled RTI to the responsible CPCB officer.
+- [ ] **Stubble-burning live tracker** — NASA FIRMS API + Punjab/Haryana focus during Oct–Nov; overlay on the Live Map.
+- [ ] **Source apportionment ring** — per-city %-from transport / industry / biomass / construction / dust, sourced from CREA + UrbanEmissions inventories. Interactive city picker.
+- [ ] **AQI forecast 24–72hr** — extend the existing forecast panel with WAQI's daily forecast arrays, render as a 3-day horizon chart with confidence bands.
+- [ ] **Push notifications** — browser push via the new service worker, gated on user-picked AQI thresholds. Complement to email digest.
+- [ ] **In-browser AQ literacy quiz** — companion to Sharath's Jeopardy game; runs on the Workshops page.
+- [ ] **Story-of-the-week rotation** — surface a blog post on the dashboard hero each week.

--- a/index.html
+++ b/index.html
@@ -2805,7 +2805,8 @@ body {
                                 background: var(--accent, #1B6B4A); color: #fff;
                                 border: 1px solid var(--accent, #1B6B4A); border-radius: 6px;
                                 padding: 4px 10px; cursor: pointer; white-space: nowrap;
-                            ">📍 Near Me</button>
+                                display: inline-flex; align-items: center; gap: 4px;
+                            "><span class="si si-pin" style="width:12px;height:12px;"></span>Near Me</button>
                             </div>
                             <div class="hero-pm25-label" id="hero-city-label">Delhi Live PM2.5</div>
                             <div class="hero-pm25-number" id="delhi-live-pm25" style="color: var(--red);">--</div>
@@ -3008,7 +3009,6 @@ body {
             }
         </style>
         <div id="pwa-install-banner" class="pwa-install-banner" role="dialog" aria-label="Install JanVayu">
-            <span class="pwa-icon" aria-hidden="true">📲</span>
             <div class="pwa-text">
                 <div class="pwa-title">Install JanVayu</div>
                 <div class="pwa-sub">Live AQI + offline access on your home screen.</div>
@@ -3474,7 +3474,7 @@ body {
                     <strong style="color: ${sol.color};">${sol.headline}</strong>
                 </div>
                 <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px;">
-                    ${sol.actions.map(a => `<li style="display: flex; gap: 6px;"><span>${a.icon}</span><span>${a.text}</span></li>`).join('')}
+                    ${sol.actions.map(a => `<li style="display: flex; gap: 8px; padding: 3px 0;"><span style="display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: ${sol.color}; margin-top: 8px; flex-shrink: 0;"></span><span>${a}</span></li>`).join('')}
                 </ul>
                 <div style="margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap;">
                     <button class="btn btn-sm" style="font-size: 0.7rem;" onclick="showPanel('purifier-calc')">Purifier sizing</button>
@@ -3511,9 +3511,9 @@ body {
                 label: 'Good', color: '#22C55E',
                 headline: 'Air is clean. Enjoy outdoors.',
                 actions: [
-                    { icon: '🏃', text: 'Outdoor exercise is safe for everyone.' },
-                    { icon: '🪟', text: 'Open windows to ventilate indoor spaces.' },
-                    { icon: '🧒', text: 'Kids and elderly: no restrictions.' },
+                    'Outdoor exercise is safe for everyone.',
+                    'Open windows to ventilate indoor spaces.',
+                    'Kids and elderly: no restrictions.',
                 ]
             };
         }
@@ -3522,9 +3522,9 @@ body {
                 label: 'Moderate', color: '#EAB308',
                 headline: 'Mostly fine. Sensitive groups should watch.',
                 actions: [
-                    { icon: '🏃', text: 'Outdoor exercise OK for most. Reduce intensity if asthmatic.' },
-                    { icon: '🪟', text: 'Windows OK; close during traffic peaks.' },
-                    { icon: '😷', text: 'Mask not needed unless you have a lung condition.' },
+                    'Outdoor exercise OK for most. Reduce intensity if asthmatic.',
+                    'Windows OK; close during traffic peaks.',
+                    'Mask not needed unless you have a lung condition.',
                 ]
             };
         }
@@ -3533,10 +3533,10 @@ body {
                 label: 'Poor', color: '#F97316',
                 headline: 'Limit prolonged outdoor exertion.',
                 actions: [
-                    { icon: '😷', text: 'Wear a well-fitted N95 outdoors for >30 min.' },
-                    { icon: '🏃', text: 'Move workouts indoors; avoid roadside running.' },
-                    { icon: '🪟', text: 'Close windows; run an air purifier in bedrooms.' },
-                    { icon: '🧒', text: 'Kids: shorten outdoor recess. Asthmatics: keep inhaler ready.' },
+                    'Wear a well-fitted N95 outdoors for over 30 minutes.',
+                    'Move workouts indoors; avoid roadside running.',
+                    'Close windows; run an air purifier in bedrooms.',
+                    'Kids: shorten outdoor recess. Asthmatics: keep inhaler ready.',
                 ]
             };
         }
@@ -3545,10 +3545,10 @@ body {
                 label: 'Very Poor', color: '#EF4444',
                 headline: 'Stay indoors. Run a HEPA purifier.',
                 actions: [
-                    { icon: '😷', text: 'N95 mandatory outdoors — even brief exposure matters.' },
-                    { icon: '🌬️', text: 'Run HEPA purifier 24/7; size for room volume.' },
-                    { icon: '🚫', text: 'No outdoor exercise. Reschedule sports.' },
-                    { icon: '🏫', text: 'Schools: consider hybrid or holiday for primary classes.' },
+                    'N95 mandatory outdoors — even brief exposure matters.',
+                    'Run HEPA purifier 24/7; size for room volume.',
+                    'No outdoor exercise. Reschedule sports.',
+                    'Schools: consider hybrid or holiday for primary classes.',
                 ]
             };
         }
@@ -3557,10 +3557,10 @@ body {
                 label: 'Severe', color: '#7C3AED',
                 headline: 'Health emergency. Avoid all outdoor exposure.',
                 actions: [
-                    { icon: '🏠', text: 'Stay indoors. Seal gaps under doors and windows.' },
-                    { icon: '🌬️', text: 'Multiple HEPA purifiers; create a "clean room" if needed.' },
-                    { icon: '🏥', text: 'Cardiac/lung patients: keep meds and emergency contacts close.' },
-                    { icon: '🚸', text: 'Schools should close. Outdoor work should pause.' },
+                    'Stay indoors. Seal gaps under doors and windows.',
+                    'Multiple HEPA purifiers; create a "clean room" if needed.',
+                    'Cardiac and lung patients: keep meds and emergency contacts close.',
+                    'Schools should close. Outdoor work should pause.',
                 ]
             };
         }
@@ -3568,10 +3568,10 @@ body {
             label: 'Hazardous', color: '#831843',
             headline: 'Emergency. Treat outdoor air as toxic.',
             actions: [
-                { icon: '🚨', text: 'Government should activate GRAP Stage IV / emergency protocols.' },
-                { icon: '🏠', text: 'Do not go outside without N95 + eye protection.' },
-                { icon: '🏥', text: 'ER visits spike. Seek help immediately for chest pain or breathing trouble.' },
-                { icon: '🛫', text: 'If feasible, consider temporary relocation for vulnerable family members.' },
+                'Government should activate GRAP Stage IV / emergency protocols.',
+                'Do not go outside without N95 plus eye protection.',
+                'ER visits spike. Seek help immediately for chest pain or breathing trouble.',
+                'If feasible, consider temporary relocation for vulnerable family members.',
             ]
         };
     }
@@ -3614,7 +3614,7 @@ body {
                     opt.value = '__nearme';
                     sel.insertBefore(opt, sel.firstChild);
                 }
-                opt.textContent = '📍 ' + stationName;
+                opt.textContent = 'Near me — ' + stationName;
                 sel.value = '__nearme';
             }
             updateHeroCity('__nearme');
@@ -10892,16 +10892,13 @@ Signature: _______________</div>
                         <span style="font-size: 0.65rem; color: var(--text-3);">External facilitator</span>
                     </div>
                     <div class="card-body" style="flex: 1; display: flex; flex-direction: column;">
-                        <div style="display: flex; gap: 12px; margin-bottom: 14px; align-items: flex-start;">
-                            <div style="font-size: 1.6rem; flex-shrink: 0;">🎲</div>
-                            <div>
-                                <strong style="display: block; font-size: 0.95rem;">Air Quality Jeopardy &amp; more</strong>
-                                <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Dr. Sarath Guttikunda of <a href="https://urbanemissions.info/" target="_blank" rel="noopener">UrbanEmissions.Info</a> runs interactive sessions on air quality science, sources, and policy &mdash; including a Jeopardy-format game tested with school and adult cohorts. Choose Class 9+ students, college, or adult learners.</p>
-                            </div>
+                        <div style="border-left: 3px solid #7C3AED; padding: 4px 0 4px 12px; margin-bottom: 14px;">
+                            <strong style="display: block; font-size: 0.95rem;">Air Quality Jeopardy and more</strong>
+                            <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Dr. Sarath Guttikunda of <a href="https://urbanemissions.info/" target="_blank" rel="noopener">UrbanEmissions.Info</a> runs interactive sessions on air quality science, sources, and policy &mdash; including a Jeopardy-format game tested with school and adult cohorts. Choose Class 9+ students, college, or adult learners.</p>
                         </div>
 
                         <div id="workshop-form-success" style="display: none; padding: 14px; background: rgba(34,197,94,0.1); border: 1px solid #22C55E; border-radius: 8px; color: #166534; font-size: 0.88rem; margin-bottom: 12px;">
-                            ✓ Request received. We'll email you within 3 working days to coordinate dates with Sharath.
+                            <strong>Request received.</strong> We'll email you within 3 working days to coordinate dates with Sharath.
                         </div>
 
                         <form name="workshop-request" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" onsubmit="return handleWorkshopSubmit(event, 'workshop')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">
@@ -10971,16 +10968,13 @@ Signature: _______________</div>
                         <span style="font-size: 0.65rem; color: var(--text-3);">JanVayu team</span>
                     </div>
                     <div class="card-body" style="flex: 1; display: flex; flex-direction: column;">
-                        <div style="display: flex; gap: 12px; margin-bottom: 14px; align-items: flex-start;">
-                            <div style="font-size: 1.6rem; flex-shrink: 0;">🧭</div>
-                            <div>
-                                <strong style="display: block; font-size: 0.95rem;">Hands-on session</strong>
-                                <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Live walkthrough of the dashboard. Set AQI alerts for your city, file an RTI in one sitting, read the NCAP scorecard, and find the right purifier for your room. Free, online, English/Hindi. Up to 25 participants.</p>
-                            </div>
+                        <div style="border-left: 3px solid #1B6B4A; padding: 4px 0 4px 12px; margin-bottom: 14px;">
+                            <strong style="display: block; font-size: 0.95rem;">Hands-on session</strong>
+                            <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Live walkthrough of the dashboard. Set AQI alerts for your city, file an RTI in one sitting, read the NCAP scorecard, and find the right purifier for your room. Free, online, English/Hindi. Up to 25 participants.</p>
                         </div>
 
                         <div id="walkthrough-form-success" style="display: none; padding: 14px; background: rgba(34,197,94,0.1); border: 1px solid #22C55E; border-radius: 8px; color: #166534; font-size: 0.88rem; margin-bottom: 12px;">
-                            ✓ Request received. We'll email you within 2 working days to confirm a slot.
+                            <strong>Request received.</strong> We'll email you within 2 working days to confirm a slot.
                         </div>
 
                         <form name="walkthrough-booking" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" onsubmit="return handleWorkshopSubmit(event, 'walkthrough')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">


### PR DESCRIPTION
## Summary

Three things in one PR:

### 1. Strip the emoji I introduced this cycle
Per the no-emoji house style:
- **Near Me button** — replaced the 📍 prefix with the existing `si-pin` SVG icon
- **PWA install banner** — removed the 📲 leading icon
- **Workshops cards** — dropped the 🎲 / 🧭 icons in favour of a coloured left border + heading
- **Workshop / walkthrough success messages** — replaced `✓` with bold "Request received."
- **Solution-recommendation card** — `computeSolution()` now returns string actions; renderer uses AQI-band-coloured dot bullets instead of per-action emoji icons
- **Synthetic Near Me dropdown option** — `📍 …` → `Near me — …`

### 2. Documentation refresh
- **`CHANGELOG.md`**: new `v26.4.0` entry covering the competitor gap-closure batch (cigarette card, disease/solution cards, Near Me, Rankings panel, hourly scrub chart, YoY comparison, pollutant SEO pages, heatmap, embed widgets, PWA, Sensor.Community), plus `v26.4.1` for Workshops + AIPC attribution + this no-emoji cleanup.
- **`docs/wiki/Roadmap.md`**: added Phase 5.6 (Competitor Gap Closure, completed), marked PWA done in Phase 9, added Phase 10 (next-build recommendations: NCAP scorecard upgrade, FIRMS stubble tracker, source apportionment, 24–72hr forecast, push notifications, AQ literacy quiz, story-of-the-week).
- **`docs/user-guide/overview.md`**: section table grew from 23 to 31 entries to cover all the new dashboard cards, panels, pages, and PWA install.

### 3. Blog post + index update
- New post: `blog/posts/2026-04-26-shipped-this-week.md` — narrative version of the v26.4 release for end users.
- Added to `blog/README.md` and `blog/_sidebar.md`.

## Test plan
- [ ] Dashboard: Near Me button shows the pin icon, no emoji; cards still update on city change
- [ ] Solution-recommendation card: dot bullets render in the band colour (green for Good, dark red for Hazardous)
- [ ] Workshops cards: clean text-only headings, no game-die or compass; success messages show in green box on submit
- [ ] PWA install banner: shows on supported browsers with no leading emoji, layout intact on mobile
- [ ] `/blog/` and sidebar show the new post at the top of April
- [ ] `/docs/wiki/Roadmap` and `/docs/user-guide/overview` render correctly via Docsify


---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_