### PR TITLE
docs: sweep repo docs for v26.6.20 renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.20] - 2026-05-26
+
+### Fixed — Chatbot accuracy (user feedback from Komal)
+
+- **Patna station count**: Added `CPCB_STATION_DATA` with per-city CAAQMS vs manual bifurcation for 27 cities. Patna now correctly reports 7 total = 3 CAAQMS (IGSC Planetarium, Muradpur, Samanpura) + 4 manual. System prompt instruction #13 rewritten to require bifurcated reporting.
+- **Delhi Mandir Marg bias**: Generic "how is the air quality" queries now auto-fetch all WAQI stations via `fetchCityStations()` and present a city-wide AQI range (min–max + average) instead of just the nearest station to centroid.
+- **Low-cost sensor detection**: `isHyperlocalQuery()` regex expanded to match "low cost sensors in [city]" patterns that were previously missed.
+- **Service worker cache**: Bumped `ask-janvayu-20260520-v3` → `ask-janvayu-20260526-v4` so returning visitors pick up the new HTML with feedback buttons.
+
+### Changed — Navigation reorganized (intent-based)
+
+Old structure (data-type grouping, Resources had 16 items):
+- Dashboard | Data & Health (5) | Monitoring (7) | Accountability (8) | Action (7) | Resources (16)
+
+New structure (intent-based, max 8 per group):
+- Dashboard | **My Air (7)** | City Data (6) | Health & Trends (6) | Accountability (8) | Take Action (8) | Resources (8)
+
+Key moves:
+- New "My Air" tab surfaces personal tools first (Ask JanVayu AI, Should I Go Outside, AQI Alerts, Exposure Report, School Closures, Purifier Calculator, Migration Calculator).
+- RTI Assistant: Resources → Take Action (it's an action, not reference).
+- Correlations: Monitoring → Health & Trends (analytical context).
+- Pollution Calendar: Resources → City Data (city-specific).
+- Social Media Feed + Live News: Monitoring → Resources (reference material).
+- All 43 panels preserved — zero functionality removed.
+
+### Changed — Renames for clarity
+
+- "Hyperlocal" → **My Neighbourhood**
+- "Policy Effectiveness" → **Policy Tracker**
+- "Research Library" → **Reading List** (in-app curated panel)
+- "Zotero Research Library" → **Full Bibliography (Zotero)** (external academic citation)
+
+### Added — Feedback UI on chatbot
+
+- Thumbs up/down buttons on every AI response in `/ask/` PWA.
+- Feedback stored in localStorage (question, city, timestamp, vote) for accuracy tracking.
+
+### Added — City bar expanded
+
+- City chip selector expanded from 10 to all 33 backend-supported cities.
+- Bar is horizontally scrollable — no extra vertical space taken.
+
+### Changed — Version markers
+
+- `package.json` 26.6.19 → **26.6.20**
+- `CITATION.cff` 26.6.19 → **26.6.20**
+- i18n updated for en, hi, ta, mr, bn across all nav labels and group names.
+
 ## [v26.6.19] - 2026-05-20
 
 ### Fixed — In-page Ask JanVayu widget (separate from /ask/ PWA) was unchanged

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-05-20"
-version: "26.6.19"
+date-released: "2026-05-26"
+version: "26.6.20"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ This is not a campaign. It is a record.
 | 17 | **Downloadable Reports** | Curated research papers and datasets for offline reference |
 | 18 | **Cultural Archive** | Satire, memes, art, and cultural responses to the pollution crisis |
 | 19 | **Blog** | Updates, data analysis, and reflections on India's air quality crisis at [janvayu.in/blog](https://www.janvayu.in/blog) |
-| 20 | **Zotero Research Library** | Public bibliography of air quality research papers at [zotero.org/groups/janvayu](https://www.zotero.org/groups/6508140/janvayu/library) |
-| 21 | **Ask JanVayu PWA** | Installable standalone AI chat app for air quality Q&A at [janvayu.in/ask](https://www.janvayu.in/ask) — works on Android, iOS, desktop |
+| 20 | **Zotero Bibliography** | Public bibliography of air quality research papers at [zotero.org/groups/janvayu](https://www.zotero.org/groups/6508140/janvayu/library) |
+| 21 | **Ask JanVayu PWA** | Installable standalone AI chat app for air quality Q&A at [janvayu.in/ask](https://www.janvayu.in/ask) — 33 cities, 10 languages, thumbs up/down feedback, works on Android, iOS, desktop |
 | 22 | **Learning Games** | Seven self-paced educational games at [janvayu.in/#games](https://www.janvayu.in/#games) — India-context Air Quality Jeopardy (5×5 board, ₹1k–₹5k tiles), 10-question PM Quick-Quiz, 7-source matcher, Clean Air Snakes & Ladders inspired by Moksha Patam, Jodi Match memory cards, Air Tambola (Indian housie), and **Vayu Junction** — an *Only Connect* / NYT-*Connections* / *Torchlight*-inspired word-grouping puzzle with four India-AQ puzzle sets |
 
 ---

--- a/docs/contributing/collaborators.md
+++ b/docs/contributing/collaborators.md
@@ -1,6 +1,6 @@
 # JanVayu — Statement of Work for Research Collaborators
 
-**Platform:** [janvayu.in](https://www.janvayu.in) | **Repository:** [github.com/JanVayu/JanVayu](https://github.com/JanVayu/JanVayu) | **Research Library:** [Zotero](https://www.zotero.org/groups/6508140/janvayu/library)
+**Platform:** [janvayu.in](https://www.janvayu.in) | **Repository:** [github.com/JanVayu/JanVayu](https://github.com/JanVayu/JanVayu) | **Bibliography:** [Zotero](https://www.zotero.org/groups/6508140/janvayu/library)
 
 **About JanVayu:** India's independent, citizen-led air quality platform — combining live data, health impact analysis, budget tracking, and government accountability. Non-partisan, CC BY-NC-SA 4.0.
 

--- a/docs/data-sources/health-data.md
+++ b/docs/data-sources/health-data.md
@@ -89,7 +89,7 @@ Two peer-reviewed studies, distinct from the Lancet Countdown synthesis above, p
 2. **"Ambient air pollution and daily mortality in ten cities of India: a causal modelling study"** &mdash; First multi-city study examining short-term PM2.5 exposure and daily mortality using causal methods.  
    [DOI: 10.1016/S2542-5196(24)00114-1](https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(24)00114-1/fulltext)
 
-> **Note on the two figures.** The 1.5 million (Krishna et al.) and 1.72 million (Lancet Countdown 2025) numbers are **both legitimate and both cited** on JanVayu &mdash; they come from different methods (causal cohort vs. annual synthesis) and we keep both in the Research Library so readers can see them side by side. The dashboard hero uses 1.72 million, the more recent and commonly-cited figure.
+> **Note on the two figures.** The 1.5 million (Krishna et al.) and 1.72 million (Lancet Countdown 2025) numbers are **both legitimate and both cited** on JanVayu &mdash; they come from different methods (causal cohort vs. annual synthesis) and we keep both in the Reading List so readers can see them side by side. The dashboard hero uses 1.72 million, the more recent and commonly-cited figure.
 
 ---
 

--- a/docs/data-sources/overview.md
+++ b/docs/data-sources/overview.md
@@ -64,7 +64,7 @@ JanVayu integrates 160+ verified public data sources. Every data point on the pl
 
 ---
 
-## Zotero Research Library
+## Zotero Bibliography
 
 JanVayu maintains a public Zotero group library for collaborative bibliography management:
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,6 +1,6 @@
 # Platform Overview
 
-JanVayu is a single-page web application with 30+ sections covering every dimension of India's air quality crisis — from live data to legal accountability.
+JanVayu is a single-page web application with 43 panels across 7 intent-based navigation categories (My Air, City Data, Health & Trends, Accountability, Take Action, Resources) covering every dimension of India's air quality crisis — from live data to legal accountability.
 
 ---
 
@@ -12,14 +12,14 @@ JanVayu is a single-page web application with 30+ sections covering every dimens
 | 2 | **"Near Me" geolocation** | One-tap nearest-station lookup via the browser's geolocation API |
 | 3 | **Interactive AQI Map** | Leaflet.js map with station-level markers, a heatmap-layer toggle, and station popups |
 | 4 | **City Rankings** | Live / Past 7 days / Past 30 days rankings of Indian cities, sortable and searchable |
-| 5 | **Hyperlocal panel** | CPCB/WAQI stations blended with free Sensor.Community community sensors, badged by source |
+| 5 | **My Neighbourhood** | CPCB/WAQI stations blended with free Sensor.Community community sensors, badged by source |
 | 6 | **Health Impact Calculator** | GEMM model estimates of mortality, disease burden, and life years lost |
 | 7 | **Economic Cost Analysis** | GDP loss, healthcare spending, productivity impact (Lancet 2025, World Bank) |
 | 8 | **Children's Health** | Lung development impacts, school closures, stunting data |
 | 9 | **Indoor Air Quality** | Household pollution from solid fuel cooking, Ujjwala scheme tracking |
 | 10 | **City Comparison** | Real-time AQI comparison plus a year-over-year tab (2024/2025/2026 monthly averages) |
 | 11 | **Historical Trends** | Hourly 24-hr scrubbable PM2.5 chart, annual trend line, seasonal pattern, key-events timeline |
-| 12 | **Policy Effectiveness** | NCAP targets vs actual outcomes, GRAP stage history |
+| 12 | **Policy Tracker** | NCAP targets vs actual outcomes, GRAP stage history |
 | 13 | **Budget Tracker** | NCAP and 15th Finance Commission fund utilisation rates |
 | 14 | **Political Accountability** | MoEFCC spending, state compliance, RTI templates |
 | 15 | **Industrial Sources** | Factory emissions, thermal power plants, brick kilns |
@@ -28,7 +28,7 @@ JanVayu is a single-page web application with 30+ sections covering every dimens
 | 18 | **Legal Framework** | Supreme Court orders, NGT rulings, Article 21 right to clean air |
 | 19 | **Take Action** | Advocacy guides, citizen tools, campaign resources |
 | 20 | **Workshops** | Request an Air Quality workshop with Dr. Sarath Guttikunda (UrbanEmissions) — including the Air Quality Jeopardy game — or book a 1-hour JanVayu walkthrough |
-| 21 | **Research Library** | Curated reports from CREA, CSE, IQAir, Lancet, World Bank |
+| 21 | **Reading List** | Curated reports from CREA, CSE, IQAir, Lancet, World Bank |
 | 22 | **Citizen Voices Archive** | Social media posts, testimonies, viral content from affected communities |
 | 23 | **Accountability Tracker** | Institutional and official responses to pollution episodes |
 | 24 | **Social Media Feeds** | Aggregated Reddit, Twitter/X, Instagram, and news coverage |
@@ -41,9 +41,9 @@ JanVayu is a single-page web application with 30+ sections covering every dimens
 | 31 | **PWA install** | Installable on Android, iOS, and desktop with offline shell + last-known AQI cache |
 | 32 | **"Did You Know" facts strip** | Six India-specific sourced fact cards on the dashboard under the anomaly banner — PM2.5 mortality, life-expectancy loss, NCAP fund split, NAAQS-vs-WHO gap, dose-response, Loni headline |
 | 33 | **Learning Games** | `/#games` — six self-paced games: Air Quality Jeopardy (₹1,000–₹5,000 INR tiles, ₹75,000 max), 10-question PM Quick-Quiz, Source Matcher, Clean Air Snakes & Ladders (inspired by *Moksha Patam*), Jodi Match (memory cards), Air Tambola (Indian housie). All original India-context content sourced from Lancet Countdown 2025, IQAir 2025, CEEW 2024, NCAP records |
-| 34 | **Ask JanVayu PWA** | Standalone installable AI chat at `/ask/` — chat-style interface, city chip selector, offline fallback. Available in English, Hindi, Tamil, Bengali, Marathi |
+| 34 | **Ask JanVayu PWA** | Standalone installable AI chat at `/ask/` — chat-style interface, 33-city chip selector, thumbs up/down feedback, offline fallback. Available in 10 languages |
 | 35 | **April–May 2026 Voices** | Curated Lancet Countdown launch reactions, Loni-residents ground report, Soumya Swaminathan at the "Be Cool" launch, Supreme Court four-week deadline, Warrior Moms commentary, CSE NCAP review |
-| 36 | **April–May 2026 Research Updates** | Featured card group at the top of the Research Library — Lancet Countdown 2025, AQLI 2025, IQAir 2025, CSE NCAP review, Krishna et al. 2024 Lancet Planetary Health, CEEW 2024 source apportionment |
+| 36 | **April–May 2026 Research Updates** | Featured card group at the top of the Reading List — Lancet Countdown 2025, AQLI 2025, IQAir 2025, CSE NCAP review, Krishna et al. 2024 Lancet Planetary Health, CEEW 2024 source apportionment |
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -29,7 +29,16 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 
 **JanVayu** (जनवायु — "People's Air") is a non-partisan, citizen-led initiative documenting India's air quality crisis through real-time data, health research, policy tracking, and public testimony.
 
-### What's New (v26.6.x — 20 May 2026)
+### What's New (v26.6.x)
+
+**v26.6.20 — Chatbot accuracy + intent-based nav + feedback UI (26 May 2026)**
+- Chatbot station-count accuracy: CPCB reference data for 27 cities with CAAQMS vs manual bifurcation.
+- Multi-station AQI range for generic queries (fixes Delhi/Mandir Marg single-station bias).
+- Navigation reorganized from data-type to intent-based: new "My Air" tab surfaces personal tools first. Resources cut from 16 → 8 items. All 43 panels preserved.
+- Renamed: Hyperlocal → My Neighbourhood, Research Library → Reading List, Policy Effectiveness → Policy Tracker.
+- Thumbs up/down feedback buttons on chatbot responses.
+- City bar expanded from 10 → 33 cities.
+- Service worker cache bumped so returning visitors see new features.
 
 **v26.6.11 — `/walkthrough/` guided-tour page featured**
 - New public page at [janvayu.in/walkthrough/](https://www.janvayu.in/walkthrough/) embedding the 64-slide JanVayu MMSF Fellows deck via Google Slides iframe.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -136,7 +136,7 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 ### Earlier (v25.4.0 — April 2026)
 
 - **Blog** — Docsify-powered blog at [janvayu.in/blog](https://www.janvayu.in/blog).
-- **Zotero Research Library** — Public bibliography at [zotero.org/groups/janvayu](https://www.zotero.org/groups/6508140/janvayu/library).
+- **Full Bibliography (Zotero)** — Public bibliography at [zotero.org/groups/janvayu](https://www.zotero.org/groups/6508140/janvayu/library).
 - **IQAir 2025 data** rolled in (Loni #1 globally; only 14% of cities meet WHO guideline).
 - **Lancet Planetary Health** causal PM2.5 mortality studies and **Science Advances** inequality study added to the library.
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -49,7 +49,7 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 - [x] Clean Air Mission Tracker
 - [x] Historical trends with seasonal patterns
 - [x] City comparison with international benchmarks
-- [x] 40 content panels across 6 navigation categories
+- [x] 43 content panels across 7 intent-based navigation categories (reorganized v26.6.20)
 
 ---
 
@@ -187,6 +187,22 @@ Adds a seventh learning game inspired by *Only Connect* / NYT *Connections* / *T
 - [x] **Translated changelogs**: v26.6 stub added to `docs-hi/CHANGELOG.md`, `docs-bn/CHANGELOG.md`, `docs-mr/CHANGELOG.md`, `docs-ta/CHANGELOG.md`.
 - [x] **New blog post** `2026-05-20-vayu-junction.md` — walks through the four puzzle sets and the design choices.
 - [x] **`/walkthrough/` guided-tour page** (v26.6.11) — public page at `janvayu.in/walkthrough/` embedding the 64-slide MMSF Fellows deck via Google Slides iframe, with PPTX (24 MB) and PDF (13 MB) as direct downloads, footer link under Tools & Action, and a NEW-badged dashboard quick-link card.
+
+---
+
+## Phase 5.10: Chatbot Accuracy & UX Feedback (✅ Completed — v26.6.20)
+
+Addresses detailed user-testing feedback from a domain expert (Komal) who verified chatbot answers against ground truth.
+
+- [x] **CPCB station reference data** for 27 cities with CAAQMS vs manual bifurcation — chatbot now reports exact station counts and types instead of relying on WAQI subset.
+- [x] **Multi-station AQI range** for generic air quality queries — fixes the single-station (Mandir Marg) bias by fetching and presenting all stations in the city.
+- [x] **Low-cost sensor detection** expanded to catch "low cost sensors in [city]" queries.
+- [x] **Intent-based navigation** reorganization: 6 data-type tabs → 7 intent-based tabs. New "My Air" tab for personal tools. Resources cut from 16 → 8 items. All 43 panels preserved.
+- [x] **Clarity renames**: Hyperlocal → My Neighbourhood, Policy Effectiveness → Policy Tracker, Research Library → Reading List.
+- [x] **Feedback UI**: thumbs up/down on chatbot responses for accuracy tracking.
+- [x] **City bar**: 10 → 33 cities in the `/ask/` quick-select chip bar.
+- [x] **Service worker cache** bumped to force-refresh for returning visitors.
+- [x] i18n updated for en, hi, ta, mr, bn across all nav labels and group names.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -12767,6 +12767,21 @@ Signature: _______________</div>
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.20 &mdash; 26 May 2026</div>
+                    <strong>Chatbot accuracy fixes, intent-based nav, feedback UI, 33-city bar</strong><br>
+                    &bull; User feedback (Komal): <em>"The number of monitoring stations in Patna was incorrect. Delhi defaulted to Mandir Marg. Low-cost sensor queries for Patna returned nothing. Tabs are confusing for a layperson."</em><br>
+                    &bull; <strong>Station count accuracy</strong>: new <code>CPCB_STATION_DATA</code> for 27 cities with CAAQMS vs manual bifurcation (e.g. Patna: 7 total = 3 CAAQMS + 4 manual, with named stations). System prompt instruction #13 rewritten to require bifurcated reporting.<br>
+                    &bull; <strong>Multi-station AQI range</strong>: generic &ldquo;how is the air quality&rdquo; queries now auto-fetch all WAQI stations and present a city-wide AQI range instead of just the nearest station. Fixes the Mandir Marg single-station bias.<br>
+                    &bull; <strong>Low-cost sensor detection</strong>: <code>isHyperlocalQuery()</code> regex expanded to match &ldquo;low cost sensors in [city]&rdquo; patterns.<br>
+                    &bull; <strong>Navigation reorganized</strong> from data-type to intent-based grouping. Old: Data &amp; Health (5) | Monitoring (7) | Accountability (8) | Action (7) | Resources (16). New: <strong>My Air (7)</strong> | City Data (6) | Health &amp; Trends (6) | Accountability (8) | Take Action (8) | Resources (8). &ldquo;My Air&rdquo; surfaces personal tools first (Ask AI, Should I Go Outside, Alerts, School Closures, calculators). All 43 panels preserved.<br>
+                    &bull; <strong>Renamed</strong>: Hyperlocal &rarr; My Neighbourhood, Policy Effectiveness &rarr; Policy Tracker, Research Library &rarr; Reading List, Zotero link &rarr; Full Bibliography (Zotero).<br>
+                    &bull; <strong>Feedback UI</strong>: thumbs up/down buttons on every chatbot AI response, stored in localStorage for accuracy tracking.<br>
+                    &bull; <strong>City bar expanded</strong>: 10 &rarr; 33 cities (all backend-supported cities now shown as scrollable chips).<br>
+                    &bull; <strong>Service worker cache</strong> bumped <code>ask-janvayu-20260520-v3</code> &rarr; <code>ask-janvayu-20260526-v4</code> so returning visitors see feedback buttons.<br>
+                    &bull; i18n updated for en, hi, ta, mr, bn across all nav labels and group names.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.19 &mdash; 20 May 2026</div>
                     <strong>In-page Ask JanVayu widget refreshed</strong><br>
                     &bull; User pointed to a screenshot showing the in-page Ask JanVayu panel at <code>tmpl-ask-janvayu</code> still saying "in English or Hindi" with no example questions. v26.6.18 updated only the standalone <code>/ask/</code> PWA &mdash; the in-page widget is a separate UI surface that was missed.<br>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.19",
+  "version": "26.6.20",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
Sweep repo docs for v26.6.20 renames (Research Library → Reading List, Hyperlocal → My Neighbourhood, Policy Effectiveness → Policy Tracker, Zotero Research Library → Bibliography/Full Bibliography).

Updated: README.md, docs/user-guide/overview.md, docs/data-sources/health-data.md, docs/data-sources/overview.md, docs/wiki/Home.md, docs/contributing/collaborators.md

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_