### PR TITLE
fix: replace all 7 undefined Sargam icons (colored squares)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8680,7 +8680,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
 <template id="tmpl-rankings">
 
             <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-list" style="color: #EF4444; margin-right: 0.4rem;"></span>India City Rankings</h2>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-bar-chart" style="color: #EF4444; margin-right: 0.4rem;"></span>India City Rankings</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="A list of which cities have the worst and best air right now, and which cities have been worst over the past week and month.">Live and historical rankings of Indian cities by air quality. Sortable, searchable. Use these to spot trends and outliers, not as a source for shaming alone — every city's residents deserve clean air.</p>
             </div>
 
@@ -11636,7 +11636,7 @@ Signature: _______________</div>
             <!-- RECENT COURT & REGULATOR ACTION (APR-MAY 2026) -->
             <div class="card mb-2" style="border-left: 4px solid var(--accent); background: rgba(27,107,74,0.04);">
                 <div class="card-header">
-                    <span class="card-title"><span class="si si-sm si-gavel" style="color: var(--accent);"></span> Recent Court &amp; Regulator Action</span>
+                    <span class="card-title"><span class="si si-sm si-hammer" style="color: var(--accent);"></span> Recent Court &amp; Regulator Action</span>
                     <span class="badge" style="background: var(--accent); color: white; margin-left: 0.5rem;">Apr&ndash;May 2026</span>
                 </div>
                 <div class="card-body">
@@ -13772,7 +13772,7 @@ Signature: _______________</div>
 </template>
 <template id="tmpl-progress">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-sm si-checkmark" style="color: var(--accent); margin-right: 0.4rem;"></span>Clean Air Wins</h2>
+        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-sm si-check" style="color: var(--accent); margin-right: 0.4rem;"></span>Clean Air Wins</h2>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="Not everything is bad news! Some cities have actually cleaned up their air. Electric buses are growing fast. Citizens are winning fights for cleaner air. Here is the good news, checked against real data.">Accountability means tracking what works, not just what fails. This section documents genuine progress, successful interventions, citizen victories, and policy moves worth watching. Verified against independent data.</p>
     </div>
 
@@ -13800,7 +13800,7 @@ Signature: _______________</div>
 
     <!-- CITIES THAT ARE ACTUALLY IMPROVING -->
     <div class="card mb-2">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-location" style="color: var(--accent);"></span> Cities Showing Real Progress</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-pin" style="color: var(--accent);"></span> Cities Showing Real Progress</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-bottom: 1rem;">While 23 of 100 NCAP cities meeting the 40% target may seem low, some individual city trajectories are genuinely encouraging. These reductions have been verified against CPCB CAAQMS data, not just government claims.</p>
 
@@ -13868,7 +13868,7 @@ Signature: _______________</div>
 
     <!-- POLICY WINS WORTH WATCHING -->
     <div class="card mb-2">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-document" style="color: #7C3AED;"></span> Policy Moves Worth Watching</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: #7C3AED;"></span> Policy Moves Worth Watching</span></div>
         <div class="card-body">
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.5rem;">
@@ -13922,7 +13922,7 @@ Signature: _______________</div>
 
     <!-- CITIZEN POWER -->
     <div class="card mb-2">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-people" style="color: #F59E0B;"></span> Citizen Power: What Communities Are Winning</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-heart" style="color: #F59E0B;"></span> Citizen Power: What Communities Are Winning</span></div>
         <div class="card-body">
             <div class="grid-2" style="gap: 1.25rem;">
                 <div>
@@ -13950,7 +13950,7 @@ Signature: _______________</div>
 
     <!-- HOW TO USE THIS SECTION -->
     <div class="card">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-bulb" style="color: var(--accent);"></span> How to Use These Wins</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-spark" style="color: var(--accent);"></span> How to Use These Wins</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-bottom: 1rem;">
                 Progress is not a reason to relax. It is evidence that action works and that inaction is a choice. When a government says clean air is "too complex" or "too expensive," point them to these numbers. Every city that improved did so because people demanded it and institutions responded.


### PR DESCRIPTION
## Summary
Full sweep of all `si-*` icon classes — found 7 that have no CSS `mask-image` definition and render as colored squares.

| Broken | Replacement | Where |
|---|---|---|
| `si-bulb` | `si-spark` | Clean Air Wins — "How to Use These Wins" |
| `si-checkmark` | `si-check` | Clean Air Wins heading |
| `si-document` | `si-article` | "Policy Moves Worth Watching" |
| `si-gavel` | `si-hammer` | Legal Framework — "Recent Court Action" |
| `si-list` | `si-bar-chart` | City Rankings heading |
| `si-location` | `si-pin` | "Cities Showing Real Progress" |
| `si-people` | `si-heart` | "Citizen Power" card |

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_