### PR TITLE
docs: v26.6.22 changelog, wiki, roadmap + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.22] - 2026-05-26
+
+### Added — Women & Air Quality panel
+
+New `tmpl-gender` panel under Health & Trends covering the gendered burden of air pollution:
+- **Indoor cooking exposure**: 70% of rural Indian women still cook with solid fuels (NFHS-5). 3-5 hours/day near chulha, PM2.5 levels 20-40× WHO guideline.
+- **Maternal health**: Every +10 µg/m³ PM2.5 → 3-5% increase in preterm birth, 6-9% increase in low birth weight (Lancet Planetary Health 2023).
+- **Mortality**: ~500,000 Indian women die annually from household air pollution; women represent ~60% of global HAP deaths (GBD 2021).
+- **Occupational exposure**: Women in construction, brick kilns, street vending face sustained exposure without protection.
+- **Gender data gap**: No CPCB indoor monitoring, health studies rarely disaggregate by gender.
+- **Action items**: Complete LPG transition, workplace standards, gender-disaggregated surveillance.
+- New "Woman / Caregiver" role in role selector with curated dashboard.
+- Added to Health & Trends nav (desktop + mobile) and search index.
+
+### Added — Historical data time-slider on map
+
+- "History" toggle in map layer controls with month/year range slider (Jan 2024 → present).
+- Fetches from `historical-aqi` function for 12 cities in parallel.
+- Color-coded circle markers by PM2.5 level (green < 30 → purple 150+).
+- In-memory cache, "Live" button to restore real-time, mobile-responsive.
+
+### Changed — Version markers
+
+- `package.json` 26.6.21 → **26.6.22**
+- `CITATION.cff` 26.6.21 → **26.6.22**
+
 ## [v26.6.21] - 2026-05-26
 
 ### Added — Auto-update infrastructure (7 systems)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-06-21"
-version: "26.6.21"
+date-released: "2026-06-22"
+version: "26.6.22"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260621-v26';
+const CACHE_NAME = 'ask-janvayu-20260622-v26';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -31,6 +31,10 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 
 ### What's New (v26.6.x)
 
+**v26.6.22 — Women & Air Quality panel + historical map overlay (26 May 2026)**
+- New "Women & Air Quality" panel: indoor cooking exposure, maternal health, occupational exposure, gender data gap, action items. New "Woman / Caregiver" role.
+- Historical data time-slider on map: month/year slider (Jan 2024 → present), color-coded PM2.5 markers for 12 cities.
+
 **v26.6.21 — Auto-update infrastructure (26 May 2026)**
 - 7 systems for freshness automation: version single-source script, sitemap auto-gen, feed health monitoring, translation key sync, data-stat system for dashboard numbers, reference data endpoint, Zotero → Reading List function.
 - Version bump now runs on every Netlify deploy. Service worker caches auto-sync. Key stats auto-patch from `stats.json`.

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -49,7 +49,7 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 - [x] Clean Air Mission Tracker
 - [x] Historical trends with seasonal patterns
 - [x] City comparison with international benchmarks
-- [x] 43 content panels across 7 intent-based navigation categories (reorganized v26.6.20)
+- [x] 44 content panels across 7 intent-based navigation categories (reorganized v26.6.20, gender panel added v26.6.22)
 
 ---
 
@@ -130,6 +130,15 @@ Installs measurement everywhere and lands the highest-leverage safe wins. Every 
 - [x] **Air Tambola ticket** horizontal-scrolls on 360 px Galaxy
 - [x] **Agent-Reach scheduled fetch workflow** — gracefully skips without secrets
 - [x] **Performance roadmap** docs/technical/performance-roadmap.md
+
+---
+
+## Phase 5.12: Gender Panel & Historical Map (✅ Completed — v26.6.22)
+
+- [x] **Women & Air Quality panel** (`tmpl-gender`): indoor cooking (NFHS-5), maternal health (Lancet), mortality (~500K HAP deaths/year), occupational exposure, gender data gap, and action items.
+- [x] **"Woman / Caregiver" role** in role selector with curated dashboard.
+- [x] **Historical map time-slider**: month/year range slider (Jan 2024 → present), fetches from `historical-aqi` function for 12 cities, color-coded PM2.5 circle markers, in-memory cache.
+- [x] Added to Health & Trends nav, search index, and `data-simple` plain language mode.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -13195,6 +13195,14 @@ Signature: _______________</div>
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.22 &mdash; 26 May 2026</div>
+                    <strong>Women &amp; Air Quality panel + historical map overlay</strong><br>
+                    &bull; <strong>New panel</strong>: &ldquo;Women &amp; Air Quality&rdquo; under Health &amp; Trends &mdash; indoor cooking exposure (70% rural women on solid fuels, NFHS-5), maternal health (preterm birth, low birth weight), ~500K annual HAP deaths, occupational exposure, gender data gap, and action items. All sourced (Lancet, WHO, CEEW, GBD, NFHS-5, CAG).<br>
+                    &bull; <strong>New role</strong>: &ldquo;Woman / Caregiver&rdquo; in role selector with curated dashboard surfacing the gender panel, indoor air, children&rsquo;s health, and calculators.<br>
+                    &bull; <strong>Historical map</strong>: &ldquo;History&rdquo; toggle on the Live Map with a month/year slider (Jan 2024 &rarr; present). Color-coded PM2.5 markers for 12 cities, in-memory cache, &ldquo;Live&rdquo; button to restore real-time view.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.21 &mdash; 26 May 2026</div>
                     <strong>Auto-update infrastructure &mdash; 7 systems for freshness automation</strong><br>
                     &bull; <strong>Version single-source</strong>: <code>scripts/bump-version.mjs</code> reads <code>package.json</code> version and patches CITATION.cff + both service worker cache names. Runs on every Netlify deploy.<br>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.21",
+  "version": "26.6.22",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260621';
+const CACHE_VERSION = 'janvayu-20260622';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
v26.6.22 documentation for Women & Air Quality panel + historical map overlay.

Updated: CHANGELOG.md, in-app changelog, wiki Home, Roadmap (Phase 5.12), version markers (package.json, CITATION.cff, SWs).

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_