### PR TITLE
Fix About-panel subline that still showed v25.4 / 12 Apr

### DIFF
--- a/index.html
+++ b/index.html
@@ -12087,7 +12087,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v25.4 | Updated 12 Apr 2026 | Blog, Zotero research library, IQAir 2025 data, mobile &amp; accessibility fixes, social feeds re-enabled.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.4 | Updated 26 Apr 2026 | Cigarette equivalence, City Rankings, hourly trends, YoY comparison, heatmap, Workshops, Sensor.Community sensors, Ask JanVayu in Hindi/Tamil/Bengali/Marathi, AIPC attribution.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">


### PR DESCRIPTION
## Summary

The on-site changelog (under "Version History") was updated in #65, but I missed a separate **small metadata line** at the top of the About panel — a `font-mono`, `font-size: 0.75rem` div that still read:

> v25.4 | Updated 12 Apr 2026 | Blog, Zotero research library, IQAir 2025 data, mobile & accessibility fixes, social feeds re-enabled.

This is the line you flagged as still stale even after the #65 deploy. Now reads:

> v26.4 | Updated 26 Apr 2026 | Cigarette equivalence, City Rankings, hourly trends, YoY comparison, heatmap, Workshops, Sensor.Community sensors, Ask JanVayu in Hindi/Tamil/Bengali/Marathi, AIPC attribution.

## Test plan
- [ ] Open About & Changelog panel — small mono line under the heading shows v26.4 dated 26 Apr 2026
- [ ] Version-history list below still shows v25.4 dated 12 Apr 2026 in its own historical entry (correct)


---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_