### PR TITLE
Docs: fix bare /hi/ /bn/ /mr/ /ta/ routes returning 404

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -257,17 +257,21 @@
         pathNamespaces: ['/hi', '/bn', '/mr', '/ta']
       },
       alias: {
-        // Language routing — map /hi/*, /bn/*, etc. to language directories
-        '/hi/(.*)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/$1',
+        // Language routing — map /hi/*, /bn/*, etc. to language directories.
+        // Regex uses (.+) so it only matches non-empty subpaths; the bare
+        // '/hi/' route is handled by the literal alias, which points at
+        // README.md. With (.*) the regex would also match '/hi/' (capture
+        // empty) and rewrite to a directory URL → 404.
+        '/hi/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/$1',
         '/hi/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/README.md',
         '/hi/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/_sidebar.md',
-        '/bn/(.*)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/$1',
+        '/bn/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/$1',
         '/bn/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/README.md',
         '/bn/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/_sidebar.md',
-        '/mr/(.*)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/$1',
+        '/mr/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/$1',
         '/mr/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/README.md',
         '/mr/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/_sidebar.md',
-        '/ta/(.*)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/$1',
+        '/ta/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/$1',
         '/ta/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/README.md',
         '/ta/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/_sidebar.md'
       },


### PR DESCRIPTION
## Why

After PR #66, the README's language links point at `/docs/#/hi/`, `/docs/#/bn/`, `/docs/#/mr/`, `/docs/#/ta/` — and clicking them lands on a 404.

Root cause is in `docs/index.html` Docsify config: the regex alias `'/hi/(.*)'` is greedy enough to match the bare route `/hi/` with `$1=''` and rewrites to `raw.githubusercontent.com/.../docs-hi/`, which is a directory URL and returns 404. The literal `'/hi/': '.../docs-hi/README.md'` alias defined below it never wins because the regex matches first.

## Fix

`(.*)` → `(.+)` for all four language regex aliases. Now the regex only matches non-empty subpaths, the literal `/<lang>/` alias handles bare landing pages, and the README renders. Subpaths like `/hi/about/license` keep working through the regex unchanged.

## Test plan

- [ ] After deploy, `janvayu.in/docs/#/hi/` renders the Hindi README
- [ ] Same for `/bn/`, `/mr/`, `/ta/`
- [ ] `/docs/#/hi/about/license` still resolves (subpath unaffected)
- [ ] Sidebars still load on each language

https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_