### PR TITLE
Auto-translate: switch from Anthropic to Sarvam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ GROQ_API_KEY=
 
 # Agent-Reach feed ingest — API key for GitHub Actions to push social media data
 FEED_INGEST_KEY=
+
+# Sarvam — Indian-language translation (auto-translates docs/ → docs-hi/bn/mr/ta/)
+SARVAM_API_KEY=

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -164,13 +164,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bail if Anthropic key is not configured
+      - name: Bail if Sarvam key is not configured
         id: gate
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SARVAM_API_KEY: ${{ secrets.SARVAM_API_KEY }}
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::warning::ANTHROPIC_API_KEY secret is not set — skipping auto-translation. Add it in repo Settings → Secrets to enable."
+          if [ -z "$SARVAM_API_KEY" ]; then
+            echo "::warning::SARVAM_API_KEY secret is not set — skipping auto-translation. Add it in repo Settings → Secrets to enable."
             echo "skip=1" >> $GITHUB_OUTPUT
           fi
 
@@ -180,14 +180,10 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Anthropic SDK
-        if: steps.gate.outputs.skip != '1'
-        run: pip install --quiet 'anthropic>=0.40,<1.0'
-
       - name: Translate stale and missing files
         if: steps.gate.outputs.skip != '1'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SARVAM_API_KEY: ${{ secrets.SARVAM_API_KEY }}
           MODE: ${{ github.event.inputs.mode || 'sync' }}
           EVENT: ${{ github.event_name }}
         run: python3 scripts/translate-docs.py
@@ -202,7 +198,7 @@ jobs:
           git config user.name "janvayu-translation-bot"
           git config user.email "translation-bot@janvayu.in"
           git add docs-hi/ docs-bn/ docs-mr/ docs-ta/
-          git commit -m "Auto-translate docs (Claude) [skip ci]"
+          git commit -m "Auto-translate docs (Sarvam) [skip ci]"
           # Retry push up to 4 times with backoff in case main moved underneath us
           for delay in 0 4 8 16; do
             if [ $delay -gt 0 ]; then sleep $delay; git pull --rebase origin main || true; fi

--- a/scripts/translate-docs.py
+++ b/scripts/translate-docs.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Translate JanVayu docs from English to Hindi/Bengali/Marathi/Tamil using Claude.
+"""Translate JanVayu docs from English to Hindi/Bengali/Marathi/Tamil using Sarvam.
+
+Sarvam's chat-completions API is used (OpenAI-compatible) because:
+- Sarvam's models are trained for Indian languages and outperform generic LLMs
+  on Hindi/Bengali/Marathi/Tamil.
+- Chat completions handles full Markdown documents in one shot, unlike the
+  /translate endpoint which has a small per-request character limit.
 
 Modes (via $MODE):
   sync     — only translate English files that changed in the most recent push.
@@ -11,12 +17,13 @@ translation bot identity.
 """
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
-
-import anthropic
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EN_DIR = REPO_ROOT / "docs"
@@ -26,12 +33,12 @@ LANGS = {
     "mr": "Marathi (मराठी)",
     "ta": "Tamil (தமிழ்)",
 }
-# Files that are routing/structural — translate filenames stay the same but
-# contents (e.g., SUMMARY.md, _sidebar.md) need careful translation of link text
-# while preserving paths.
 TRANSLATE_EXTENSIONS = {".md"}
 
-MODEL = "claude-sonnet-4-6"
+API_URL = "https://api.sarvam.ai/v1/chat/completions"
+MODEL = "sarvam-m"
+MAX_TOKENS = 8192
+TEMPERATURE = 0.2
 
 PROMPT_TEMPLATE = """You are translating JanVayu's air quality accountability documentation from English into {lang_name}. JanVayu is India's independent, citizen-led air quality platform.
 
@@ -39,7 +46,7 @@ TRANSLATION RULES:
 1. Translate naturally for fluent native readers — not word-for-word.
 2. Keep ALL Markdown structure intact: headings, lists, tables, code blocks, links, image references, HTML tags, frontmatter.
 3. Preserve link targets exactly (e.g. `[text](path/to/file.md)` — translate `text` only).
-4. Keep these in English: product names (JanVayu, Supabase, Netlify, Anthropic, GitHub, NCAP, WAQI, CPCB, Docsify), technical identifiers (variable names, API endpoints, file paths, env vars), units (µg/m³, ppm), and all numbers/dates/code.
+4. Keep these in English: product names (JanVayu, Supabase, Netlify, Sarvam, GitHub, NCAP, WAQI, CPCB, Docsify), technical identifiers (variable names, API endpoints, file paths, env vars), units (µg/m³, ppm), and all numbers/dates/code.
 5. Pollutant names (PM2.5, PM10, NO2, SO2, O3, CO) stay as-is.
 6. Use respectful, neutral, journalistic tone. JanVayu is non-partisan in mission.
 7. If the source file has YAML frontmatter, translate values but keep keys in English.
@@ -52,16 +59,12 @@ ENGLISH SOURCE FILE: {rel_path}
 """
 
 
-def run(cmd: list[str], **kwargs) -> str:
-    return subprocess.check_output(cmd, cwd=REPO_ROOT, text=True, **kwargs).strip()
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, cwd=REPO_ROOT, text=True).strip()
 
 
 def english_files() -> list[Path]:
-    out = []
-    for p in EN_DIR.rglob("*"):
-        if p.is_file() and p.suffix in TRANSLATE_EXTENSIONS:
-            out.append(p)
-    return out
+    return [p for p in EN_DIR.rglob("*") if p.is_file() and p.suffix in TRANSLATE_EXTENSIONS]
 
 
 def git_unix_time(path: Path) -> int:
@@ -99,36 +102,40 @@ def is_stale(en_path: Path, lang: str) -> bool:
     return git_unix_time(en_path) > git_unix_time(tgt)
 
 
-def translate(client: anthropic.Anthropic, content: str, lang: str, rel_path: str) -> str:
-    msg = client.messages.create(
-        model=MODEL,
-        max_tokens=8192,
-        messages=[
+def translate(api_key: str, content: str, lang: str, rel_path: str) -> str:
+    payload = {
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "temperature": TEMPERATURE,
+        "messages": [
             {
                 "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": PROMPT_TEMPLATE.format(
-                            lang_name=LANGS[lang],
-                            rel_path=rel_path,
-                            content=content,
-                        ),
-                        # Cache the system rules + structure across calls in this run.
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
+                "content": PROMPT_TEMPLATE.format(
+                    lang_name=LANGS[lang],
+                    rel_path=rel_path,
+                    content=content,
+                ),
             }
         ],
+    }
+    req = urllib.request.Request(
+        API_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
     )
-    parts = [b.text for b in msg.content if b.type == "text"]
-    return "".join(parts).strip() + "\n"
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    return body["choices"][0]["message"]["content"].strip() + "\n"
 
 
 def main() -> int:
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get("SARVAM_API_KEY")
     if not api_key:
-        print("ANTHROPIC_API_KEY missing.", file=sys.stderr)
+        print("SARVAM_API_KEY missing.", file=sys.stderr)
         return 1
 
     mode = os.environ.get("MODE", "sync").strip()
@@ -144,15 +151,11 @@ def main() -> int:
     else:
         candidates = english_files()
 
-    client = anthropic.Anthropic(api_key=api_key)
-
     summary = []
     for en_path in candidates:
         rel_str = str(en_path.relative_to(EN_DIR))
         for lang in LANGS:
-            if mode == "sync" and not is_stale(en_path, lang):
-                continue
-            if mode == "backfill" and not is_stale(en_path, lang):
+            if not is_stale(en_path, lang):
                 continue
             try:
                 content = en_path.read_text(encoding="utf-8")
@@ -161,7 +164,12 @@ def main() -> int:
                 continue
             print(f"translate {rel_str} → {lang}")
             try:
-                translated = translate(client, content, lang, rel_str)
+                translated = translate(api_key, content, lang, rel_str)
+            except urllib.error.HTTPError as e:
+                detail = e.read().decode("utf-8", errors="replace")[:500]
+                print(f"  HTTP {e.code}: {detail}", file=sys.stderr)
+                summary.append(f"FAILED {rel_str} ({lang}): HTTP {e.code}")
+                continue
             except Exception as e:
                 print(f"  failed: {e}", file=sys.stderr)
                 summary.append(f"FAILED {rel_str} ({lang}): {e}")


### PR DESCRIPTION
## Why

Sarvam's models are trained for Indian languages and produce noticeably better Hindi/Bengali/Marathi/Tamil than generic LLMs. Repo already has a `SARVAM_API_KEY` provisioned; no Anthropic key was set up. So the auto-translate workflow merged in #70 was inert — switching it over makes it actually run with the key you already have.

## Changes

- **`scripts/translate-docs.py`** rewritten to call Sarvam's chat-completions endpoint (`https://api.sarvam.ai/v1/chat/completions`, model `sarvam-m`, OpenAI-compatible). Uses stdlib `urllib` only — drops the `anthropic` SDK dependency, so the workflow no longer needs `pip install`.
- **`.github/workflows/translations.yml`** gates on `SARVAM_API_KEY` instead of `ANTHROPIC_API_KEY`, removes the SDK install step, updates the bot commit message.
- **`.env.example`** documents `SARVAM_API_KEY` alongside the other service keys.

## Required follow-up (after merge)

- [ ] Add `SARVAM_API_KEY` to repo Settings → Secrets and variables → Actions (if not already there for some other use).
- [ ] Trigger Actions → Translation Sync → Run workflow → `mode=backfill` to translate the 11 missing files × 4 languages and bring stale ones up to date.

## Test plan

- [ ] After merge with secret set, manual `mode=backfill` run successfully translates and commits to main.
- [ ] On a subsequent push touching `docs/*.md`, `mode=sync` translates only the diff.
- [ ] Without the secret, the job no-ops with a clear warning (already validated on #70).

https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_