### PR TITLE
v26.6.12: Ask JanVayu — three real bugs fixed from user testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.12] - 2026-05-20
+
+### Fixed — Ask JanVayu: three real bugs from user testing
+
+User feedback after using `/ask/` in production:
+
+> *"Chatbot — does not give number of station data correctly, no sources are mentioned in some answers (low cost sensors, EVs), for most questions I just got Delhi based information (mandir marg data)."*
+
+All three issues were genuine bugs in `netlify/functions/air-query.mjs`. Fixed below.
+
+#### Bug 1 — Station-count questions returned guesses
+
+The function only fetched a **single station** for the user's city via the WAQI `geo:` endpoint (which returns the nearest station to the city centroid). When asked "how many CAAQMS stations does Delhi have?", the Llama model had no station-count data in its context and made up an answer.
+
+**Fix.** New `fetchCityStations(cityKey)` helper hits the WAQI `map/bounds/` endpoint with a ~0.5° box (~50 km wide) around the city centroid and returns the indexed-station list. Triggered when `isStationCountQuery(question)` matches phrases like *"how many stations"*, *"number of monitoring stations"*, *"station count"*, *"how many sensors/monitors"*. The fetched count and a sample of station names are injected into the `dataContext` block sent to Groq. A national reference is also added: *"CPCB CAAQMS national total is ~533 stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community runs ~3,000+ low-cost community sensors nationwide."*
+
+#### Bug 2 — No sources cited in topical answers
+
+The system prompt mentioned canonical reference data (Lancet Countdown, IQAir, CREA) but never **required** the model to cite the source of any number it gave. Topical answers about low-cost sensors, EVs, BS-VI etc. came out as generic prose with no provenance.
+
+**Fix.** Two changes to `buildSystemPrompt()`:
+
+1. New **`TOPICAL_REFERENCE`** block injected into every system prompt — covers the monitoring network (CPCB CAAQMS ~533 stations, WAQI subset, Sensor.Community ~3,000+ low-cost sensors, CAG April 2025 audit finding 88% had data-quality issues), low-cost sensors (Sensor.Community CC0, IQAir commercial, OpenAQ aggregators), EVs & transport (BS-VI from Apr 2020, PM-eBus Sewa ₹20,000 Cr / 10,000 buses by 2026, FAME-II→E-DRIVE, Delhi 4,286 e-buses Feb 2026, 8,849 charging stations Dec 2025), and recent Apr–May 2026 policy moves (CAQM off-season GRAP, NGT south-India order, NGT SPCB diesel-genset notices, NCAP deadline elapsed, 15th FC cliff).
+2. New **Instruction #11**: *"ALWAYS cite the source for any specific number or claim. Use the formats: 'per CREA Jan 2026', 'IQAir 2025', 'Lancet Countdown 2025', 'CPCB CAAQMS', 'Sensor.Community', 'CAG April 2025 audit', 'CSE April 2026', 'NGT order Apr 2026', etc. **If you cite a number without a source, you have failed.**"*
+
+#### Bug 3 — Delhi / Mandir Marg dominance on topical questions
+
+Mandir Marg is the CPCB station nearest to Delhi's centroid (28.6139, 77.2090); the WAQI `geo:` endpoint always returned it for Delhi. The system prompt also led with Delhi-specific reference text ("Most polluted capital globally", "₹300 Cr pollution budget"). When users asked **national topical questions** (EVs, low-cost sensors, NCAP), the model fell back to Delhi context because that was the heaviest signal in the prompt.
+
+**Fix.** Two changes:
+
+1. New **`isNationalQuery(question)`** detector matches phrases like *"India(n)"*, *"nationwide"*, *"across cities"*, *"BS-VI"*, *"e-bus / electric vehicle"*, *"low-cost sensor"*, *"community sensor"*, *"FAME"*, *"PM-eBus"*, *"CAAQMS"*, *"CPCB"*, *"how many stations/sensors/monitors"*. When matched, the system prompt gains a hard instruction: *"IMPORTANT — NATIONAL/TOPICAL QUERY: The user's question is about an India-wide topic… Frame your answer for India broadly. Do NOT default to Delhi-specific or single-station (e.g. Mandir Marg) context."*
+2. **KEY REFERENCE DATA block** restructured to lead with India-wide figures (NAAQS, India average PM2.5, Lancet Countdown national death toll, NCAP national outcome, AQLI national life-expectancy loss, Loni #1) rather than Delhi-first framing. Delhi is now just one example, not the anchor.
+3. The single-station context now reads "**Nearest WAQI station**: …" (was "Station: …") so it's clear to the model that the value is one station, not "the city's data".
+
+### Verified
+
+- `node --check netlify/functions/air-query.mjs` → Syntax OK
+- New `fetchCityStations()` uses the same WAQI token and timeout pattern as the existing `fetchCityAQI()` — no new auth surface
+- `isStationCountQuery()` and `isNationalQuery()` regexes tested against the canonical bug examples (low-cost sensors / EVs / monitoring stations) — all match correctly
+- `TOPICAL_REFERENCE` block is ~300 words; well within Groq's context window even with the existing prompt and live data context
+
+### Changed — Version markers
+
+- `package.json` 26.6.11 → **26.6.12**
+- `CITATION.cff` 26.6.11 → **26.6.12**
+- `index.html` About-panel footer ribbon and on-page Version History card refreshed
+
 ## [v26.6.11] - 2026-05-20
 
 ### Added — Feature the new /walkthrough/ page on the dashboard

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-05-20"
-version: "26.6.11"
+version: "26.6.12"

--- a/index.html
+++ b/index.html
@@ -12645,7 +12645,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.11 | Updated 20 May 2026 | <strong>Walkthrough page featured</strong> &mdash; the new <code>/walkthrough/</code> guided-tour page (64-slide MMSF Fellows deck embedded via Google Slides iframe + PPTX + PDF downloads) now appears as a dashboard quick-link card with a NEW badge, and is mentioned at the end of the hero alert. Roadmap and wiki Home updated.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.12 | Updated 20 May 2026 | <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong>. (1) <em>Station-count queries</em>: new WAQI bounds-endpoint fetch returns a real station list + count for the user's city plus the CPCB national ~533 figure. (2) <em>Sources required</em>: new <code>TOPICAL_REFERENCE</code> prompt block (monitoring network, low-cost sensors, EVs, transport, recent court orders) + hard instruction "if you cite a number without a source, you have failed". (3) <em>Delhi/Mandir-Marg bias</em>: new <code>isNationalQuery()</code> detector triggers India-wide framing for topical questions; reference data restructured to lead with national figures, not Delhi.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -12732,6 +12732,15 @@ Signature: _______________</div>
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.12 &mdash; 20 May 2026</div>
+                    <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong><br>
+                    &bull; User feedback: <em>"Chatbot &mdash; does not give number of station data correctly, no sources are mentioned in some answers (low-cost sensors, EVs), for most questions I just got Delhi-based information (Mandir Marg data)."</em><br>
+                    &bull; <strong>Station-count fix</strong>: new <code>fetchCityStations()</code> calls the WAQI <code>map/bounds/</code> endpoint with a ~50 km box around the city centroid when the question matches <code>isStationCountQuery()</code>. Real count + sample station names injected into the data context, plus the CPCB national reference (~533 CAAQMS stations across ~250 cities; Sensor.Community ~3,000+ low-cost sensors).<br>
+                    &bull; <strong>Sources fix</strong>: new <code>TOPICAL_REFERENCE</code> block in the system prompt covers monitoring network, low-cost sensors, EVs / BS-VI / PM-eBus Sewa, and the Apr-May 2026 court orders. New Instruction #11: <em>"If you cite a number without a source, you have failed."</em><br>
+                    &bull; <strong>Delhi/Mandir-Marg bias fix</strong>: new <code>isNationalQuery()</code> detects India-wide topical questions and tells the model: <em>"Do NOT default to Delhi-specific or single-station context."</em> KEY REFERENCE DATA restructured to lead with India-wide figures, not Delhi-first. Single-station context now labelled "Nearest WAQI station" so the model knows it's one station, not "the city's data".
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.11 &mdash; 20 May 2026</div>

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -1,5 +1,14 @@
 // Netlify Function: Natural Language Query Interface for JanVayu
-// Accepts a question + city, fetches live AQI, sends to Groq for analysis
+// Accepts a question + city, fetches live AQI, sends to Groq for analysis.
+//
+// v26.6.12 — User-feedback fixes:
+//  1. Station-count queries now fetch the WAQI bounds endpoint to return
+//     a real station list for the user's city, plus a CPCB CAAQMS national
+//     reference figure.
+//  2. System prompt requires explicit source citations on every claim.
+//  3. Delhi/Mandir-Marg bias reduced — topical queries (EVs, sensors,
+//     national schemes) are framed for India broadly, not defaulted to
+//     Delhi context.
 
 const WAQI_TOKEN = "1f64cc8563a165dc5a6ce48f7eeb9ba0221b63f3";
 
@@ -65,6 +74,32 @@ async function fetchCityAQI(cityKey) {
   return null;
 }
 
+// v26.6.12 — Fetch the list of WAQI-indexed stations inside a 0.5° box
+// around the city centroid. Used when the user asks "how many stations"
+// so we can give a real count and a station-name sample rather than a
+// generic guess.
+async function fetchCityStations(cityKey) {
+  const city = CITIES[cityKey];
+  if (!city) return null;
+  const d = 0.25;
+  const bounds = `${city.lat - d},${city.lon - d},${city.lat + d},${city.lon + d}`;
+  try {
+    const res = await fetch(
+      `https://api.waqi.info/map/bounds/?latlng=${bounds}&token=${WAQI_TOKEN}`,
+      { signal: AbortSignal.timeout(8000) }
+    );
+    const data = await res.json();
+    if (data.status === "ok" && Array.isArray(data.data)) {
+      return data.data
+        .map(s => ({ name: s.station?.name || `uid:${s.uid}`, aqi: s.aqi }))
+        .filter(s => s.name && s.name !== "uid:undefined");
+    }
+  } catch (e) {
+    console.log(`Failed to fetch station list for ${cityKey}:`, e.message);
+  }
+  return null;
+}
+
 function getSeasonalContext() {
   const now = new Date();
   const month = now.getMonth(); // 0-indexed
@@ -84,7 +119,6 @@ function getSeasonalContext() {
     season = "PRE-MONSOON/SUMMER (Apr-Jun): Dust storms in north/west India. Construction activity high. Heat increases ozone formation. Moderate pollution levels.";
   }
 
-  const diwaliMonth = 10; // Nov approx
   let diwaliNote = "";
   if (month === 10 && day >= 1 && day <= 15) {
     diwaliNote = " DIWALI PERIOD: Firecracker emissions cause extreme PM2.5 spikes (often 500+ µg/m³ in Delhi) lasting 2-3 days.";
@@ -94,7 +128,7 @@ function getSeasonalContext() {
 }
 
 const NCAP_CITY_DATA = {
-  delhi: { ncapTarget: "40% PM10 reduction by 2026", budget: "₹300 Cr pollution budget (43% utilised)", note: "Most polluted capital globally. 0 days met WHO limit in 2026." },
+  delhi: { ncapTarget: "40% PM10 reduction by 2026", budget: "₹300 Cr pollution budget (43% utilised)", note: "Most polluted capital globally (IQAir 2025). 0 days met WHO limit in 2026." },
   mumbai: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "PM2.5 increased 38% since 2019 despite NCAP." },
   kolkata: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Winter inversions + vehicle emissions. Limited monitoring coverage." },
   lucknow: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Indo-Gangetic plain — trapped pollutants. Brick kilns major source." },
@@ -118,6 +152,36 @@ WHO activity guidance by PM2.5 level:
 Transport exposure multipliers (vs ambient): Walking 1.0x, Cycling 2-3x (heavy breathing), Auto-rickshaw 1.5x (open vehicle), Car (AC, windows up) 0.3-0.5x, Metro 0.2-0.4x, Bus 0.8-1.0x.
 `;
 
+// v26.6.12 — Topical reference cards. Added to system prompt so the LLM
+// has concrete, sourced facts for common non-AQI-data questions instead
+// of falling back to generic Delhi-tinted training-data answers.
+const TOPICAL_REFERENCE = `
+MONITORING NETWORK (national):
+- CPCB CAAQMS (Continuous Ambient Air Quality Monitoring Stations): ~533 stations across ~250 Indian cities as of 2025 (CPCB Annual Report).
+- WAQI / aqicn.org: surfaces a subset of CAAQMS + community sensors. Geo lookups return the nearest single station.
+- Sensor.Community: ~3,000+ CC0 low-cost community sensors across India (the "Hyperlocal" panel on JanVayu blends these with CPCB/WAQI data).
+- CAG April 2025 audit: 88% of monitoring stations had data-quality issues at least once in 2023-24.
+
+LOW-COST SENSORS:
+- Sensor.Community (Open Knowledge Foundation, CC0): community-deployed PM2.5/PM10 sensors. Free data; lower accuracy than CPCB-grade but excellent spatial density.
+- IQAir AirVisual (commercial, $300+): retail-grade laser scattering sensors; data licensed.
+- Aerogram, OpenAQ, BreatheLife: aggregator platforms.
+
+EVs & TRANSPORT POLICY (India-wide):
+- BS-VI emission standards: nationwide since April 2020 (India skipped BS-V — went BS-IV → BS-VI direct).
+- PM-eBus Sewa: ₹20,000 Cr scheme for 10,000 e-buses across 169 cities by 2026 (WRI India estimates ~$2.4B).
+- FAME-II: ₹10,000 Cr EV adoption subsidy scheme; replaced by E-DRIVE (₹500 Cr) in 2024.
+- Delhi e-bus fleet: 4,286 operational as of 9 Feb 2026 (largest in India). Target 7,500 by end 2026.
+- 8,849 EV charging stations across India as of Dec 2025.
+
+RECENT POLICY/COURT ACTIONS (Apr-May 2026):
+- CAQM: invoked GRAP Stage-I off-season on 19 May 2026 (first-ever off-season invocation at AQI 208) — signals year-round enforcement.
+- NGT: directed 6 south-Indian states (TN/KL/KA/AP/TS/PY) to file sector-wise PM10/PM2.5 reduction roadmaps tied to state budgets (Apr 2026).
+- NGT: nationwide notices to all SPCBs/PCCs on diesel-generator retrofit non-compliance (9 Apr 2026; next hearing 21 Jul 2026).
+- NCAP March 2026 deadline elapsed: 23/100 cities (CREA Jan 2026) or 37/131 (CSE Apr 2026 5-year review) met the target.
+- 15th Finance Commission grants (₹16,539 Cr for 49 cities) expired 31 March 2026; 16th FC report expected Oct 2026.
+`;
+
 const LANG_NAMES = {
   en: "English",
   hi: "Hindi (Devanagari script)",
@@ -126,11 +190,21 @@ const LANG_NAMES = {
   mr: "Marathi (Devanagari script)",
 };
 
-function buildSystemPrompt(seasonal, lang) {
+// v26.6.12 — Detect when the user is asking a NATIONAL/TOPICAL question
+// vs a city-specific one. If national, we instruct the LLM to NOT default
+// to Delhi context.
+function isNationalQuery(question) {
+  const q = question.toLowerCase();
+  // Topical keywords that imply India-wide framing
+  return /\b(india(n)?|nationwide|national|across cities|across india|bs-?vi|bs vi|e-?buses?|electric (bus|vehicle|car)|ev policy|charging station|sensor|low.?cost|community sensor|fame|pm-?ebus|caaqms|cpcb|stations? in india|monitoring (network|stations? )?|how many (stations|sensors|monitors|e-?buses?)|number of (stations|sensors|monitors|e-?buses?))\b/i.test(q);
+}
+
+function isStationCountQuery(question) {
+  return /\b(how many (caaqms|monitoring |air quality |cpcb |waqi )?stations?|number of (monitoring |caaqms |cpcb )?stations?|number of caaqms|how many caaqms|station count|how many sensors|how many monitors|station list)\b/i.test(question);
+}
+
+function buildSystemPrompt(seasonal, lang, nationalQuery) {
   const langName = LANG_NAMES[lang] || null;
-  // If the UI passes a language code, hard-force the response language above
-  // the numbered instructions. If no code, instruction 9 keeps the older
-  // "match the user's question language" behaviour.
   const langOverride = langName
     ? `\nCRITICAL — RESPONSE LANGUAGE: The user has selected ${langName} as their interface language. You MUST respond entirely in ${langName}. Use the native script throughout (Devanagari, Tamil, Bengali as appropriate). Do not mix languages. Acronyms like NCAP, RTI, WHO, AQI, GRAP, PM2.5, PM10 may stay in Roman letters as they are widely recognised that way in Indian discourse. Numerals can be Indo-Arabic (1, 2, 3).\n`
     : "";
@@ -139,6 +213,10 @@ function buildSystemPrompt(seasonal, lang) {
     ? `9. Respond entirely in ${langName} (see CRITICAL note above).`
     : `9. Respond in the same language the question is asked in — Hindi in Devanagari, Tamil in Tamil script, Bengali in Bengali script, Marathi in Devanagari script.`;
 
+  const nationalFraming = nationalQuery
+    ? `\nIMPORTANT — NATIONAL/TOPICAL QUERY: The user's question is about an India-wide topic (monitoring network, low-cost sensors, EVs, BS-VI, NCAP, court orders, etc.) and NOT about their selected city's live air quality. Frame your answer for India broadly. Do NOT default to Delhi-specific or single-station (e.g. Mandir Marg) context. Use the TOPICAL REFERENCE block below for concrete facts.\n`
+    : "";
+
   return `You are JanVayu, India's citizen-led air quality assistant. You are NOT a generic chatbot — you have access to LIVE pollution data and deep knowledge of India's air quality context.
 
 TODAY: ${seasonal.dateStr}
@@ -146,15 +224,18 @@ SEASONAL CONTEXT: ${seasonal.season}
 
 ${ACTIVITY_THRESHOLDS}
 
-KEY REFERENCE DATA:
-- WHO annual PM2.5 guideline: 5 µg/m³. India's NAAQS: 40 µg/m³.
-- India average PM2.5 (2025): 48.9 µg/m³ (~10x WHO limit)
-- 1.72 million Indians die annually from air pollution (Lancet Countdown 2025)
-- Economic cost: $339.4 billion/year (9.5% GDP)
-- NCAP target: 40% PM10 reduction across 131 cities by 2025-26. Only 23 cities met this.
-- Average Indian loses 3.5 years of life expectancy to pollution (AQLI)
-- 1 SD increase in PM2.5 → 5 percentage point increase in child stunting
-${langOverride}
+${TOPICAL_REFERENCE}
+
+KEY REFERENCE DATA (India-wide, not Delhi-specific):
+- WHO annual PM2.5 guideline: 5 µg/m³. India's NAAQS: 40 µg/m³ (8× WHO).
+- India average PM2.5: 48.9 µg/m³ (~10× WHO limit) — IQAir 2025.
+- 1.72 million Indians die annually from air pollution — Lancet Countdown 2025 (~70% of global PM2.5 mortality).
+- Economic cost: $339.4 billion/year, ~9.5% of GDP — Lancet Countdown 2025.
+- NCAP target: 40% PM10 reduction across 131 non-attainment cities by 31 March 2026. Deadline elapsed: 23/100 cities (CREA) or 37/131 (CSE Apr 2026) met target.
+- Average Indian loses 3.5 years of life expectancy to pollution — AQLI 2025. Indo-Gangetic Plain residents lose 7-8 years.
+- 1 SD increase in PM2.5 → 5 percentage point increase in child stunting (Krishna et al. 2024).
+- Most polluted city globally: Loni, India (112.5 µg/m³ annual) — IQAir 2025, the 2025 edition covering 2024 data.
+${langOverride}${nationalFraming}
 INSTRUCTIONS:
 1. Use the ACTUAL live data numbers provided — never give generic advice.
 2. For "Should I..." questions: give a direct YES/NO first, then explain using the activity thresholds and the person's specific situation.
@@ -165,7 +246,10 @@ INSTRUCTIONS:
 7. Include the seasonal context when it's relevant (e.g. stubble burning, monsoon).
 8. If asked to draft an RTI: generate a proper RTI application format with department, subject, and specific questions.
 ${instruction9}
-10. Keep responses under 200 words. Be direct, specific, and actionable.`;
+10. Keep responses under 200 words. Be direct, specific, and actionable.
+11. ALWAYS cite the source for any specific number or claim. Use the formats: "per CREA Jan 2026", "IQAir 2025", "Lancet Countdown 2025", "CPCB CAAQMS", "Sensor.Community", "CAG April 2025 audit", "CSE April 2026", "NGT order Apr 2026", etc. If you cite a number without a source, you have failed.
+12. For NATIONAL/TOPICAL questions (EVs, low-cost sensors, BS-VI, monitoring network, court orders, NCAP): use the TOPICAL REFERENCE block. Do NOT default to Delhi or single-station context unless the user explicitly asks about Delhi.
+13. For station-count questions: cite both the CPCB national figure (~533 CAAQMS) and the live count for the user's city if provided in the DATA CONTEXT.`;
 }
 
 export default async function handler(req) {
@@ -206,6 +290,13 @@ export default async function handler(req) {
     }), { status: 200, headers });
   }
 
+  // v26.6.12 — If the user asked about station counts, fetch the WAQI
+  // bounds endpoint so we can return a real number rather than make one up.
+  let stationList = null;
+  if (isStationCountQuery(question)) {
+    stationList = await fetchCityStations(cityKey);
+  }
+
   // Detect comparison queries and fetch second city if needed
   const compareMatch = question.match(/(?:compare|vs|versus|or)\s+(\w+)/i);
   let compareResult = null;
@@ -216,10 +307,18 @@ export default async function handler(req) {
     }
   }
 
-  let dataContext = `PRIMARY CITY — ${aqiResult.city}: AQI ${aqiResult.aqi}, PM2.5 ${aqiResult.pm25 ?? "N/A"} µg/m³, PM10 ${aqiResult.pm10 ?? "N/A"} µg/m³, Station: ${aqiResult.station}, Updated: ${aqiResult.time}.`;
+  let dataContext = `PRIMARY CITY — ${aqiResult.city}: AQI ${aqiResult.aqi}, PM2.5 ${aqiResult.pm25 ?? "N/A"} µg/m³, PM10 ${aqiResult.pm10 ?? "N/A"} µg/m³, Nearest WAQI station: ${aqiResult.station}, Updated: ${aqiResult.time}.`;
 
   if (compareResult) {
     dataContext += `\nCOMPARISON CITY — ${compareResult.city}: AQI ${compareResult.aqi}, PM2.5 ${compareResult.pm25 ?? "N/A"} µg/m³, PM10 ${compareResult.pm10 ?? "N/A"} µg/m³, Station: ${compareResult.station}.`;
+  }
+
+  if (stationList && stationList.length > 0) {
+    const sample = stationList.slice(0, 8).map(s => `${s.name} (AQI ${s.aqi})`).join("; ");
+    dataContext += `\nWAQI STATIONS WITHIN ~25 km of ${aqiResult.city} CENTROID: ${stationList.length} indexed station(s). Sample: ${sample}.`;
+    dataContext += `\nNOTE: This is the WAQI-indexed subset only. CPCB CAAQMS national total is ~533 stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community adds ~3,000+ low-cost community sensors nationwide.`;
+  } else if (isStationCountQuery(question)) {
+    dataContext += `\nSTATION COUNT NOTE: WAQI bounds query returned no list for ${aqiResult.city}. CPCB CAAQMS national total is ~533 stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community runs ~3,000+ low-cost community sensors nationwide.`;
   }
 
   // Add NCAP city data if available
@@ -229,6 +328,7 @@ export default async function handler(req) {
   }
 
   const seasonal = getSeasonalContext();
+  const nationalQuery = isNationalQuery(question);
 
   try {
     const groqRes = await fetch("https://api.groq.com/openai/v1/chat/completions", {
@@ -237,7 +337,7 @@ export default async function handler(req) {
       body: JSON.stringify({
         model: "llama-3.3-70b-versatile",
         messages: [
-          { role: "system", content: buildSystemPrompt(seasonal, requestedLang) },
+          { role: "system", content: buildSystemPrompt(seasonal, requestedLang, nationalQuery) },
           { role: "user", content: `${dataContext}\n\nQuestion: ${question}` }
         ],
         max_tokens: 450,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.11",
+  "version": "26.6.12",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

User feedback from testing Ask JanVayu in production:

> *"Chatbot — does not give number of station data correctly, no sources are mentioned in some answers (low cost sensors, EVs), for most questions I just got Delhi based information (mandir marg data)."*

All three were **genuine bugs** in `netlify/functions/air-query.mjs`. Fixed below.

## Bug 1 — Station-count queries returned guesses

`fetchCityAQI()` only fetched **one** station via the WAQI `geo:` endpoint (the nearest to the city centroid). When asked "how many CPCB stations does Delhi have?", the model had no station-count data and made one up.

**Fix.** New `fetchCityStations(cityKey)` calls the WAQI `map/bounds/` endpoint with a ~50 km box around the city centroid. Triggered by `isStationCountQuery(question)` matching *"how many stations"*, *"number of CAAQMS"*, *"station count"*, etc. Real count + sample station names injected into the data context, plus the **national reference**:

> CPCB CAAQMS national total ~**533** stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community runs ~**3,000+** low-cost community sensors nationwide.

## Bug 2 — No sources cited in topical answers

System prompt mentioned reference data but didn't **require** citation. Topical answers (low-cost sensors, EVs) came out as generic prose with no provenance.

**Fix.** Two changes:

1. New **`TOPICAL_REFERENCE`** block covering:
   - **Monitoring network**: CPCB CAAQMS (~533), WAQI, Sensor.Community (~3,000+ CC0), CAG April 2025 audit (88% data-quality issues)
   - **Low-cost sensors**: Sensor.Community, IQAir, Aerogram, OpenAQ, BreatheLife
   - **EVs & transport**: BS-VI from Apr 2020 (skipped BS-V), PM-eBus Sewa ₹20,000 Cr / 10,000 buses by 2026, FAME-II → E-DRIVE, Delhi 4,286 e-buses (Feb 2026), 8,849 charging stations (Dec 2025)
   - **Recent Apr–May 2026 actions**: CAQM off-season GRAP (19 May), NGT south-India order, NGT SPCB diesel-genset notices, NCAP deadline elapsed, 15th FC cliff

2. New **Instruction #11**:
   > "ALWAYS cite the source for any specific number or claim. Use the formats: 'per CREA Jan 2026', 'IQAir 2025', 'Lancet Countdown 2025', 'CPCB CAAQMS', 'Sensor.Community', 'CAG April 2025 audit', 'CSE April 2026', 'NGT order Apr 2026', etc. **If you cite a number without a source, you have failed.**"

## Bug 3 — Delhi / Mandir Marg dominance

The WAQI `geo:` endpoint always returned **Mandir Marg** for Delhi (nearest CPCB station to centroid 28.6139, 77.2090). The system prompt led with Delhi-specific reference text. When users asked **national topical questions**, the model fell back to Delhi context.

**Fix.** Three changes:

1. New **`isNationalQuery(question)`** detector matches *"India(n)"*, *"nationwide"*, *"BS-VI"*, *"e-bus/electric vehicle"*, *"low-cost sensor"*, *"community sensor"*, *"FAME"*, *"PM-eBus"*, *"CAAQMS"*, *"CPCB"*, *"how many stations/sensors/monitors/e-buses"*, etc. When matched, the prompt gains:
   > "IMPORTANT — NATIONAL/TOPICAL QUERY: The user's question is about an India-wide topic… Frame your answer for India broadly. Do NOT default to Delhi-specific or single-station (e.g. Mandir Marg) context."

2. **KEY REFERENCE DATA** restructured to lead with **India-wide figures** (NAAQS, India average PM2.5, Lancet national death toll, NCAP national, AQLI national, Loni #1) rather than Delhi-first.

3. Single-station context now reads **"Nearest WAQI station: …"** (was "Station: …") so the model knows it's one station, not "the city's data".

## Verification

- `node --check netlify/functions/air-query.mjs` → **Syntax OK**
- Detectors tested against 10 realistic user questions (CAAQMS count / low-cost sensors / EV policy / BS-VI / jogging / city comparison / e-bus / etc.) — all classified correctly into `station-count`, `national`, or `neither`

## Version markers

- `package.json` 26.6.11 → **26.6.12**
- `CITATION.cff` 26.6.11 → **26.6.12**
- `index.html` footer ribbon + on-page Version History card
- `CHANGELOG.md` new v26.6.12 entry

## Test plan after deploy

- [x] Syntax + regex tests
- [ ] Live: Open `/ask/`, select Delhi, ask "How many CPCB stations does Delhi have?" — should return a real WAQI count + the national ~533 reference, with CPCB cited
- [ ] Live: Ask "Tell me about low-cost sensors in India" — should cite Sensor.Community, OpenAQ, BreatheLife; should NOT lead with Mandir Marg
- [ ] Live: Ask "What is BS-VI?" — should cite Apr 2020 nationwide rollout, mention skipping BS-V
- [ ] Live: Ask "How many e-buses does India have?" — should cite Delhi 4,286 (Feb 2026), PM-eBus Sewa 10,000 by 2026

https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW)_