### PR TITLE
v26.6.19: In-page Ask JanVayu widget refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.19] - 2026-05-20
+
+### Fixed — In-page Ask JanVayu widget (separate from /ask/ PWA) was unchanged
+
+User pointed to a screenshot showing the **in-page Ask JanVayu panel** at `tmpl-ask-janvayu` (accessible via the dashboard nav) still displaying the pre-v26.6.x text: *"Ask any question about air quality in your city. Get answers grounded in live data, in English or Hindi."*
+
+v26.6.18 had updated the standalone `/ask/` PWA but the in-page widget inside `index.html` is a **separate UI surface** that I missed. Both share the name but they're distinct templates. Fixed now.
+
+#### In-page widget rewritten
+
+- **Section intro paragraph**: from "Ask any question..." to the full v26.6.x capability statement (live AQI, calculators, rankings, trends, apportionment, RTI drafts, multi-source reliability, source citation on every number).
+- **Language list** explicitly named (English, हिन्दी, தமிழ், বাংলা, मराठी, తెలుగు, ગુજરાતી, ಕನ್ನಡ, മലയാളം, ਪੰਜਾਬੀ) — was "English or Hindi" before.
+- **10 example chips** added in a green-accent info-box: tap any chip to load the question into the input. Same chip list as the `/ask/` PWA (jogging, top-5 worst, transport exposure, apportionment, RTI, reliability, cigarettes, trend, migration, comparison).
+- **New language dropdown** in the question form so users can pick the response language explicitly. Defaults to English. All 10 languages selectable.
+- **"How it works" rewritten** to describe what the bot actually does — 4 data fetches (WAQI live + WAQI bounds + community sensors + IQAir cached annual), 7 calculators, 6 RTI templates, source citation requirement, national framing for topical queries. Plus a pointer to `/ask/` for the full chat experience with history + PWA install.
+- **Placeholder text** updated from the Delhi-specific phrasing to a generic capability hint.
+
+#### Wiring
+
+- `submitAirQuery()` now reads the new `#ask-lang` dropdown and passes `lang` to the function call, so the existing 10-language Groq pinning works.
+- New `loadAskChip(text)` helper (exposed on `window`) fills the input when a chip is tapped, then focuses — does NOT auto-submit so the user can change city/language first.
+
+### Changed — Version markers
+
+- `package.json` 26.6.18 → **26.6.19**
+- `CITATION.cff` 26.6.18 → **26.6.19**
+
 ## [v26.6.18] - 2026-05-20
 
 ### Changed — Ask JanVayu onboarding refresh + 5 new languages

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-05-20"
-version: "26.6.18"
+version: "26.6.19"

--- a/index.html
+++ b/index.html
@@ -6752,8 +6752,19 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
     // ══════════════════════════════════════════
 
     // ── Feature 1: Ask JanVayu ──
+    // v26.6.19 — tap a chip on the Ask JanVayu panel to load that question
+    // into the input field. The user can then submit, edit it first, or
+    // submit immediately by hitting the button (we do NOT auto-submit on
+    // chip tap — the user may want to swap the city or language first).
+    function loadAskChip(text) {
+        const input = document.getElementById('ask-question');
+        if (input) { input.value = text; input.focus(); }
+    }
+    window.loadAskChip = loadAskChip;
+
     async function submitAirQuery() {
         const city = document.getElementById('ask-city')?.value;
+        const lang = document.getElementById('ask-lang')?.value || 'en';
         const question = document.getElementById('ask-question')?.value?.trim();
         const responseEl = document.getElementById('ask-response');
         const dataEl = document.getElementById('ask-data-used');
@@ -6770,7 +6781,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
             const res = await fetch('/.netlify/functions/air-query', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ question, city }),
+                body: JSON.stringify({ question, city, lang }),
             });
             const data = await res.json();
             responseEl.classList.remove('loading');
@@ -12645,7 +12656,7 @@ Signature: _______________</div>
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.18 | Updated 20 May 2026 | <strong>Ask JanVayu onboarding refresh + 5 new languages</strong>. (1) Welcome subtitle rewritten across all languages to surface what the bot actually does: live AQI · calculators · rankings · trends · apportionment · RTI · multi-source. (2) Suggestion chips: 7 &rarr; 10, surfacing the new Phase A&ndash;D capabilities (rankings, apportionment, RTI drafting, trend, multi-source reliability, cigarette equivalence, migration). (3) Five new languages added: Telugu, Gujarati, Kannada, Malayalam, Punjabi &mdash; total now 10, covering ~95% of Indian mother-tongue speakers. Backend LANG_NAMES extended so Groq language-pinning works for all 10.<br>v26.6.17 | Updated 20 May 2026 | <strong>Two bugs found by live integration testing of Phases A&ndash;D</strong>. (1) Ranking responses were stripping city names because <code>rankings.mjs</code> returns <code>{key, name, aqi, pm25}</code> but the integration code used <code>c.city</code> (undefined). Fixed: <code>c.name || c.city || c.key</code>. (2) Empty Groq responses returned a useless "No response generated." string. Now the fallback surfaces the actual live data (AQI, PM2.5, nearest station) + Groq error message + retry hint. Plus the raw Groq response is logged for diagnostics. 8 queries tested end-to-end against the live endpoint &mdash; all returning useful, sourced answers.<br>v26.6.16 | Updated 20 May 2026 | <strong>Ask JanVayu Phase D &mdash; multi-source spread + divergence flagging</strong>. Closes the calibration loop. Cross-references four sources: WAQI nearest station, WAQI bounds-network (intra-city spread), Sensor.Community community sensors, and a new cached <code>IQAIR_2025_ANNUAL</code> dataset of 37 Indian cities. Computes (a) intra-city spatial spread, (b) WAQI-vs-community snapshot agreement, (c) today-vs-IQAir-baseline anomaly ratio. Flags >2× station range, >50% inter-source disagreement, >1.5× / <0.5× annual deviation. Always-on anomaly note injected even on non-multi-source queries when live PM2.5 is anomalous. <strong>Cumulative across Phases A&ndash;D</strong>: bot wires 4 tools, runs 7 calculators, knows 10 cities' apportionment, drafts 6 RTI templates, cross-references 4 sources, cites every number.<br>v26.6.15 | Updated 20 May 2026 | <strong>Ask JanVayu Phase C &mdash; source apportionment + RTI drafting</strong>. New city-level apportionment dataset (10 cities + national fallback) with citations to CEEW 2024 / TERI / IIT-Delhi DSS / CSIR-NEERI / Bose Institute / Jadavpur — bot returns precise source-mix breakdown when asked "where does the pollution come from in [city]". Six RTI templates inline (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) each with correct PIO department + address + statutory anchors. Instruction #15 tells the LLM to present templates AS-IS, not paraphrase.<br>v26.6.14 | Updated 20 May 2026 | <strong>Ask JanVayu Phase B &mdash; calculators the bot actually runs</strong>. Seven deterministic calculators wired in: cigarette equivalence (Berkeley Earth), mortality risk (Krishna et al. 2024), life-expectancy loss (AQLI 2025), migration benefit (live PM2.5 of both cities), transport exposure (WHO/CPCB multipliers), purifier CADR (AHAM formula), school-closure forecast (CAQM GRAP). Each runs deterministically when the question implies it, returns its result with a primary-source citation, and the LLM is instructed to use those numbers verbatim. Input extraction handles transport mode + hours, room sqft, destination city.<br>v26.6.13 | Updated 20 May 2026 | <strong>Ask JanVayu Phase A &mdash; tool wiring + methodology calibration</strong>. The chatbot now calls three more JanVayu endpoints based on the user's question: <code>rankings.mjs</code> for "top 5 worst" / "cleanest" / leaderboard queries; <code>historical-aqi.mjs</code> for trend / YoY / "since 2019" queries; <code>community-sensors.mjs</code> (Sensor.Community CC0) for "near my area" / hyperlocal / community-sensor queries. All three run in parallel via Promise.all with 6 s timeouts. Plus a new <code>METHODOLOGY_REFERENCE</code> prompt block covering the five biggest "why do two sources disagree" cases &mdash; CPCB-vs-US-EPA AQI scales, WAQI single station vs CPCB network, CPCB-vs-IQAir annual, Krishna-1.5M vs Lancet-1.72M, low-cost vs regulatory accuracy trade-offs. Phase B/C/D coming next.<br>v26.6.12 | Updated 20 May 2026 | <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong>. (1) <em>Station-count queries</em>: new WAQI bounds-endpoint fetch returns a real station list + count for the user's city plus the CPCB national ~533 figure. (2) <em>Sources required</em>: new <code>TOPICAL_REFERENCE</code> prompt block (monitoring network, low-cost sensors, EVs, transport, recent court orders) + hard instruction "if you cite a number without a source, you have failed". (3) <em>Delhi/Mandir-Marg bias</em>: new <code>isNationalQuery()</code> detector triggers India-wide framing for topical questions; reference data restructured to lead with national figures, not Delhi.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.19 | Updated 20 May 2026 | <strong>In-page Ask JanVayu widget refreshed</strong> &mdash; v26.6.18 updated the standalone <code>/ask/</code> PWA but missed the in-page panel at <code>tmpl-ask-janvayu</code>, which still said "in English or Hindi" and had no example questions. Now matches the PWA: full v26.6.x capability statement, 10 example chips that fill the input on tap, new language dropdown (10 languages selectable), "How it works" rewritten to describe the 4 data fetches + 7 calculators + 6 RTI templates + source-citation requirement.<br>v26.6.18 | Updated 20 May 2026 | <strong>Ask JanVayu onboarding refresh + 5 new languages</strong>. (1) Welcome subtitle rewritten across all languages to surface what the bot actually does: live AQI · calculators · rankings · trends · apportionment · RTI · multi-source. (2) Suggestion chips: 7 &rarr; 10, surfacing the new Phase A&ndash;D capabilities (rankings, apportionment, RTI drafting, trend, multi-source reliability, cigarette equivalence, migration). (3) Five new languages added: Telugu, Gujarati, Kannada, Malayalam, Punjabi &mdash; total now 10, covering ~95% of Indian mother-tongue speakers. Backend LANG_NAMES extended so Groq language-pinning works for all 10.<br>v26.6.17 | Updated 20 May 2026 | <strong>Two bugs found by live integration testing of Phases A&ndash;D</strong>. (1) Ranking responses were stripping city names because <code>rankings.mjs</code> returns <code>{key, name, aqi, pm25}</code> but the integration code used <code>c.city</code> (undefined). Fixed: <code>c.name || c.city || c.key</code>. (2) Empty Groq responses returned a useless "No response generated." string. Now the fallback surfaces the actual live data (AQI, PM2.5, nearest station) + Groq error message + retry hint. Plus the raw Groq response is logged for diagnostics. 8 queries tested end-to-end against the live endpoint &mdash; all returning useful, sourced answers.<br>v26.6.16 | Updated 20 May 2026 | <strong>Ask JanVayu Phase D &mdash; multi-source spread + divergence flagging</strong>. Closes the calibration loop. Cross-references four sources: WAQI nearest station, WAQI bounds-network (intra-city spread), Sensor.Community community sensors, and a new cached <code>IQAIR_2025_ANNUAL</code> dataset of 37 Indian cities. Computes (a) intra-city spatial spread, (b) WAQI-vs-community snapshot agreement, (c) today-vs-IQAir-baseline anomaly ratio. Flags >2× station range, >50% inter-source disagreement, >1.5× / <0.5× annual deviation. Always-on anomaly note injected even on non-multi-source queries when live PM2.5 is anomalous. <strong>Cumulative across Phases A&ndash;D</strong>: bot wires 4 tools, runs 7 calculators, knows 10 cities' apportionment, drafts 6 RTI templates, cross-references 4 sources, cites every number.<br>v26.6.15 | Updated 20 May 2026 | <strong>Ask JanVayu Phase C &mdash; source apportionment + RTI drafting</strong>. New city-level apportionment dataset (10 cities + national fallback) with citations to CEEW 2024 / TERI / IIT-Delhi DSS / CSIR-NEERI / Bose Institute / Jadavpur — bot returns precise source-mix breakdown when asked "where does the pollution come from in [city]". Six RTI templates inline (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) each with correct PIO department + address + statutory anchors. Instruction #15 tells the LLM to present templates AS-IS, not paraphrase.<br>v26.6.14 | Updated 20 May 2026 | <strong>Ask JanVayu Phase B &mdash; calculators the bot actually runs</strong>. Seven deterministic calculators wired in: cigarette equivalence (Berkeley Earth), mortality risk (Krishna et al. 2024), life-expectancy loss (AQLI 2025), migration benefit (live PM2.5 of both cities), transport exposure (WHO/CPCB multipliers), purifier CADR (AHAM formula), school-closure forecast (CAQM GRAP). Each runs deterministically when the question implies it, returns its result with a primary-source citation, and the LLM is instructed to use those numbers verbatim. Input extraction handles transport mode + hours, room sqft, destination city.<br>v26.6.13 | Updated 20 May 2026 | <strong>Ask JanVayu Phase A &mdash; tool wiring + methodology calibration</strong>. The chatbot now calls three more JanVayu endpoints based on the user's question: <code>rankings.mjs</code> for "top 5 worst" / "cleanest" / leaderboard queries; <code>historical-aqi.mjs</code> for trend / YoY / "since 2019" queries; <code>community-sensors.mjs</code> (Sensor.Community CC0) for "near my area" / hyperlocal / community-sensor queries. All three run in parallel via Promise.all with 6 s timeouts. Plus a new <code>METHODOLOGY_REFERENCE</code> prompt block covering the five biggest "why do two sources disagree" cases &mdash; CPCB-vs-US-EPA AQI scales, WAQI single station vs CPCB network, CPCB-vs-IQAir annual, Krishna-1.5M vs Lancet-1.72M, low-cost vs regulatory accuracy trade-offs. Phase B/C/D coming next.<br>v26.6.12 | Updated 20 May 2026 | <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong>. (1) <em>Station-count queries</em>: new WAQI bounds-endpoint fetch returns a real station list + count for the user's city plus the CPCB national ~533 figure. (2) <em>Sources required</em>: new <code>TOPICAL_REFERENCE</code> prompt block (monitoring network, low-cost sensors, EVs, transport, recent court orders) + hard instruction "if you cite a number without a source, you have failed". (3) <em>Delhi/Mandir-Marg bias</em>: new <code>isNationalQuery()</code> detector triggers India-wide framing for topical questions; reference data restructured to lead with national figures, not Delhi.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -12732,6 +12743,17 @@ Signature: _______________</div>
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.19 &mdash; 20 May 2026</div>
+                    <strong>In-page Ask JanVayu widget refreshed</strong><br>
+                    &bull; User pointed to a screenshot showing the in-page Ask JanVayu panel at <code>tmpl-ask-janvayu</code> still saying "in English or Hindi" with no example questions. v26.6.18 updated only the standalone <code>/ask/</code> PWA &mdash; the in-page widget is a separate UI surface that was missed.<br>
+                    &bull; <strong>Section intro</strong> rewritten with the full v26.6.x capability statement + the 10-language list explicitly named (English, हिन्दी, தமிழ், বাংলা, मराठी, తెలుగు, ગુજરાતી, ಕನ್ನಡ, മലയാളം, ਪੰਜਾਬੀ).<br>
+                    &bull; <strong>10 example chips</strong> added in a green-accent box &mdash; tap a chip to load the question into the input (does NOT auto-submit, so users can change city/lang first).<br>
+                    &bull; <strong>Language dropdown</strong> added in the form so users can pick the response language. All 10 languages selectable.<br>
+                    &bull; <strong>"How it works"</strong> rewritten to describe the 4 data fetches (WAQI live + bounds + Sensor.Community + IQAir cached) + 7 calculators + 6 RTI templates + source-citation requirement + India-default framing.<br>
+                    &bull; <code>submitAirQuery()</code> now passes <code>lang</code> in the body so the existing 10-language Groq pinning kicks in.
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.18 &mdash; 20 May 2026</div>
@@ -14094,8 +14116,26 @@ Signature: _______________</div>
 
 <template id="tmpl-ask-janvayu">
             <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: var(--accent); margin-right: 0.4rem;"></span>Ask JanVayu <span class="ai-badge">AI Powered</span></h2>
-                <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;">Ask any question about air quality in your city. Get answers grounded in live data, in English or Hindi.</p>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: var(--accent); margin-right: 0.4rem;"></span>Ask JanVayu <span class="ai-badge">AI · sources cited</span></h2>
+                <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 56rem;">Live AQI · health &amp; exposure calculators · city rankings &amp; trends · source apportionment · RTI drafts · multi-source reliability checks. Every answer cites a primary source (CPCB, IQAir, Lancet Countdown, AQLI, CREA, Sensor.Community). Available in <strong>10 Indian languages</strong> &mdash; English, हिन्दी, தமிழ், বাংলা, मराठी, తెలుగు, ગુજરાતી, ಕನ್ನಡ, മലയാളം, ਪੰਜਾਬੀ.</p>
+                <p style="font-size: 0.9rem; color: var(--text-3); margin-top: 0.5rem;">For the full chat experience with conversation history and PWA install, open <a href="/ask/" style="color: var(--accent);">/ask/ &rarr;</a></p>
+            </div>
+
+            <!-- EXAMPLE QUESTION CHIPS — surface what the bot can do -->
+            <div class="info-box" style="background: rgba(27,107,74,0.04); border-left: 3px solid var(--accent); margin-bottom: 1.25rem; padding: 1rem;">
+                <h4 style="margin: 0 0 0.5rem; color: var(--accent); font-size: 0.875rem; font-weight: 700;">Try one of these &mdash; tap a chip to load the question</h4>
+                <div style="display: flex; flex-wrap: wrap; gap: 6px;">
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Should I go jogging today?')">Should I go jogging today?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Top 5 worst Indian cities right now')">Top 5 worst Indian cities right now</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('I commute 2 hours by auto — what is my PM2.5 exposure?')">I commute 2 hours by auto &mdash; what's my exposure?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Where does the pollution in Patna come from?')">Where does pollution come from?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Draft an RTI about brick kilns near my school')">Draft an RTI about brick kilns</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('How reliable is today’s AQI reading?')">How reliable is today's reading?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('How many cigarettes equivalent am I smoking today?')">How many cigarettes today?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Has Mumbai air gotten worse since 2019?')">Has Mumbai gotten worse since 2019?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Should I move from Delhi to Bangalore?')">Should I move from Delhi to Bangalore?</button>
+                    <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Compare Delhi vs Bangalore air quality')">Compare Delhi vs Bangalore</button>
+                </div>
             </div>
 
             <div class="grid-2 mb-2">
@@ -14103,7 +14143,7 @@ Signature: _______________</div>
                     <div class="card-header"><span class="card-title">Your Question</span></div>
                     <div class="card-body">
                         <div class="form-group">
-                            <label class="form-label">City</label>
+                            <label class="form-label">City <span style="color: var(--text-3); font-weight: 400; font-size: 0.78rem;">(live AQI source)</span></label>
                             <select class="form-select" id="ask-city">
                                 <optgroup label="Metros">
                                     <option value="delhi" selected>Delhi</option>
@@ -14155,8 +14195,23 @@ Signature: _______________</div>
                             </select>
                         </div>
                         <div class="form-group">
+                            <label class="form-label">Language <span style="color: var(--text-3); font-weight: 400; font-size: 0.78rem;">(response language)</span></label>
+                            <select class="form-select" id="ask-lang">
+                                <option value="en">English</option>
+                                <option value="hi">हिन्दी (Hindi)</option>
+                                <option value="ta">தமிழ் (Tamil)</option>
+                                <option value="bn">বাংলা (Bengali)</option>
+                                <option value="mr">मराठी (Marathi)</option>
+                                <option value="te">తెలుగు (Telugu)</option>
+                                <option value="gu">ગુજરાતી (Gujarati)</option>
+                                <option value="kn">ಕನ್ನಡ (Kannada)</option>
+                                <option value="ml">മലയാളം (Malayalam)</option>
+                                <option value="pa">ਪੰਜਾਬੀ (Punjabi)</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label class="form-label">Your Question</label>
-                            <input type="text" class="form-input" id="ask-question" placeholder="Delhi mein aaj bahar jaana safe hai? / Is it safe to go outside in Delhi today?">
+                            <input type="text" class="form-input" id="ask-question" placeholder="e.g. Should I go jogging today? &middot; Top 5 worst cities &middot; Draft an RTI...">
                         </div>
                         <button class="btn btn-primary" id="ask-submit" onclick="submitAirQuery()">Ask JanVayu</button>
                     </div>
@@ -14171,8 +14226,10 @@ Signature: _______________</div>
             </div>
 
             <div class="info-box">
-                <h4>How it works</h4>
-                <p>Ask JanVayu fetches <strong>live AQI data</strong> from the WAQI API for your selected city, then uses an open-source LLM (Llama 3.3 70B via Groq) to answer your question grounded in actual numbers. Ask in English or Hindi — the AI responds in the language you use. All AI calls go through our server; your question never leaves JanVayu's infrastructure.</p>
+                <h4>What this bot can do</h4>
+                <p style="margin-bottom: 0.75rem;">JanVayu's Ask system runs <strong>four internal data fetches</strong> for the city you pick (live WAQI, intra-city WAQI bounds-network, Sensor.Community community sensors, IQAir 2025 cached annual baseline), then layers <strong>seven deterministic calculators</strong> (cigarette equivalence per Berkeley Earth, mortality risk per Krishna et al. 2024, life-expectancy loss per AQLI 2025, migration delta, transport exposure, purifier CADR sizing, school-closure forecast) and <strong>six RTI templates</strong> (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) onto the open-source Llama 3.3 70B model via Groq.</p>
+                <p style="margin-bottom: 0.75rem;"><strong>Every answer cites the primary source</strong> for any number it gives &mdash; CPCB Annual Report, IQAir World Air Quality Report 2025, Lancet Countdown 2025, AQLI 2025, CREA, Sensor.Community, CAG audits, NGT orders. If a source is missing, the bot has failed (its own instruction).</p>
+                <p>For national/topical questions (BS-VI, e-buses, NCAP, monitoring network), the bot frames India-wide and does NOT default to Delhi context. All AI calls go through JanVayu's server; your question never leaves our infrastructure. <strong>Full chat history + PWA install</strong> available at <a href="/ask/" style="color: var(--accent);">/ask/ &rarr;</a></p>
             </div>
 </template>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.18",
+  "version": "26.6.19",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

User shared a screenshot of the in-page Ask JanVayu panel still showing:

> *"Ask any question about air quality in your city. Get answers grounded in live data, in English or Hindi."*

v26.6.18 had updated the standalone `/ask/` PWA but **the in-page widget is a separate UI surface** (template `tmpl-ask-janvayu` inside `index.html`) that was missed. Both share the name but they're distinct templates.

## Fixed

### Section intro
Now: *"Live AQI · health & exposure calculators · city rankings & trends · source apportionment · RTI drafts · multi-source reliability checks. Every answer cites a primary source (CPCB, IQAir, Lancet Countdown, AQLI, CREA, Sensor.Community). Available in 10 Indian languages — English, हिन्दी, தமிழ், বাংলা, मराठी, తెలుగు, ગુજરાતી, ಕನ್ನಡ, മലയാളം, ਪੰਜਾਬੀ."*

### 10 example question chips
Tap a chip to load the question into the input (does NOT auto-submit so users can change city or language first). Same set as the `/ask/` PWA — jogging, top-5 worst, transport exposure, apportionment, RTI, reliability, cigarettes, trend, migration, comparison.

### Language dropdown
Added in the form. All 10 languages selectable. `submitAirQuery()` now reads `#ask-lang` and passes `lang` in the body so the existing Groq response-language pinning works for the in-page widget too.

### "How it works" rewritten
Describes the 4 data fetches (WAQI live + WAQI bounds + Sensor.Community + IQAir cached annual), 7 calculators, 6 RTI templates, source-citation requirement, India-default framing for topical queries. Plus pointer to `/ask/` for the full chat experience + PWA install.

## Verified

- `node --check` on all index.html JS blocks passes
- Two new IDs (`#ask-lang`, chip onclicks) wired correctly
- `loadAskChip()` exposed on `window`

Version 26.6.18 → **26.6.19**. Both changelogs updated.

https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQT8YrEEyXLJ2qEApzsKW)_