### PR TITLE
Docs: same-origin language routes + auto-translate workflow

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -9,6 +9,13 @@ on:
       - 'docs-bn/**'
       - 'docs-mr/**'
       - 'docs-ta/**'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'sync (changed-since-last-push) | backfill (every stale or missing file)'
+        type: choice
+        options: [sync, backfill]
+        default: sync
 
 jobs:
   check-translation-coverage:
@@ -145,3 +152,60 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "> **$STALE** translations may need updating." >> $GITHUB_STEP_SUMMARY
           fi
+
+  auto-translate:
+    needs: [check-translation-coverage]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bail if Anthropic key is not configured
+        id: gate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning::ANTHROPIC_API_KEY secret is not set — skipping auto-translation. Add it in repo Settings → Secrets to enable."
+            echo "skip=1" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Python
+        if: steps.gate.outputs.skip != '1'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Anthropic SDK
+        if: steps.gate.outputs.skip != '1'
+        run: pip install --quiet 'anthropic>=0.40,<1.0'
+
+      - name: Translate stale and missing files
+        if: steps.gate.outputs.skip != '1'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MODE: ${{ github.event.inputs.mode || 'sync' }}
+          EVENT: ${{ github.event_name }}
+        run: python3 scripts/translate-docs.py
+
+      - name: Commit translations
+        if: steps.gate.outputs.skip != '1'
+        run: |
+          if git diff --quiet docs-hi/ docs-bn/ docs-mr/ docs-ta/; then
+            echo "No translation changes."
+            exit 0
+          fi
+          git config user.name "janvayu-translation-bot"
+          git config user.email "translation-bot@janvayu.in"
+          git add docs-hi/ docs-bn/ docs-mr/ docs-ta/
+          git commit -m "Auto-translate docs (Claude) [skip ci]"
+          # Retry push up to 4 times with backoff in case main moved underneath us
+          for delay in 0 4 8 16; do
+            if [ $delay -gt 0 ]; then sleep $delay; git pull --rebase origin main || true; fi
+            if git push origin HEAD:main; then exit 0; fi
+          done
+          exit 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -257,23 +257,24 @@
         pathNamespaces: ['/hi', '/bn', '/mr', '/ta']
       },
       alias: {
-        // Language routing — map /hi/*, /bn/*, etc. to language directories.
-        // Regex uses (.+) so it only matches non-empty subpaths; the bare
-        // '/hi/' route is handled by the literal alias, which points at
-        // README.md. With (.*) the regex would also match '/hi/' (capture
-        // empty) and rewrite to a directory URL → 404.
-        '/hi/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/$1',
-        '/hi/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/README.md',
-        '/hi/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-hi/_sidebar.md',
-        '/bn/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/$1',
-        '/bn/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/README.md',
-        '/bn/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-bn/_sidebar.md',
-        '/mr/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/$1',
-        '/mr/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/README.md',
-        '/mr/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-mr/_sidebar.md',
-        '/ta/(.+)': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/$1',
-        '/ta/': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/README.md',
-        '/ta/_sidebar.md': 'https://raw.githubusercontent.com/JanVayu/JanVayu/main/docs-ta/_sidebar.md'
+        // Language routing — map /hi/*, /bn/*, etc. to language directories
+        // served from this same Netlify deploy. Same-origin keeps it simple:
+        // no CORS, no cross-origin Docsify quirks, files always match the
+        // current commit. Regex uses (.+) so the bare '/hi/' route falls
+        // through to the literal alias which points at README.md; '(.*)'
+        // would swallow '/hi/' with empty capture and produce a directory URL.
+        '/hi/(.+)': 'https://www.janvayu.in/docs-hi/$1',
+        '/hi/': 'https://www.janvayu.in/docs-hi/README.md',
+        '/hi/_sidebar.md': 'https://www.janvayu.in/docs-hi/_sidebar.md',
+        '/bn/(.+)': 'https://www.janvayu.in/docs-bn/$1',
+        '/bn/': 'https://www.janvayu.in/docs-bn/README.md',
+        '/bn/_sidebar.md': 'https://www.janvayu.in/docs-bn/_sidebar.md',
+        '/mr/(.+)': 'https://www.janvayu.in/docs-mr/$1',
+        '/mr/': 'https://www.janvayu.in/docs-mr/README.md',
+        '/mr/_sidebar.md': 'https://www.janvayu.in/docs-mr/_sidebar.md',
+        '/ta/(.+)': 'https://www.janvayu.in/docs-ta/$1',
+        '/ta/': 'https://www.janvayu.in/docs-ta/README.md',
+        '/ta/_sidebar.md': 'https://www.janvayu.in/docs-ta/_sidebar.md'
       },
       pagination: {
         previousText: 'Previous',

--- a/scripts/translate-docs.py
+++ b/scripts/translate-docs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Translate JanVayu docs from English to Hindi/Bengali/Marathi/Tamil using Claude.
+
+Modes (via $MODE):
+  sync     — only translate English files that changed in the most recent push.
+  backfill — translate every English file whose translation is missing or older
+             than the English source (by git author date).
+
+Triggered by .github/workflows/translations.yml. Commits the result with the
+translation bot identity.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import anthropic
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EN_DIR = REPO_ROOT / "docs"
+LANGS = {
+    "hi": "Hindi (हिन्दी)",
+    "bn": "Bengali (বাংলা)",
+    "mr": "Marathi (मराठी)",
+    "ta": "Tamil (தமிழ்)",
+}
+# Files that are routing/structural — translate filenames stay the same but
+# contents (e.g., SUMMARY.md, _sidebar.md) need careful translation of link text
+# while preserving paths.
+TRANSLATE_EXTENSIONS = {".md"}
+
+MODEL = "claude-sonnet-4-6"
+
+PROMPT_TEMPLATE = """You are translating JanVayu's air quality accountability documentation from English into {lang_name}. JanVayu is India's independent, citizen-led air quality platform.
+
+TRANSLATION RULES:
+1. Translate naturally for fluent native readers — not word-for-word.
+2. Keep ALL Markdown structure intact: headings, lists, tables, code blocks, links, image references, HTML tags, frontmatter.
+3. Preserve link targets exactly (e.g. `[text](path/to/file.md)` — translate `text` only).
+4. Keep these in English: product names (JanVayu, Supabase, Netlify, Anthropic, GitHub, NCAP, WAQI, CPCB, Docsify), technical identifiers (variable names, API endpoints, file paths, env vars), units (µg/m³, ppm), and all numbers/dates/code.
+5. Pollutant names (PM2.5, PM10, NO2, SO2, O3, CO) stay as-is.
+6. Use respectful, neutral, journalistic tone. JanVayu is non-partisan in mission.
+7. If the source file has YAML frontmatter, translate values but keep keys in English.
+8. Output ONLY the translated Markdown. No preamble, no explanation, no code fences wrapping the whole document.
+
+ENGLISH SOURCE FILE: {rel_path}
+
+---
+{content}
+"""
+
+
+def run(cmd: list[str], **kwargs) -> str:
+    return subprocess.check_output(cmd, cwd=REPO_ROOT, text=True, **kwargs).strip()
+
+
+def english_files() -> list[Path]:
+    out = []
+    for p in EN_DIR.rglob("*"):
+        if p.is_file() and p.suffix in TRANSLATE_EXTENSIONS:
+            out.append(p)
+    return out
+
+
+def git_unix_time(path: Path) -> int:
+    try:
+        ts = run(["git", "log", "-1", "--format=%at", "--", str(path.relative_to(REPO_ROOT))])
+        return int(ts) if ts else 0
+    except (subprocess.CalledProcessError, ValueError):
+        return 0
+
+
+def changed_english_files_since_previous_commit() -> list[Path]:
+    try:
+        diff = run(["git", "diff", "--name-only", "HEAD~1", "HEAD", "--", "docs/"])
+    except subprocess.CalledProcessError:
+        return []
+    files = []
+    for line in diff.splitlines():
+        if not line:
+            continue
+        p = REPO_ROOT / line
+        if p.exists() and p.suffix in TRANSLATE_EXTENSIONS and p.is_relative_to(EN_DIR):
+            files.append(p)
+    return files
+
+
+def target_path(en_path: Path, lang: str) -> Path:
+    rel = en_path.relative_to(EN_DIR)
+    return REPO_ROOT / f"docs-{lang}" / rel
+
+
+def is_stale(en_path: Path, lang: str) -> bool:
+    tgt = target_path(en_path, lang)
+    if not tgt.exists():
+        return True
+    return git_unix_time(en_path) > git_unix_time(tgt)
+
+
+def translate(client: anthropic.Anthropic, content: str, lang: str, rel_path: str) -> str:
+    msg = client.messages.create(
+        model=MODEL,
+        max_tokens=8192,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": PROMPT_TEMPLATE.format(
+                            lang_name=LANGS[lang],
+                            rel_path=rel_path,
+                            content=content,
+                        ),
+                        # Cache the system rules + structure across calls in this run.
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ],
+    )
+    parts = [b.text for b in msg.content if b.type == "text"]
+    return "".join(parts).strip() + "\n"
+
+
+def main() -> int:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ANTHROPIC_API_KEY missing.", file=sys.stderr)
+        return 1
+
+    mode = os.environ.get("MODE", "sync").strip()
+    if mode not in {"sync", "backfill"}:
+        print(f"Unknown MODE={mode!r}, expected 'sync' or 'backfill'.", file=sys.stderr)
+        return 2
+
+    if mode == "sync":
+        candidates = changed_english_files_since_previous_commit()
+        if not candidates:
+            print("No English docs changed in the latest push — nothing to do.")
+            return 0
+    else:
+        candidates = english_files()
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    summary = []
+    for en_path in candidates:
+        rel_str = str(en_path.relative_to(EN_DIR))
+        for lang in LANGS:
+            if mode == "sync" and not is_stale(en_path, lang):
+                continue
+            if mode == "backfill" and not is_stale(en_path, lang):
+                continue
+            try:
+                content = en_path.read_text(encoding="utf-8")
+            except OSError as e:
+                print(f"skip {en_path}: {e}", file=sys.stderr)
+                continue
+            print(f"translate {rel_str} → {lang}")
+            try:
+                translated = translate(client, content, lang, rel_str)
+            except Exception as e:
+                print(f"  failed: {e}", file=sys.stderr)
+                summary.append(f"FAILED {rel_str} ({lang}): {e}")
+                continue
+            tgt = target_path(en_path, lang)
+            tgt.parent.mkdir(parents=True, exist_ok=True)
+            tgt.write_text(translated, encoding="utf-8")
+            summary.append(f"OK     {rel_str} ({lang})")
+
+    print("\n".join(summary) or "No changes written.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-v2';
+const CACHE_VERSION = 'janvayu-v3';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Why

Two production fixes plus the automation needed so translations don't silently fall behind English again.

## What's in here

**1. Language route 404 (real fix this time).** PR #69's regex tweak should have worked, but `/docs/#/hi/` and friends are still 404'ing for users. Switching the Docsify aliases from `raw.githubusercontent.com` to same-origin `https://www.janvayu.in/docs-<lang>/*` removes cross-origin and the public-CDN copy as variables. The files are already in the Netlify deploy, response always matches the current commit, no CORS, no Docsify cross-origin quirks.

**2. Service worker `v2 → v3`.** Forces the `activate` handler to evict any older caches that pinned the previous `docs/index.html` on returning visitors, so the new alias actually reaches them on the next load.

**3. Auto-translate workflow + `scripts/translate-docs.py`.** The existing `translations.yml` only *reported* staleness — now a new `auto-translate` job actually runs Claude Sonnet 4.6 over each changed-or-stale English doc and commits Hindi/Bengali/Marathi/Tamil versions back to main.
- Push to main with `docs/*` changes → `sync` mode (translate just the diff)
- Manual `workflow_dispatch` with `mode=backfill` → re-translate every stale or missing file. Run this once to clear the current 11-files-per-language gap.
- Job no-ops cleanly if `ANTHROPIC_API_KEY` isn't configured (with a warning), so this can merge before the secret is added.

## Required follow-up (after merge)

- [ ] Add `ANTHROPIC_API_KEY` to repo Settings → Secrets and variables → Actions.
- [ ] Trigger Actions → Translation Sync → Run workflow → `mode=backfill` to translate the 11 missing files × 4 languages.

## Test plan

- [ ] After deploy, `janvayu.in/docs/#/hi/` renders the Hindi README. Same for `/bn/`, `/mr/`, `/ta/`.
- [ ] Subpaths still resolve: `/docs/#/hi/about/license`.
- [ ] Service worker activates v3, evicts v1/v2.
- [ ] Auto-translate workflow runs (and skips clean) on this PR's merge commit since no `docs/*.md` changed in the diff.

https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_