### PR TITLE
v26.6.11: Feature /walkthrough/ on dashboard + roadmap/changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.11] - 2026-05-20
+
+### Added — Feature the new /walkthrough/ page on the dashboard
+
+The `/walkthrough/` page shipped in the previous (unversioned) commit, surfaced only via a footer link. This release features it prominently on the dashboard and updates the hero alert + Roadmap + wiki Home to reference it.
+
+#### Dashboard quick-link card
+
+A new **"Walkthrough"** quick-link card has been added to the dashboard's `.grid-4` quick-links row, sitting next to "Learning Games":
+
+- Amber accent (`#FEF3C7` / `#B45309`) to differentiate from the green Learning Games card and the existing red/blue/green role-specific cards
+- **NEW badge** in the heading
+- Description: "64-slide guided tour (MMSF Fellows deck)"
+- Links to `/walkthrough/` (target is a separate static page; opens in same tab, with a Back-to-JanVayu link at the top of the walkthrough page itself)
+
+#### Hero alert addition
+
+The "May 2026:" hero alert previously closed with the games-panel mention. Now extends to: "*…and a 64-slide guided walkthrough of the whole platform built for the MMSF Fellows cohort.*" — so first-time visitors see the walkthrough exists.
+
+#### Roadmap update
+
+`docs/wiki/Roadmap.md` gets a new bullet under Phase 5.9 (May 20 Polish) listing the walkthrough page.
+
+#### Wiki Home update
+
+`docs/wiki/Home.md` "What's New (v26.6.x)" section gets a v26.6.10 → v26.6.11 entry noting the walkthrough.
+
+### Changed — Version markers
+
+- `package.json` 26.6.10 → **26.6.11**
+- `CITATION.cff` 26.6.10 → **26.6.11**
+- `index.html` About-panel footer ribbon and on-page Version History card refreshed
+
 ## [v26.6.10] - 2026-05-20
 
 ### Fixed — Temporal-framing mismatches (same class of bug as v26.6.9)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-05-20"
-version: "26.6.10"
+version: "26.6.11"

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -31,6 +31,20 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 
 ### What's New (v26.6.x — 20 May 2026)
 
+**v26.6.11 — `/walkthrough/` guided-tour page featured**
+- New public page at [janvayu.in/walkthrough/](https://www.janvayu.in/walkthrough/) embedding the 64-slide JanVayu MMSF Fellows deck via Google Slides iframe.
+- PPTX (24 MB) and PDF (13 MB) downloads pulled directly from the live deck.
+- Dashboard quick-link card with NEW badge; hero alert extended; footer link under Tools & Action.
+
+**v26.6.10 — Temporal-framing fixes**
+- 8 more sentences with the same class of bug as v26.6.9 (action verbs like *"shows"* / *"found"* paired with year-only citations from 2023–2024 papers that are now 5–29 months old). Reframed to "*A 2023 study in X documented…*" so publication vintage is explicit.
+
+**v26.6.9 — Hero alert IQAir 2025 framing fix**
+- Hero said *"May 2026: IQAir 2025 confirms Loni…"* — confusing because IQAir 2025 was actually published March 2025 (covering 2024 data), ~14 months old. Reframed to lead with the freshest items (Lancet Countdown launched May 2026, CAQM off-season GRAP 19 May) and explicitly label IQAir's vintage.
+
+**v26.6.8 — Final corners**
+- `docs/wiki/Home.md` "What's New" rewritten to lead with the v26.6.x ship list; v26.5.x history preserved as "Previous".
+
 **v26.6.7 — Deep sweep**
 - Every outbound HTTP request from JanVayu's serverless tier (all 19 Netlify Functions) now reports v26.6 as its User-Agent — combined `scheduled-fetch.mjs`, `instagram-feed.js`, `news-proxy.js`, `community-sensors.mjs`, `waqi-proxy.mjs`, `reddit-feed.js`, `twitter-feed.js` bumps.
 - English `docs/user-guide/aqi-dashboard.md` + `health-calculator.md` and three translated copies (Bengali, Marathi, Tamil) updated to **Delhi 91.6 µg/m³ (IQAir 2025)** from `~100 µg/m³`.

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -186,6 +186,7 @@ Adds a seventh learning game inspired by *Only Connect* / NYT *Connections* / *T
 - [x] **Documentation refresh**: `README.md` "six games" → **"seven games"**; `package.json` 26.5.6 → **26.6.0**; `CITATION.cff` version + date-released; `sitemap.xml` lastmod; `index.html` About-panel footer ribbon.
 - [x] **Translated changelogs**: v26.6 stub added to `docs-hi/CHANGELOG.md`, `docs-bn/CHANGELOG.md`, `docs-mr/CHANGELOG.md`, `docs-ta/CHANGELOG.md`.
 - [x] **New blog post** `2026-05-20-vayu-junction.md` — walks through the four puzzle sets and the design choices.
+- [x] **`/walkthrough/` guided-tour page** (v26.6.11) — public page at `janvayu.in/walkthrough/` embedding the 64-slide MMSF Fellows deck via Google Slides iframe, with PPTX (24 MB) and PDF (13 MB) as direct downloads, footer link under Tools & Action, and a NEW-badged dashboard quick-link card.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -2861,7 +2861,7 @@ body {
                         <h1 class="hero-headline" data-i18n="hero_title">India's air is killing <em>1.72 million people</em> every year</h1>
                         <p class="hero-sub" data-i18n="hero_sub">JanVayu is India's independent, citizen-led air quality platform. We track live pollution data, measure health impacts, follow the money, and hold governments accountable. Because clean air is not a privilege, it is a right.</p>
                         <div class="hero-live-alert">
-                            <strong>May 2026:</strong> India's air remains in crisis. The most recent IQAir World Air Quality Report (the 2025 edition, published March 2025 covering 2024 data) ranks <strong>Loni, India</strong> as the most polluted city on Earth (112.5 &micro;g/m&sup3; &mdash; 22&times; the WHO guideline); India's average PM2.5 of 48.9 &micro;g/m&sup3; is nearly 10&times; the WHO limit; only 14% of global cities meet safe air standards. The Lancet Countdown 2025 (launched May 2026) attributes <strong>1.72 million</strong> Indian deaths per year to ambient PM2.5 &mdash; ~70% of the global burden. NCAP's 31 March 2026 deadline has elapsed: only 23 of 100 cities with sufficient data hit the target (CREA Jan 2026); CSE's April 2026 five-year review counts 37 of 131. CAQM invoked Stage-I GRAP off-season for the first time on 19 May 2026, signalling year-round enforcement. New: a <a href="#games" onclick="showPanel('games'); return false;" style="color: inherit; text-decoration: underline;">seven-game Learning Games</a> panel is now live &mdash; including the new <em>Vayu Junction</em> word-grouping puzzle.
+                            <strong>May 2026:</strong> India's air remains in crisis. The most recent IQAir World Air Quality Report (the 2025 edition, published March 2025 covering 2024 data) ranks <strong>Loni, India</strong> as the most polluted city on Earth (112.5 &micro;g/m&sup3; &mdash; 22&times; the WHO guideline); India's average PM2.5 of 48.9 &micro;g/m&sup3; is nearly 10&times; the WHO limit; only 14% of global cities meet safe air standards. The Lancet Countdown 2025 (launched May 2026) attributes <strong>1.72 million</strong> Indian deaths per year to ambient PM2.5 &mdash; ~70% of the global burden. NCAP's 31 March 2026 deadline has elapsed: only 23 of 100 cities with sufficient data hit the target (CREA Jan 2026); CSE's April 2026 five-year review counts 37 of 131. CAQM invoked Stage-I GRAP off-season for the first time on 19 May 2026, signalling year-round enforcement. New: a <a href="#games" onclick="showPanel('games'); return false;" style="color: inherit; text-decoration: underline;">seven-game Learning Games</a> panel is now live &mdash; including the new <em>Vayu Junction</em> word-grouping puzzle &mdash; and a 64-slide <a href="/walkthrough/" style="color: inherit; text-decoration: underline;">guided walkthrough</a> of the whole platform built for the MMSF Fellows cohort.
                         </div>
                     </div>
                     <div class="hero-data">
@@ -3080,6 +3080,10 @@ body {
                         <div class="quick-link-icon" style="background: #ECFDF5; color: #1B6B4A;"><span class="si si-library" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_games_t">Learning Games</h4><p data-i18n="ql_games_d">Seven games: Jeopardy, Vayu Junction &amp; more</p></div>
                     </div>
+                    <a class="quick-link" href="/walkthrough/" style="text-decoration: none; color: inherit;">
+                        <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-presentation" style="width:20px;height:20px;"></span></div>
+                        <div><h4 data-i18n="ql_walk_t">Walkthrough <span style="font-size: 0.55rem; padding: 1px 6px; border-radius: 999px; background: var(--accent); color: #fff; vertical-align: middle; margin-left: 4px;">NEW</span></h4><p data-i18n="ql_walk_d">64-slide guided tour (MMSF Fellows deck)</p></div>
+                    </a>
                 </div>
             </div>
         </section>
@@ -12641,7 +12645,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.10 | Updated 20 May 2026 | <strong>Temporal-framing fixes</strong> &mdash; same class of bug as v26.6.9 IQAir, found in 8 more sentences. Phrases like <em>"PNAS (2024) shows…"</em> or <em>"Lancet Respiratory Medicine (2023) found…"</em> implied recent discovery but the cited papers are 5&ndash;29 months old. Switched to "A 2023 study in X documented…" / "Research published in X in 2024…" framing so publication vintage is explicit. Fixed 7 sentences in <code>index.html</code> (Children's Health, Mission Tracker, Clean Air Wins, Policy Effectiveness, Jeopardy clues) and 2 in <code>blog/posts/2026-04-01-children-air-pollution.md</code> (IEG working paper, Vital Strategies). Plus added a vintage hint to the GBD India estimate.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.11 | Updated 20 May 2026 | <strong>Walkthrough page featured</strong> &mdash; the new <code>/walkthrough/</code> guided-tour page (64-slide MMSF Fellows deck embedded via Google Slides iframe + PPTX + PDF downloads) now appears as a dashboard quick-link card with a NEW badge, and is mentioned at the end of the hero alert. Roadmap and wiki Home updated.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -12728,6 +12732,15 @@ Signature: _______________</div>
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.11 &mdash; 20 May 2026</div>
+                    <strong>Walkthrough page featured on the dashboard</strong><br>
+                    &bull; New <code>/walkthrough/</code> guided-tour page (64-slide MMSF Fellows deck embedded via Google Slides iframe + PPTX 24 MB + PDF 13 MB downloads) shipped earlier today. This release features it prominently rather than burying it in the footer.<br>
+                    &bull; <strong>Dashboard quick-link card</strong> added next to Learning Games &mdash; amber accent, NEW badge, links to <code>/walkthrough/</code>.<br>
+                    &bull; <strong>Hero alert</strong> extended: <em>"&hellip;and a 64-slide guided walkthrough of the whole platform built for the MMSF Fellows cohort"</em> &mdash; first-time visitors now see it exists.<br>
+                    &bull; <strong>Roadmap</strong> updated (Phase 5.9 bullet) and <strong>wiki Home</strong> "What's New (v26.6.x)" gets a v26.6.11 entry.
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.10 &mdash; 20 May 2026</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.10",
+  "version": "26.6.11",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

The `/walkthrough/` page shipped via PR #88 but was surfaced only via a footer link. This release features it prominently.

## What changed

### Dashboard quick-link card

New **Walkthrough** card in the `.grid-4` quick-links row, next to Learning Games:

- Amber accent (`#FEF3C7` / `#B45309`) — visually distinct from the green Learning Games card
- **NEW** badge
- Description: "*64-slide guided tour (MMSF Fellows deck)*"
- Links to `/walkthrough/`

### Hero alert extension

```diff
- New: a seven-game Learning Games panel is now live — including the new Vayu Junction word-grouping puzzle.
+ New: a seven-game Learning Games panel is now live — including the new Vayu Junction word-grouping puzzle —
+ and a 64-slide guided walkthrough of the whole platform built for the MMSF Fellows cohort.
```

### Roadmap (`docs/wiki/Roadmap.md`)

Phase 5.9 gains a new bullet:
> **`/walkthrough/` guided-tour page** (v26.6.11) — public page at `janvayu.in/walkthrough/` embedding the 64-slide MMSF Fellows deck via Google Slides iframe, with PPTX (24 MB) and PDF (13 MB) as direct downloads, footer link under Tools & Action, and a NEW-badged dashboard quick-link card.

### Wiki Home (`docs/wiki/Home.md`)

The "What's New (v26.6.x)" section was anchored at v26.6.7 — extended to cover v26.6.8 (final corners) → v26.6.9 (IQAir framing) → v26.6.10 (temporal framing) → **v26.6.11 (walkthrough featured)**.

### Both changelogs updated

- `CHANGELOG.md` new v26.6.11 entry
- `index.html` About-panel footer ribbon + on-page Version History card

## Version markers

- `package.json` 26.6.10 → **26.6.11**
- `CITATION.cff` 26.6.10 → **26.6.11**

## Verification

- All 9 non-module JS blocks parse cleanly
- Dashboard quick-link card renders next to Learning Games
- Walkthrough page from PR #88 already live at https://www.janvayu.in/walkthrough/

## Test plan

- [x] JS validation
- [ ] Manual smoke after deploy: open `https://www.janvayu.in/`, scroll to dashboard quick-links, see the new "Walkthrough · NEW" card next to "Learning Games"
- [ ] Click the card — should navigate to `/walkthrough/`
- [ ] Hero alert mentions "64-slide guided walkthrough"

https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW)_