### PR TITLE
Wire workshop forms to Resend (contribute@janvayu.in), drop Netlify Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.4.2] - 2026-04-26
+
+### Changed — Workshop forms now use Resend instead of Netlify Forms
+
+- New Netlify Function `workshop-submit.mjs` handles both `workshop-request` and `walkthrough-booking` POSTs. Emails the submission to `contribute@janvayu.in` (overridable via `WORKSHOP_INBOX_EMAIL` env) using the existing Resend integration (`RESEND_API_KEY`, `RESEND_FROM`). Reply-to is set to the submitter's email so the team can reply directly.
+- Submissions are also written to Netlify Blobs (`janvayu-feeds` store under `workshops/<form-name>/<timestamp>-<email>.json`) for a durable record.
+- Honeypot anti-spam preserved — `bot-field` submissions are silently accepted and discarded.
+- Removed the Netlify Forms detection stubs and `data-netlify="true"` attributes since Netlify Forms is disabled at the project level (`processing_settings.ignore_html_forms: true`). The forms now POST directly to the function.
+- Fixed a stale `hello@janvayu.in` reference in the submit-error fallback to use the documented `contribute@janvayu.in`.
+
 ## [v26.4.1] - 2026-04-26
 
 ### Added — Workshops, Roadmap docs, Programme attribution

--- a/index.html
+++ b/index.html
@@ -10901,7 +10901,7 @@ Signature: _______________</div>
                             <strong>Request received.</strong> We'll email you within 3 working days to coordinate dates with Sharath.
                         </div>
 
-                        <form name="workshop-request" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" onsubmit="return handleWorkshopSubmit(event, 'workshop')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">
+                        <form name="workshop-request" method="POST" onsubmit="return handleWorkshopSubmit(event, 'workshop')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">
                             <input type="hidden" name="form-name" value="workshop-request">
                             <p style="display: none;"><label>Don't fill this out: <input name="bot-field"></label></p>
 
@@ -10977,7 +10977,7 @@ Signature: _______________</div>
                             <strong>Request received.</strong> We'll email you within 2 working days to confirm a slot.
                         </div>
 
-                        <form name="walkthrough-booking" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" onsubmit="return handleWorkshopSubmit(event, 'walkthrough')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">
+                        <form name="walkthrough-booking" method="POST" onsubmit="return handleWorkshopSubmit(event, 'walkthrough')" style="display: flex; flex-direction: column; gap: 10px; flex: 1;">
                             <input type="hidden" name="form-name" value="walkthrough-booking">
                             <p style="display: none;"><label>Don't fill this out: <input name="bot-field"></label></p>
 
@@ -14337,7 +14337,7 @@ window.addEventListener('resize', () => {
     }, 250);
 });
 
-// ── Workshops form submit handler (Netlify Forms) ──
+// ── Workshops form submit handler — posts JSON to workshop-submit Netlify Function ──
 window.handleWorkshopSubmit = async function (event, kind) {
     event.preventDefault();
     const form = event.target;
@@ -14345,46 +14345,25 @@ window.handleWorkshopSubmit = async function (event, kind) {
     const submitBtn = form.querySelector('button[type="submit"]');
     if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Sending…'; }
     try {
-        const data = new FormData(form);
-        await fetch('/', {
+        const fd = new FormData(form);
+        const payload = {};
+        for (const [k, v] of fd.entries()) payload[k] = v;
+        const res = await fetch('/.netlify/functions/workshop-submit', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams(data).toString()
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
         });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
         const ok = document.getElementById(successId);
         if (ok) ok.style.display = 'block';
         form.style.display = 'none';
     } catch (e) {
-        alert('Could not submit just now. Please email us at hello@janvayu.in instead.');
+        alert('Could not submit just now. Please email us at contribute@janvayu.in instead.');
         if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = kind === 'workshop' ? 'Request a workshop' : 'Request a slot'; }
     }
     return false;
 };
 </script>
-
-<!-- ─────────────────────────────────────────────────────────────────────
-     Netlify Forms detection stubs.
-     These hidden forms are crawled at deploy time so Netlify Forms picks
-     up the field schemas. The visible/styled forms inside <template> tags
-     are not crawled, so we mirror them here. Submissions to either form
-     end up in the Netlify dashboard under the matching form-name.
-     ───────────────────────────────────────────────────────────────────── -->
-<form name="workshop-request" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="form-name" value="workshop-request">
-  <input name="bot-field"><input name="name"><input name="email"><input name="organisation">
-  <select name="audience"><option></option></select>
-  <input name="group-size"><select name="format"><option></option></select>
-  <input name="city"><input name="preferred-dates"><textarea name="notes"></textarea>
-</form>
-<form name="walkthrough-booking" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="form-name" value="walkthrough-booking">
-  <input name="bot-field"><input name="name"><input name="email">
-  <select name="group-context"><option></option></select>
-  <input name="attendees">
-  <input name="slot-1"><input name="slot-2"><input name="slot-3">
-  <select name="language"><option></option></select>
-  <textarea name="goals"></textarea>
-</form>
 
 </body>
 </html>

--- a/netlify/functions/workshop-submit.mjs
+++ b/netlify/functions/workshop-submit.mjs
@@ -1,0 +1,177 @@
+// Netlify Function: Workshop & walkthrough submission handler
+//
+// Receives POST submissions from the two forms on the Workshops panel,
+// emails them to contribute@janvayu.in via Resend, and stores a durable
+// copy in the "janvayu-feeds" Netlify Blobs store under "workshops/".
+//
+// Forms:
+//   - form-name = "workshop-request"      → request a workshop with Sharath / UrbanEmissions
+//   - form-name = "walkthrough-booking"   → book a 1-hour JanVayu walkthrough
+//
+// Body: JSON OR x-www-form-urlencoded. Both are accepted. Netlify Forms is
+// not used; the form submits to /.netlify/functions/workshop-submit.
+
+import { Resend } from "resend";
+import { getStore } from "@netlify/blobs";
+
+const TO_EMAIL = process.env.WORKSHOP_INBOX_EMAIL || "contribute@janvayu.in";
+const FROM_EMAIL = process.env.RESEND_FROM || "JanVayu <alerts@janvayu.in>";
+
+function getBlobStore(name) {
+  const siteID = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
+  const token = process.env.BLOB_TOKEN;
+  if (siteID && token) return getStore({ name, siteID, token, consistency: "strong" });
+  return getStore({ name, consistency: "strong" });
+}
+
+const FIELD_LABELS = {
+  // workshop-request fields
+  name: "Name",
+  email: "Email",
+  organisation: "Organisation / school",
+  audience: "Audience",
+  "group-size": "Group size",
+  format: "Preferred format",
+  city: "City",
+  "preferred-dates": "Preferred dates",
+  notes: "Notes",
+  // walkthrough-booking fields
+  "group-context": "Group context",
+  attendees: "Approx. attendees",
+  "slot-1": "Slot 1",
+  "slot-2": "Slot 2",
+  "slot-3": "Slot 3",
+  language: "Language preference",
+  goals: "Learning goals",
+};
+
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+function buildEmail(formName, fields) {
+  const isWorkshop = formName === "workshop-request";
+  const heading = isWorkshop ? "New workshop request — UrbanEmissions" : "New JanVayu walkthrough booking";
+
+  const subjectBits = [];
+  if (fields.name) subjectBits.push(fields.name.trim());
+  if (fields.organisation) subjectBits.push(fields.organisation.trim());
+  if (fields["group-size"]) subjectBits.push(fields["group-size"].trim());
+  if (fields.attendees) subjectBits.push(fields.attendees.trim() + " attendees");
+  if (fields.city) subjectBits.push(fields.city.trim());
+  const subject = (isWorkshop ? "Workshop request" : "Walkthrough booking") +
+    (subjectBits.length ? ` — ${subjectBits.slice(0, 2).join(", ")}` : "");
+
+  const rows = Object.entries(fields)
+    .filter(([k, v]) => k !== "form-name" && k !== "bot-field" && v && String(v).trim() !== "")
+    .map(([k, v]) => `
+      <tr>
+        <td style="padding: 6px 12px 6px 0; color: #475569; font-size: 13px; vertical-align: top; white-space: nowrap;">${escapeHtml(FIELD_LABELS[k] || k)}</td>
+        <td style="padding: 6px 0; font-size: 14px; color: #0F172A;">${escapeHtml(v).replace(/\n/g, "<br>")}</td>
+      </tr>`).join("");
+
+  const html = `<!DOCTYPE html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #F8FAFC; padding: 24px; margin: 0;">
+  <div style="max-width: 600px; margin: 0 auto; background: #fff; border: 1px solid #E2E8F0; border-radius: 10px; overflow: hidden;">
+    <div style="padding: 18px 22px; background: #1B6B4A; color: #fff;">
+      <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.85;">JanVayu — AirQuality for Janhit</div>
+      <div style="font-size: 18px; font-weight: 600; margin-top: 4px;">${escapeHtml(heading)}</div>
+    </div>
+    <div style="padding: 22px;">
+      <table style="border-collapse: collapse; width: 100%;">${rows}</table>
+      <div style="margin-top: 22px; padding: 12px; background: #F8FAFC; border-left: 3px solid #1B6B4A; font-size: 13px; color: #475569; line-height: 1.5;">
+        ${isWorkshop
+          ? "Triage and forward to Sharath (UrbanEmissions). Aim to acknowledge within 3 working days."
+          : "Confirm one of the three preferred slots and reply with a Google Meet link. Aim to confirm within 2 working days."}
+      </div>
+      <div style="margin-top: 18px; font-size: 12px; color: #94A3B8;">
+        Submitted via <a href="https://www.janvayu.in/#workshops" style="color: #1B6B4A;">www.janvayu.in/#workshops</a> at ${new Date().toUTCString()}.
+        Reply to this email and the recipient will see your message in their inbox alongside the form data.
+      </div>
+    </div>
+  </div>
+</body></html>`;
+
+  // Plain-text fallback
+  const text = Object.entries(fields)
+    .filter(([k, v]) => k !== "form-name" && k !== "bot-field" && v && String(v).trim() !== "")
+    .map(([k, v]) => `${FIELD_LABELS[k] || k}: ${v}`).join("\n");
+
+  return { subject, html, text };
+}
+
+async function parseBody(req) {
+  const contentType = req.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return await req.json();
+  }
+  if (contentType.includes("application/x-www-form-urlencoded") || contentType.includes("multipart/form-data")) {
+    const formData = await req.formData();
+    const obj = {};
+    for (const [k, v] of formData.entries()) obj[k] = typeof v === "string" ? v : "";
+    return obj;
+  }
+  // Best-effort: try JSON
+  try { return JSON.parse(await req.text()); } catch { return {}; }
+}
+
+export default async function handler(req) {
+  const headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Content-Type": "application/json",
+  };
+
+  if (req.method === "OPTIONS") return new Response("", { status: 204, headers });
+  if (req.method !== "POST") return new Response(JSON.stringify({ error: "POST required" }), { status: 405, headers });
+
+  const fields = await parseBody(req);
+  const formName = fields["form-name"] || fields.form;
+
+  // Honeypot — if the bot-field is populated, silently accept and discard.
+  if (fields["bot-field"]) {
+    return new Response(JSON.stringify({ ok: true, dropped: "honeypot" }), { status: 200, headers });
+  }
+
+  if (formName !== "workshop-request" && formName !== "walkthrough-booking") {
+    return new Response(JSON.stringify({ error: "unknown form-name" }), { status: 400, headers });
+  }
+  if (!fields.name || !fields.email) {
+    return new Response(JSON.stringify({ error: "name and email are required" }), { status: 400, headers });
+  }
+
+  // Durable record in Blobs (best-effort, non-blocking)
+  try {
+    const store = getBlobStore("janvayu-feeds");
+    const key = `workshops/${formName}/${new Date().toISOString().replace(/[:.]/g, "-")}-${(fields.email || "anon").replace(/[^a-z0-9]/gi, "_")}.json`;
+    await store.setJSON(key, { ...fields, _received_at: new Date().toISOString() });
+  } catch (e) { console.log("Blobs write failed:", e.message); }
+
+  // Email via Resend
+  const RESEND_API_KEY = process.env.RESEND_API_KEY;
+  if (!RESEND_API_KEY) {
+    console.log("RESEND_API_KEY not set — submission stored only.");
+    return new Response(JSON.stringify({ ok: true, stored: true, emailed: false }), { status: 200, headers });
+  }
+
+  try {
+    const resend = new Resend(RESEND_API_KEY);
+    const { subject, html, text } = buildEmail(formName, fields);
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: TO_EMAIL,
+      reply_to: fields.email,
+      subject,
+      html,
+      text,
+    });
+    return new Response(JSON.stringify({ ok: true, stored: true, emailed: true }), { status: 200, headers });
+  } catch (e) {
+    console.log("Resend error:", e.message);
+    // Submission is durable in Blobs even if email fails. Return ok so the
+    // user sees the success state; the team can audit Blobs if needed.
+    return new Response(JSON.stringify({ ok: true, stored: true, emailed: false, error: e.message }), { status: 200, headers });
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the Netlify Forms wiring on the Workshops panel with a custom Netlify Function that uses the **already-configured Resend** integration to email submissions to **`contribute@janvayu.in`** (the footer/About contact address).

### Why
The site has `processing_settings.ignore_html_forms: true` set at the project level (verified via Netlify API), so the `data-netlify="true"` form stubs added in #60 were never going to be detected. Rather than ask you to flip the project setting, this PR uses what we already have — Resend was set up for the daily digest in v25.4.

### What changed

**New: `netlify/functions/workshop-submit.mjs`**
- Accepts JSON or form-encoded POST for both `workshop-request` and `walkthrough-booking`
- Validates `form-name` + `name` + `email`; honeypot `bot-field` is silently accepted-and-dropped
- Writes a durable record to Netlify Blobs under `janvayu-feeds/workshops/<form>/<timestamp>-<email>.json` — submissions survive even if Resend has a hiccup
- Sends a styled HTML email plus plain-text fallback to `WORKSHOP_INBOX_EMAIL` (defaults to `contribute@janvayu.in`) via Resend (`RESEND_API_KEY` / `RESEND_FROM` env vars, same ones daily-digest uses)
- `reply_to` is the submitter's email so the team can reply directly without copy-pasting

**Front-end (`index.html`)**
- Removed `data-netlify` and `data-netlify-honeypot` from both forms
- `handleWorkshopSubmit()` now POSTs JSON to `/.netlify/functions/workshop-submit`
- Removed the two Netlify Forms detection stubs at the end of `<body>`
- Fixed a stale `hello@janvayu.in` reference in the submit-error fallback to `contribute@janvayu.in` (matches footer + About attribution)

**`CHANGELOG.md`**: new `v26.4.2` entry.

## Env vars used (all already set in production)
- `RESEND_API_KEY` — already wired up for daily-digest
- `RESEND_FROM` — defaults to `JanVayu <alerts@janvayu.in>` if unset
- `WORKSHOP_INBOX_EMAIL` — optional override; defaults to `contribute@janvayu.in`
- `BLOB_TOKEN` + `NETLIFY_SITE_ID` (or auto-detect) — already used by other functions

## Test plan
- [ ] After deploy, fill in the workshop form on `/#workshops` — should see the green "Request received" success state
- [ ] Confirm the email arrives at `contribute@janvayu.in` with a subject like "Workshop request — RWA in Noida, 30 attendees"
- [ ] Hit Reply on the email — should auto-fill the submitter's address
- [ ] Open Netlify Blobs (`janvayu-feeds` store) — see the durable JSON entries under `workshops/`
- [ ] Test the walkthrough form too
- [ ] No regressions to the dashboard, Ask JanVayu, Hyperlocal, or any other panel


---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_