### PR TITLE
feat: wire Zotero + reference-data into live platform + update walkthrough

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,64 @@
             });
         }
 
+    function loadZoteroItems() {
+        const section = document.getElementById('zotero-section');
+        const loading = document.getElementById('zotero-loading');
+        const container = document.getElementById('zotero-items');
+        const countBadge = document.getElementById('zotero-count');
+        if (!section || !loading || !container) return;
+
+        // Show loading spinner
+        loading.style.display = '';
+        section.style.display = 'none';
+
+        fetch('/.netlify/functions/zotero-library')
+            .then(function(res) {
+                if (!res.ok) throw new Error('Zotero API returned ' + res.status);
+                return res.json();
+            })
+            .then(function(data) {
+                loading.style.display = 'none';
+                if (!data.items || data.items.length === 0) return;
+
+                var items = data.items.slice(0, 10);
+                var html = '';
+                items.forEach(function(item) {
+                    var tagsHtml = '';
+                    if (item.tags && item.tags.length > 0) {
+                        item.tags.slice(0, 2).forEach(function(tag) {
+                            tagsHtml += '<span class="badge badge-info" style="margin-right: 4px; margin-top: 4px;">' + escapeHTML(tag) + '</span>';
+                        });
+                    }
+                    var typeBadge = item.type
+                        ? '<span class="badge badge-success" style="margin-right: 4px;">' + escapeHTML(item.type) + '</span>'
+                        : '';
+                    var yearStr = item.year ? ' (' + escapeHTML(item.year) + ')' : '';
+                    var authorsStr = item.authors ? '<div class="resource-desc" style="margin-bottom: 2px; font-style: italic;">' + escapeHTML(item.authors) + yearStr + '</div>' : '';
+                    var titleLink = item.url
+                        ? '<a href="' + escapeHTML(item.url) + '" target="_blank" rel="noopener" style="color: inherit; text-decoration: none;"><div class="resource-title">' + escapeHTML(item.title) + '</div></a>'
+                        : '<div class="resource-title">' + escapeHTML(item.title) + '</div>';
+
+                    html += '<div class="resource-card" data-keywords="zotero ' + escapeHTML((item.title || '') + ' ' + (item.authors || '')).toLowerCase() + '">'
+                        + '<div class="resource-type">' + typeBadge + 'Zotero</div>'
+                        + titleLink
+                        + authorsStr
+                        + (item.abstract ? '<div class="resource-desc" style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;">' + escapeHTML(item.abstract) + '</div>' : '')
+                        + '<div style="margin-top: 6px;">' + tagsHtml + '</div>'
+                        + '</div>';
+                });
+
+                container.innerHTML = html;
+                if (countBadge) countBadge.textContent = data.count ? data.count + ' items in library' : items.length + ' items';
+                section.style.display = '';
+            })
+            .catch(function(err) {
+                console.warn('Zotero fetch failed:', err);
+                loading.style.display = 'none';
+                section.style.display = 'none';
+            });
+    }
+
     function loadDashboardNews() {
             document.getElementById('dashboard-news').innerHTML = `
                 <div class="news-item" style="padding: 0.5rem 0;"><div class="news-meta"><span class="news-source">Lancet</span>Dec 2024</div><div class="news-title" style="font-size: 0.75rem;">7.2% of Delhi daily deaths attributable to PM2.5 above WHO</div></div>
@@ -1123,6 +1181,7 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     animation: pulse 2s infinite;
 }
 @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+@keyframes spin { to { transform: rotate(360deg); } }
 
 /* ── Sections ──────────────────────────── */
 .page-section {
@@ -11674,6 +11733,20 @@ Signature: _______________</div>
             <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
                 <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-library" style="color: var(--accent); margin-right: 0.4rem;"></span>Reading List</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="A collection of trustworthy reports, studies, and data sources about air pollution in India. All free to access. Great for school projects, journalism, or just learning more.">Curated, verified open-access resources from peer-reviewed studies, government portals, and research institutions.</p>
+            </div>
+
+            <!-- ZOTERO LATEST (loaded dynamically) -->
+            <div id="zotero-section" style="display: none; margin-bottom: 2rem;">
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem;">
+                    <span class="si si-library" style="color: var(--accent);"></span>
+                    <h3 style="font-family: var(--serif); font-size: 1.25rem; margin: 0; color: var(--ink);">Latest from Zotero</h3>
+                    <span id="zotero-count" class="badge badge-info" style="margin-left: 0.25rem;"></span>
+                </div>
+                <div id="zotero-items" class="grid-3" style="gap: 0.75rem;"></div>
+            </div>
+            <div id="zotero-loading" style="display: none; text-align: center; padding: 1.5rem; margin-bottom: 2rem;">
+                <div style="display: inline-block; width: 24px; height: 24px; border: 3px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+                <p style="font-size: 0.85rem; color: var(--text-3); margin-top: 0.5rem;">Loading Zotero library&hellip;</p>
             </div>
 
             <!-- SEARCH + CATEGORY FILTERS -->

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -1,3 +1,10 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REF_DATA = JSON.parse(readFileSync(join(__dirname, 'data', 'reference-data.json'), 'utf8'));
+
 // Netlify Function: Natural Language Query Interface for JanVayu
 // Accepts a question + city, fetches live AQI, sends to Groq for analysis.
 //
@@ -138,18 +145,8 @@ function getSeasonalContext() {
   return { dateStr, season: season + diwaliNote };
 }
 
-const NCAP_CITY_DATA = {
-  delhi: { ncapTarget: "40% PM10 reduction by 2026", budget: "₹300 Cr pollution budget (43% utilised)", note: "Most polluted capital globally (IQAir 2025). 0 days met WHO limit in 2026." },
-  mumbai: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "PM2.5 increased 38% since 2019 despite NCAP." },
-  kolkata: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Winter inversions + vehicle emissions. Limited monitoring coverage." },
-  lucknow: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Indo-Gangetic plain — trapped pollutants. Brick kilns major source." },
-  patna: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Among worst PM2.5 in India. Limited enforcement capacity." },
-  varanasi: { ncapTarget: "40% PM10 reduction", budget: "NCAP success story", note: "PM2.5 fell 72% in 5 years — best NCAP performer." },
-  jaipur: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Desert dust + vehicle emissions. Seasonal variation high." },
-  pune: { ncapTarget: "40% PM10 reduction", budget: "NCAP city", note: "Relatively better air quality than Delhi/Mumbai. Growing vehicle fleet a concern." },
-  chennai: { ncapTarget: "Not in original NCAP 131", budget: "N/A", note: "Coastal city — sea breeze helps dispersion. Industrial corridor a concern." },
-  bangalore: { ncapTarget: "Not in original NCAP 131", budget: "N/A", note: "Generally better air quality. Vehicle growth and construction are rising concerns." },
-};
+// NCAP city data — loaded from data/reference-data.json
+const NCAP_CITY_DATA = REF_DATA.ncap_cities;
 
 const ACTIVITY_THRESHOLDS = `
 WHO activity guidance by PM2.5 level:
@@ -255,35 +252,8 @@ function isStationCountQuery(question) {
 // v26.6.18 — CPCB station reference data per city. Sourced from CPCB
 // Annual Report 2024-25 and ENVIS Centre. Includes CAAQMS (continuous,
 // real-time) vs manual (gravimetric, 24-hr sampling, twice-weekly).
-const CPCB_STATION_DATA = {
-  delhi: { caaqms: 40, manual: 6, total: 46, note: "Densest monitoring network in India; includes DPCC + CPCB + IMD stations" },
-  mumbai: { caaqms: 10, manual: 4, total: 14, note: "Includes MPCB + CPCB stations; Worli, Bandra, Andheri, Colaba among key sites" },
-  kolkata: { caaqms: 7, manual: 3, total: 10, note: "WBPCB network; Victoria, Rabindra Bharati, Fort William among key sites" },
-  chennai: { caaqms: 4, manual: 3, total: 7, note: "TNPCB network; Alandur, Manali, Velachery among key sites" },
-  bangalore: { caaqms: 7, manual: 3, total: 10, note: "KSPCB network; Peenya, BTM, Silk Board, Hebbal among key sites" },
-  hyderabad: { caaqms: 6, manual: 3, total: 9, note: "TSPCB network; Sanathnagar, Zoo Park, Balanagar among key sites" },
-  lucknow: { caaqms: 4, manual: 2, total: 6, note: "UPPCB network; Lalbagh, Talkatora among key sites" },
-  patna: { caaqms: 3, manual: 4, total: 7, note: "BSPCB network; IGSC Planetarium, Muradpur, Samanpura among CAAQMS sites; manual stations at Rajbansi Nagar, Khajpura, Gardanibagh, Phulwari Sharif" },
-  pune: { caaqms: 5, manual: 2, total: 7, note: "MPCB network; Shivajinagar, Lohegaon, Katraj among key sites" },
-  jaipur: { caaqms: 3, manual: 2, total: 5, note: "RSPCB network; Adarsh Nagar, Shastri Nagar among key sites" },
-  ahmedabad: { caaqms: 4, manual: 2, total: 6, note: "GPCB network" },
-  varanasi: { caaqms: 3, manual: 2, total: 5, note: "UPPCB + CPCB stations; Ardhali Bazaar among key sites" },
-  kanpur: { caaqms: 3, manual: 2, total: 5, note: "UPPCB network" },
-  agra: { caaqms: 2, manual: 2, total: 4, note: "UPPCB network; Sanjay Place among key sites" },
-  bhopal: { caaqms: 2, manual: 2, total: 4, note: "MPPCB network" },
-  indore: { caaqms: 2, manual: 1, total: 3, note: "MPPCB network" },
-  nagpur: { caaqms: 3, manual: 2, total: 5, note: "MPCB network" },
-  chandigarh: { caaqms: 2, manual: 1, total: 3, note: "CPCC network" },
-  gurgaon: { caaqms: 4, manual: 1, total: 5, note: "HSPCB network; Sector 51, Teri Gram, Vikas Sadan among key sites" },
-  noida: { caaqms: 3, manual: 1, total: 4, note: "UPPCB network; Sector 125, Sector 62 among key sites" },
-  faridabad: { caaqms: 2, manual: 1, total: 3, note: "HSPCB network" },
-  ghaziabad: { caaqms: 3, manual: 1, total: 4, note: "UPPCB network; Vasundhara, Indirapuram among key sites" },
-  raipur: { caaqms: 2, manual: 1, total: 3, note: "CGPCB network" },
-  dehradun: { caaqms: 2, manual: 1, total: 3, note: "UKPCB network" },
-  guwahati: { caaqms: 2, manual: 1, total: 3, note: "APCB network" },
-  muzaffarpur: { caaqms: 1, manual: 1, total: 2, note: "BSPCB network; limited coverage" },
-  gaya: { caaqms: 1, manual: 1, total: 2, note: "BSPCB network; limited coverage" },
-};
+// Loaded from data/reference-data.json
+const CPCB_STATION_DATA = REF_DATA.cpcb_stations;
 
 // v26.6.13 — Phase A query-routing detectors. The LLM gets data
 // from these endpoints when the user's question fits the pattern.

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -839,19 +839,8 @@ NOTE: This is a deterministic JanVayu RTI template (key: "${templateKey}"). Repl
 // v26.6.16 — Phase D: multi-source spread + divergence flagging
 // ════════════════════════════════════════════════════════════════════════
 
-const IQAIR_2025_ANNUAL = {
-  loni: 112.5, byrnihat: 99.3, begusarai: 95.0, hajipur: 95.0,
-  delhi: 91.6, ghaziabad: 92.1, noida: 80.4, faridabad: 79.2, gurgaon: 80.6,
-  patna: 96.8, muzaffarpur: 88.0, gaya: 78.5,
-  lucknow: 76.5, kanpur: 71.2, varanasi: 78.4, agra: 60.3,
-  jaipur: 56.1, jodhpur: 53.4, amritsar: 55.7,
-  ahmedabad: 49.2, bhopal: 47.5, indore: 47.1, raipur: 50.9,
-  kolkata: 50.2, guwahati: 56.2, dehradun: 49.6, chandigarh: 42.3,
-  pune: 35.8, hyderabad: 33.5, bangalore: 27.6, nagpur: 35.4, mumbai: 41.4,
-  visakhapatnam: 30.1, chennai: 18.1, kochi: 16.7,
-  coimbatore: 19.5, thiruvananthapuram: 16.2,
-  __india_avg: 48.9,
-};
+// IQAir 2025 annual PM2.5 data — loaded from data/reference-data.json
+const IQAIR_2025_ANNUAL = REF_DATA.iqair_annual;
 
 function isMultiSourceQuery(question) {
   const q = question.toLowerCase();

--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -149,13 +149,16 @@
   <div class="what-you-see">
     <h2 style="margin-top: 0;">What this walkthrough covers</h2>
     <ul>
-      <li>How JanVayu is structured &mdash; the dashboard, the 40+ panels, the role-based landing experience</li>
-      <li>Live AQI data sources (WAQI, CPCB CAAQMS, Sensor.Community) and how they flow through the Netlify Functions tier</li>
-      <li>The accountability layer &mdash; NCAP budget tracker, mission tracker, political accountability, RTI templates</li>
-      <li>The seven learning games, including the new <em>Vayu Junction</em> word-grouping puzzle</li>
+      <li>How JanVayu is structured &mdash; the intent-based navigation (My Air, City Data, Health &amp; Trends, Accountability, Take Action, Resources), the 40+ panels, and the role-based landing experience</li>
+      <li>Live AQI data for 33 cities via WAQI, CPCB CAAQMS, and Sensor.Community &mdash; and how they flow through the Netlify Functions tier</li>
+      <li>The Accountability section &mdash; NCAP budget tracker, mission tracker, political accountability, RTI templates</li>
+      <li>The seven learning games, including the <em>Vayu Junction</em> word-grouping puzzle</li>
+      <li>The Reading List (curated research and resources for air-quality advocates)</li>
       <li>How to fork JanVayu for a new city or country &mdash; cost, setup, attribution</li>
     </ul>
   </div>
+
+  <p style="font-size: 0.85rem; color: var(--text-2); background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 18px; margin-bottom: 20px;"><strong>Note:</strong> The embedded slides reflect the platform&rsquo;s navigation as of May&nbsp;20,&nbsp;2026. Since then, the navigation has been reorganised into intent-based groupings (My&nbsp;Air, City&nbsp;Data, Health&nbsp;&amp;&nbsp;Trends, Accountability, Take&nbsp;Action, Resources) and several features have been added including chatbot feedback, 33-city support, and auto-update infrastructure.</p>
 
   <p style="font-size: 0.85rem; color: var(--text-3);">The PDF and PPTX above are exported directly from the live Google Slides deck and may lag the linked version by a few minutes. For the absolute latest, use <em>Open in Google Slides</em>. To run the deck offline, download the PDF (presentation-only) or the PPTX (editable in PowerPoint, Keynote, or LibreOffice Impress).</p>
 


### PR DESCRIPTION
## Summary
Three wiring tasks to connect the auto-update infrastructure to the live platform:

1. **Reference data → chatbot**: `air-query.mjs` now imports CPCB station data, NCAP city data, and IQAir annual figures from `data/reference-data.json` instead of hardcoded constants. Edit the JSON to update chatbot knowledge — no code changes needed.

2. **Zotero → Reading List panel**: "Latest from Zotero" section rendered at the top of the Reading List panel. Fetches from `/.netlify/functions/zotero-library` on panel load with loading state and error handling.

3. **Walkthrough page**: Updated to reflect v26.6.20-21 changes — new nav structure, 33 cities, Reading List rename, note about slides being from May 20.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_