### PR TITLE
fix: Walkthrough card icon rendering as brown square

### DIFF
--- a/index.html
+++ b/index.html
@@ -3197,7 +3197,7 @@ body {
                         <div><h4 data-i18n="ql_games_t">Learning Games</h4><p data-i18n="ql_games_d">Seven games: Jeopardy, Vayu Junction &amp; more</p></div>
                     </div>
                     <a class="quick-link" href="/walkthrough/" style="text-decoration: none; color: inherit;">
-                        <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-presentation" style="width:20px;height:20px;"></span></div>
+                        <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-book" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_walk_t">Walkthrough <span style="font-size: 0.55rem; padding: 1px 6px; border-radius: 999px; background: var(--accent); color: #fff; vertical-align: middle; margin-left: 4px;">NEW</span></h4><p data-i18n="ql_walk_d">64-slide guided tour (MMSF Fellows deck)</p></div>
                     </a>
                 </div>


### PR DESCRIPTION
`si-presentation` doesn't exist in Sargam Icons — same class of bug as #113. Replaced with `si-book`.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_