### PR TITLE
Service worker: network-first for .md, bump cache to v2

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-v1';
+const CACHE_VERSION = 'janvayu-v2';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
@@ -40,12 +40,13 @@ self.addEventListener('fetch', (event) => {
   const isWaqi = url.hostname.endsWith('waqi.info');
   const isNetlifyFn = url.pathname.startsWith('/.netlify/functions/');
   const isShellNav = req.mode === 'navigate' || req.destination === 'document';
+  const isMarkdown = url.pathname.endsWith('.md');
 
   if (isShellNav) {
     event.respondWith(networkFirst(req));
     return;
   }
-  if (isWaqi || isNetlifyFn) {
+  if (isWaqi || isNetlifyFn || isMarkdown) {
     event.respondWith(networkFirst(req));
     return;
   }


### PR DESCRIPTION
## Why

After PR #66 cleaned the gitbook links out of `docs/README.md`, visitors still saw the old gitbook.io rows in `/docs/` even after a hard refresh — on both desktop and mobile.

Root cause: `sw.js` was running `cacheFirst` on every same-origin GET. Docsify fetches `/docs/*.md` via JavaScript, and SW-intercepted subresource fetches don't honour the browser's hard-refresh cache bypass. So the pre-#66 README stayed pinned in the SW cache forever.

## Fix

- `.md` requests now go through `networkFirst` → docs always reflect the live deploy.
- `CACHE_VERSION` bumped `janvayu-v1` → `janvayu-v2` so the `activate` handler evicts the stale cache for every existing visitor the moment the new SW takes over.

## Test plan

- [ ] Visit `janvayu.in/docs/` once after deploy — new SW installs and skip-waits, old `janvayu-v1` cache is dropped.
- [ ] Reload `/docs/` — README shows the `/docs/#/hi/` etc. routes, no gitbook URLs.
- [ ] Edit a docs `.md` in a future commit and confirm changes appear on next reload without manual cache-clear.

https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_