### PR TITLE
Fix feedback button visibility + expand city bar to 33 cities

### DIFF
--- a/ask/index.html
+++ b/ask/index.html
@@ -267,6 +267,29 @@
     <button class="city-chip" data-city="patna">Patna</button>
     <button class="city-chip" data-city="pune">Pune</button>
     <button class="city-chip" data-city="jaipur">Jaipur</button>
+    <button class="city-chip" data-city="ahmedabad">Ahmedabad</button>
+    <button class="city-chip" data-city="kanpur">Kanpur</button>
+    <button class="city-chip" data-city="varanasi">Varanasi</button>
+    <button class="city-chip" data-city="agra">Agra</button>
+    <button class="city-chip" data-city="bhopal">Bhopal</button>
+    <button class="city-chip" data-city="indore">Indore</button>
+    <button class="city-chip" data-city="nagpur">Nagpur</button>
+    <button class="city-chip" data-city="chandigarh">Chandigarh</button>
+    <button class="city-chip" data-city="gurgaon">Gurgaon</button>
+    <button class="city-chip" data-city="noida">Noida</button>
+    <button class="city-chip" data-city="ghaziabad">Ghaziabad</button>
+    <button class="city-chip" data-city="faridabad">Faridabad</button>
+    <button class="city-chip" data-city="raipur">Raipur</button>
+    <button class="city-chip" data-city="guwahati">Guwahati</button>
+    <button class="city-chip" data-city="dehradun">Dehradun</button>
+    <button class="city-chip" data-city="amritsar">Amritsar</button>
+    <button class="city-chip" data-city="jodhpur">Jodhpur</button>
+    <button class="city-chip" data-city="kochi">Kochi</button>
+    <button class="city-chip" data-city="visakhapatnam">Visakhapatnam</button>
+    <button class="city-chip" data-city="coimbatore">Coimbatore</button>
+    <button class="city-chip" data-city="thiruvananthapuram">Thiruvananthapuram</button>
+    <button class="city-chip" data-city="muzaffarpur">Muzaffarpur</button>
+    <button class="city-chip" data-city="gaya">Gaya</button>
   </div>
 
   <div class="chat-area" id="chatArea" role="log" aria-live="polite" aria-atomic="false" aria-label="Ask JanVayu conversation">

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260520-v3';
+const CACHE_NAME = 'ask-janvayu-20260526-v4';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',


### PR DESCRIPTION
## Summary
- Bump service worker cache (v3 → v4) so returning visitors get the new HTML with feedback buttons
- Expand city chip bar from 10 to all 33 backend-supported cities (scrollable)

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_