### PR TITLE
Docs: rephrase 'Non-partisan' guiding principle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ These docs are available in 5 languages:
 
 ## Guiding Principles
 
-- **Non-partisan** — not affiliated with any political party, government body, or corporate entity
+- **Non-partisan** — air quality affects every Indian regardless of political affiliation, and our data, analysis, and accountability work serves everyone
 - **Verifiable** — every data point links to a primary source
 - **Accessible** — available in English, Hindi, Tamil, Marathi, and Bengali
 - **Open** — code is MIT-licensed; content is CC BY-NC-SA 4.0

--- a/docs/about/background.md
+++ b/docs/about/background.md
@@ -31,7 +31,7 @@ JanVayu is **national in scope** — it covers 30+ cities across all major regio
 
 JanVayu is:
 
-- **Non-partisan** — not affiliated with any political party, government body, or corporate entity
+- **Non-partisan** — air quality affects every Indian regardless of political affiliation, and our data, analysis, and accountability work serves everyone
 - **Independently maintained** — decisions are guided by editorial principles, not donor requirements
 - **Open source** — code is MIT-licensed; content is CC BY-NC-SA 4.0
 


### PR DESCRIPTION
## Why

The "Non-partisan" guiding principle currently reads:

> Non-partisan — not affiliated with any political party, government body, or corporate entity

The political-party clause is not strictly accurate, so the bullet was overclaiming. Reframing the principle around what is true: air quality is a universal issue, and JanVayu's data and accountability work serves everyone regardless of political affiliation.

## Scope

Two identical bullets updated:
- `docs/README.md:48`
- `docs/about/background.md:34`

Other "non-partisanship" references in the docs are about editorial *method* ("criticise policies and systems, not parties or individuals", the "Non-Partisan Standard" section in `content-standards.md`) — those describe how content is written and still hold, so they're unchanged.

https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kHtXT69vGWWnPDont3akL)_