### PR TITLE
v26.6.8: Final corners — wiki Home, last small surfaces (completes the v26.6 sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.8] - 2026-05-20
+
+### Changed — Final corners: wiki Home, last small surfaces
+
+User feedback: *"Yes I want you to do all small or big. Everything."* Final pass on the smallest remaining surfaces from the v26.6.7 stocktake. Audit confirmed most are already clean.
+
+#### `docs/wiki/Home.md` — "What's New" rewritten for the v26.6.x cycle
+
+The wiki landing page's "What's New" section was anchored to v26.5.x (May 2026 cycle, when v26.5.6 was the latest). It now leads with the v26.6.x ship list:
+
+- **v26.6.7** — Deep sweep (every outbound HTTP request now reports v26.6; English + 3 translated docs Delhi PM2.5 aligned to IQAir 2025)
+- **v26.6.6** — Secondary surface sweep (pollutant pages regenerated, root SW cache bumped, 4 blog posts realigned)
+- **v26.6.5** — Complete panel content freshness sweep (every remaining panel template)
+- **v26.6.4** — Top-five panel freshness (Clean Air Wins / Budget / Mission Tracker / Children / Political Accountability)
+- **v26.6.3** — Back-to-home button visibility patch
+- **v26.6.2** — Audit sweep + Resources + stale stats
+- **v26.6.1** — Back-to-home floating button
+- **v26.6.0** — Vayu Junction (7th learning game) + Ask JanVayu verification + Roadmap restructure
+
+The v26.5.x history is preserved below the new section as **"Previous (v26.5.x — May 2026)"**.
+
+### Verified clean — no edits needed
+
+- **`docs/wiki/Adding-a-New-Panel.md`, `Adding-a-New-Role.md`, `Role-Based-Landing-Page.md`, `Simple-Language-Mode.md`, `Translation-Guide.md`** — contributor-facing how-to docs; no stat references; no version markers visible to end users
+- **`TerraStudioCollab/index.html`** — gated internal page for the Terra.Do studio collab; no stale stats, no version markers in body
+- **`downloads/index.html`** — file listing page; no stats; the underlying PDFs/PPTX are historical documents and properly dated
+- **`manifest.json`** (root) — current
+- **`robots.txt`** — current
+- **`netlify.toml`** — cron schedules and redirects current
+- **`.github/workflows/`** (9 yml files) — all current; advisory CI from v26.5.x
+- **GitHub Discussions seed text** — none stored in the repo; lives on the GitHub Discussions UI
+
+### What's now complete
+
+After v26.6.0 → v26.6.8, **every meaningful user-facing and developer-facing surface** in the JanVayu repository has been swept for May-2026 freshness:
+
+- ✅ All 43 panel templates in `index.html` (content + version markers + click-through verified)
+- ✅ Ask JanVayu PWA (all 5 languages)
+- ✅ Vayu Junction game (new) + 6 existing games
+- ✅ Back-to-home floating button
+- ✅ All 19 Netlify Functions (UAs, code health)
+- ✅ Both service workers (root + `/ask/`)
+- ✅ Six per-pollutant SEO pages (regenerated)
+- ✅ Two embed widgets
+- ✅ Daily email digest
+- ✅ All 10 blog posts (stat alignment) + 1 new blog post
+- ✅ Resources panel + Latest Research card relabel
+- ✅ `docs/` in 5 languages (READMEs + key sub-pages)
+- ✅ Wiki: Home + Roadmap (restructured)
+- ✅ Per-language sidebars + learning-games.md in 5 languages
+- ✅ SEO meta description + Twitter Card
+- ✅ All version markers (package.json, CITATION.cff, sitemap.xml, footer ribbon, on-page changelog)
+- ✅ CHANGELOG.md — eight new entries (v26.6.0 → v26.6.8)
+- ✅ ImpactMojo docs confirmed as a separate project (no audit needed)
+
+### Changed — Version markers
+
+- `package.json` 26.6.7 → **26.6.8**
+- `CITATION.cff` 26.6.7 → **26.6.8**
+- `index.html` About-panel footer ribbon and on-page Version History card refreshed
+
 ## [v26.6.7] - 2026-05-20
 
 ### Changed — Deep sweep: remaining Netlify Functions, docs sub-pages, translated docs

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-05-20"
-version: "26.6.7"
+version: "26.6.8"

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -29,7 +29,52 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 
 **JanVayu** (जनवायु — "People's Air") is a non-partisan, citizen-led initiative documenting India's air quality crisis through real-time data, health research, policy tracking, and public testimony.
 
-### What's New (v26.5.x — May 2026)
+### What's New (v26.6.x — 20 May 2026)
+
+**v26.6.7 — Deep sweep**
+- Every outbound HTTP request from JanVayu's serverless tier (all 19 Netlify Functions) now reports v26.6 as its User-Agent — combined `scheduled-fetch.mjs`, `instagram-feed.js`, `news-proxy.js`, `community-sensors.mjs`, `waqi-proxy.mjs`, `reddit-feed.js`, `twitter-feed.js` bumps.
+- English `docs/user-guide/aqi-dashboard.md` + `health-calculator.md` and three translated copies (Bengali, Marathi, Tamil) updated to **Delhi 91.6 µg/m³ (IQAir 2025)** from `~100 µg/m³`.
+- ImpactMojo docs confirmed as a separate project (development education, not air quality).
+
+**v26.6.6 — Secondary surface sweep**
+- Six per-pollutant SEO pages regenerated; **build-script bug fixed** (`datePublished` was being reset to today's date on every regeneration — now pinned to 2026-04-26 with `dateModified` updating to current date).
+- Root service worker cache bumped `janvayu-20260508` → `janvayu-20260520` so returning visitors pick up everything from v26.6.0–v26.6.5.
+- Four blog posts realigned to canonical 1.72M / $339.4B figures (lancet-causal-evidence, iqair-2025-india, learning-games "six → now seven", economic-cost World Bank framing clarified).
+
+**v26.6.5 — Complete panel content freshness sweep**
+- Every remaining panel template (30+) audited and either refreshed or confirmed evergreen.
+- Historical Trends timeline gains 3 May 2026 entries (NCAP deadline elapsed, NGT south-India order, off-season GRAP).
+- Legal Framework gains a new "Recent Court & Regulator Action (Apr–May 2026)" card.
+- Policy GRAP Stages, Citizen Voices, Industrial Sources, Citizen Action Plan, AQI Forecast, Climate Displacement all gained May-2026 framing.
+
+**v26.6.4 — Top-five panel freshness**
+- **Clean Air Wins** gains an "Update — May 2026" card (CAQM off-season GRAP, NGT south-India order, SPCB diesel-generator notices).
+- **Budget Tracker** Funding Cliff Alert reframed: 15th FC grants *expired* 31 Mar 2026; 16th FC report expected Oct 2026.
+- **Mission Tracker** NCAP card retitled "Deadline Missed" with CREA 23/100 + CSE Apr 2026 37/131 outcomes.
+- **Children's Health**, **Political Accountability** also refreshed.
+
+**v26.6.3 — Back-to-home button visibility patch**
+- Solid accent-green background + white house icon (was light-on-accent and easy to miss). 52 px desktop, 48 px mobile. One-time gentle pulse on appearance.
+
+**v26.6.2 — Audit sweep: Resources + stale stats**
+- Five fresh May 2026 items in Resources (CREA April snapshot, two NGT orders, CAQM off-season GRAP, DTE/AAD 2026 briefing).
+- SEO meta + Twitter Card: "2 million" → "1.72 million (Lancet Countdown 2025)".
+- `docs/README.md` in all five languages updated to canonical 1.72M / $339.4B / 91.6 µg/m³ figures.
+- "Latest Research 2025" card relabelled "Recent Peer-Reviewed Findings (2024–2025)".
+- Headless click-through of all 43 panels — zero uncaught JS exceptions.
+
+**v26.6.1 — Back-to-home floating button**
+- Small arrow button bottom-left (mirror of the search FAB) — returns to dashboard hero from any panel.
+- `data-i18n-attr` extension to `setLanguage()` so icon-only buttons can be translated without touching innerHTML.
+
+**v26.6.0 — Vayu Junction (7th learning game)**
+- Word-grouping puzzle inspired by BBC's *Only Connect*, NYT *Connections*, and the *Torchlight* climate puzzle at Times of Climate Change.
+- Four original India-AQ puzzles ship at launch: Basics, Sources/Seasons/Protection, Names & Numbers, Devious.
+- 16 tiles on a 4×4 grid, four hidden groups of four, four strikes, auto-detects "one-off" near-misses.
+- Ask JanVayu verified end-to-end in all five UI languages (EN/HI/TA/BN/MR).
+- Roadmap restructured: Phase 5.7 returned to numeric order; duplicate Phase 6 renamed; new Phase 5.9.
+
+### Previous (v26.5.x — May 2026)
 
 **v26.5.6 — Performance + accessibility hardening**
 - **Lazy-loaded Chart.js + Leaflet** behind `window.ensureChartJs()` and `window.ensureLeaflet()` — ~120 KB off first paint for sessions that don't open Trends/Map; dashboard mini-charts pre-warmed in `requestIdleCallback`.

--- a/index.html
+++ b/index.html
@@ -12640,7 +12640,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.7 | Updated 20 May 2026 | <strong>Deep sweep &mdash; remaining Netlify Functions + docs sub-pages</strong>. Five more Netlify Functions had their User-Agent strings bumped to v26.6 (scheduled-fetch.mjs &times;6, instagram-feed.js, news-proxy.js, community-sensors.mjs, waqi-proxy.mjs) &mdash; <em>every outbound HTTP request from JanVayu's serverless tier now reports v26.6</em>. Two English docs files (<code>aqi-dashboard.md</code>, <code>health-calculator.md</code>) + three translated copies (Bengali, Marathi, Tamil) had Delhi PM2.5 "~100 µg/m³" aligned to the canonical IQAir 2025 figure of <strong>91.6 µg/m³</strong>. Roadmap Phase 5.7 clarified to reference both six (v26.5) and seven (v26.6.0 Vayu Junction) games. Audit confirmed 12 other Netlify Functions, all other docs sub-pages, and ImpactMojo (a separate project) are clean.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.8 | Updated 20 May 2026 | <strong>Final corners</strong> &mdash; <code>docs/wiki/Home.md</code> "What's New" rewritten to lead with the v26.6.x ship list (v26.6.0 Vayu Junction &rarr; v26.6.7 deep sweep); v26.5.x history preserved as "Previous". Audit confirmed the remaining smallest surfaces are all clean: other wiki pages (Adding-a-New-Panel, Adding-a-New-Role, Role-Based-Landing-Page, Simple-Language-Mode, Translation-Guide), TerraStudioCollab index, downloads index, manifest.json, robots.txt, netlify.toml, all 9 GitHub Actions workflows. <strong>After v26.6.0 &rarr; v26.6.8, every meaningful user-facing and developer-facing surface in the JanVayu repository has been swept for May-2026 freshness.</strong></div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -12727,6 +12727,15 @@ Signature: _______________</div>
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.8 &mdash; 20 May 2026</div>
+                    <strong>Final corners &mdash; wiki Home, last small surfaces</strong><br>
+                    &bull; User feedback: <em>"Yes I want you to do all small or big. Everything."</em> Final pass on the smallest remaining surfaces.<br>
+                    &bull; <strong><code>docs/wiki/Home.md</code></strong> &mdash; "What's New" section rewritten to lead with the v26.6.x ship list (v26.6.0 Vayu Junction &rarr; v26.6.7 deep sweep, all 8 versions listed). v26.5.x history preserved as "Previous".<br>
+                    &bull; <strong>Verified clean</strong>: other wiki pages (Adding-a-New-Panel/Role, Role-Based-Landing, Simple-Language-Mode, Translation-Guide), TerraStudioCollab, downloads index, manifest.json, robots.txt, netlify.toml, all 9 GitHub Actions workflows.<br>
+                    &bull; <strong>Cumulative achievement (v26.6.0 &rarr; v26.6.8)</strong>: every meaningful user-facing and developer-facing surface in the repository has been swept for May-2026 freshness &mdash; 43 panels, Ask JanVayu in 5 languages, 7 learning games, back-to-home button, 19 Netlify Functions, 2 service workers, 6 per-pollutant pages, 2 embed widgets, daily email digest, 10 blog posts + 1 new, Resources + Health cards, docs in 5 languages, wiki Home + Roadmap, SEO meta, all version markers, eight changelog entries.
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.7 &mdash; 20 May 2026</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.7",
+  "version": "26.6.8",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

User feedback: *"Yes I want you to do all small or big. Everything."*

Final pass on the smallest remaining surfaces from the v26.6.7 stocktake. Audit confirmed most are already clean.

**Both changelogs updated** as standing practice.

## What changed

### `docs/wiki/Home.md` — "What's New" rewritten for v26.6.x

The wiki landing page's "What's New" section was anchored to v26.5.x (when v26.5.6 was the latest). Now leads with all eight v26.6.x ship lists (v26.6.0 → v26.6.7), with v26.5.x preserved underneath as "Previous".

## Verified clean — no edits needed

- **Other wiki pages**: `Adding-a-New-Panel.md`, `Adding-a-New-Role.md`, `Role-Based-Landing-Page.md`, `Simple-Language-Mode.md`, `Translation-Guide.md` — contributor-facing how-to docs; no stats; no version markers
- **`TerraStudioCollab/index.html`** — gated internal page for the Terra.Do studio collab; no stale stats
- **`downloads/index.html`** — file listing page; no stats; PDFs/PPTX are properly dated historical documents
- **`manifest.json`** (root) — current
- **`robots.txt`** — current
- **`netlify.toml`** — cron schedules and redirects current
- **`.github/workflows/`** (9 yml files) — all current
- **GitHub Discussions** — none stored in repo

## Cumulative achievement (v26.6.0 → v26.6.8)

Every meaningful user-facing and developer-facing surface in the JanVayu repository has been swept for May-2026 freshness:

- ✅ All 43 panel templates in `index.html`
- ✅ Ask JanVayu PWA (5 languages)
- ✅ Vayu Junction game (new) + 6 existing games
- ✅ Back-to-home floating button
- ✅ All 19 Netlify Functions (every outbound HTTP report v26.6)
- ✅ Both service workers
- ✅ Six per-pollutant SEO pages (regenerated + build-script bug fix)
- ✅ Two embed widgets
- ✅ Daily email digest
- ✅ All 10 blog posts (stat alignment) + 1 new blog post
- ✅ Resources panel + Latest Research relabel
- ✅ `docs/` in 5 languages
- ✅ Wiki: Home + Roadmap
- ✅ SEO meta + Twitter Card
- ✅ All version markers
- ✅ CHANGELOG.md (eight new entries)
- ✅ ImpactMojo docs confirmed as separate project

## Verification

- All 9 non-module JS blocks in `index.html` parse cleanly
- `docs/wiki/Home.md` re-read for structural integrity (new section at top, old preserved below)

## Version markers

- `package.json` 26.6.7 → **26.6.8**
- `CITATION.cff` 26.6.7 → **26.6.8**
- `index.html` footer ribbon + on-page Version History card
- `CHANGELOG.md` new v26.6.8 entry

## Test plan

- [x] JS validation
- [ ] Manual smoke: open `https://github.com/JanVayu/JanVayu/wiki/Home` — confirm "What's New (v26.6.x)" section is at top, v26.5.x preserved below

https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW)_