### PR TITLE
fix: nav label audit — 17 fixes for clarity and consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -2827,7 +2827,7 @@ body {
                 <button class="mobile-nav-item" data-panel="rankings" data-i18n="nav_rankings">City Rankings</button>
                 <button class="mobile-nav-item" data-panel="compare" data-i18n="nav_compare">City Comparison</button>
                 <button class="mobile-nav-item" data-panel="hyperlocal" data-i18n="nav_hyperlocal">My Neighbourhood</button>
-                <button class="mobile-nav-item" data-panel="forecast" data-i18n="nav_forecast">AQI Forecast</button>
+                <button class="mobile-nav-item" data-panel="forecast" data-i18n="nav_forecast">Air Quality Forecast</button>
                 <button class="mobile-nav-item" data-panel="pollution-calendar" data-i18n="nav_pollution_calendar">Pollution Calendar</button>
             </div>
             <div class="mobile-nav-group">
@@ -2838,17 +2838,17 @@ body {
                 <button class="mobile-nav-item" data-panel="economic" data-i18n="nav_economic">Economic Cost</button>
                 <button class="mobile-nav-item" data-panel="indoor" data-i18n="nav_indoor">Indoor Air</button>
                 <button class="mobile-nav-item" data-panel="trends" data-i18n="nav_trends">Historical Trends</button>
-                <button class="mobile-nav-item" data-panel="correlations" data-i18n="nav_correlations">Correlations</button>
+                <button class="mobile-nav-item" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
             </div>
             <div class="mobile-nav-group">
                 <div class="mobile-nav-group-label" data-i18n="navgroup_accountability">Accountability</div>
                 <button class="mobile-nav-item" data-panel="policy" data-i18n="nav_policy">Policy Tracker</button>
                 <button class="mobile-nav-item" data-panel="budget" data-i18n="nav_budget">Budget Tracker</button>
                 <button class="mobile-nav-item" data-panel="mission-tracker" data-i18n="nav_mission">Mission Tracker</button>
-                <button class="mobile-nav-item" data-panel="scorecards" data-i18n="nav_scorecards">Scorecards</button>
+                <button class="mobile-nav-item" data-panel="scorecards" data-i18n="nav_scorecards">City Scorecards</button>
                 <button class="mobile-nav-item" data-panel="corporate" data-i18n="nav_corporate">Industrial Sources</button>
-                <button class="mobile-nav-item" data-panel="accountability" data-i18n="nav_accountability">Political</button>
-                <button class="mobile-nav-item" data-panel="accountability-brief">AI Brief</button>
+                <button class="mobile-nav-item" data-panel="accountability" data-i18n="nav_accountability">Political Accountability</button>
+                <button class="mobile-nav-item" data-panel="accountability-brief" data-i18n="nav_accountability_brief">Accountability Brief</button>
                 <button class="mobile-nav-item" data-panel="progress" data-i18n="nav_progress">Clean Air Wins</button>
             </div>
             <div class="mobile-nav-group">
@@ -2889,7 +2889,7 @@ body {
     <nav class="section-nav" id="sectionNav">
         <div class="container">
             <div class="nav-item">
-                <button class="nav-link active" data-panel="dashboard">Dashboard</button>
+                <button class="nav-link active" data-panel="dashboard" data-i18n="nav_dashboard">Dashboard</button>
             </div>
             <div class="nav-item">
                 <button class="nav-link" data-panel="go-outside" data-i18n="nav_myair">My Air <span class="nav-caret"></span></button>
@@ -2910,7 +2910,7 @@ body {
                     <button class="nav-dropdown-link" data-panel="rankings" data-i18n="nav_rankings">City Rankings</button>
                     <button class="nav-dropdown-link" data-panel="compare" data-i18n="nav_compare">City Comparison</button>
                     <button class="nav-dropdown-link" data-panel="hyperlocal" data-i18n="nav_hyperlocal">My Neighbourhood</button>
-                    <button class="nav-dropdown-link" data-panel="forecast" data-i18n="nav_forecast">AQI Forecast</button>
+                    <button class="nav-dropdown-link" data-panel="forecast" data-i18n="nav_forecast">Air Quality Forecast</button>
                     <button class="nav-dropdown-link" data-panel="pollution-calendar" data-i18n="nav_pollution_calendar">Pollution Calendar</button>
                 </div>
             </div>
@@ -2923,7 +2923,7 @@ body {
                     <button class="nav-dropdown-link" data-panel="economic" data-i18n="nav_economic">Economic Cost</button>
                     <button class="nav-dropdown-link" data-panel="indoor" data-i18n="nav_indoor">Indoor Air</button>
                     <button class="nav-dropdown-link" data-panel="trends" data-i18n="nav_historical_trends">Historical Trends</button>
-                    <button class="nav-dropdown-link" data-panel="correlations" data-i18n="nav_correlations">Correlations</button>
+                    <button class="nav-dropdown-link" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
                 </div>
             </div>
             <div class="nav-item">
@@ -2932,10 +2932,10 @@ body {
                     <button class="nav-dropdown-link" data-panel="policy" data-i18n="nav_policy">Policy Tracker</button>
                     <button class="nav-dropdown-link" data-panel="budget" data-i18n="nav_budget">Budget Tracker</button>
                     <button class="nav-dropdown-link" data-panel="mission-tracker" data-i18n="nav_mission">Mission Tracker</button>
-                    <button class="nav-dropdown-link" data-panel="scorecards" data-i18n="nav_scorecards">Scorecards</button>
+                    <button class="nav-dropdown-link" data-panel="scorecards" data-i18n="nav_scorecards">City Scorecards</button>
                     <button class="nav-dropdown-link" data-panel="corporate" data-i18n="nav_corporate">Industrial Sources</button>
-                    <button class="nav-dropdown-link" data-panel="accountability" data-i18n="nav_accountability">Political</button>
-                    <button class="nav-dropdown-link" data-panel="accountability-brief" data-i18n="nav_accountability_brief">AI Brief</button>
+                    <button class="nav-dropdown-link" data-panel="accountability" data-i18n="nav_accountability">Political Accountability</button>
+                    <button class="nav-dropdown-link" data-panel="accountability-brief" data-i18n="nav_accountability_brief">Accountability Brief</button>
                     <button class="nav-dropdown-link" data-panel="progress" data-i18n="nav_progress">Clean Air Wins</button>
                 </div>
             </div>
@@ -2949,7 +2949,7 @@ body {
                     <button class="nav-dropdown-link" data-panel="voices" data-i18n="nav_voices">Citizen Voices</button>
                     <button class="nav-dropdown-link" data-panel="workshops" data-i18n="nav_workshops">Workshops</button>
                     <button class="nav-dropdown-link" data-panel="games" data-i18n="nav_games">Learning Games</button>
-                    <button class="nav-dropdown-link" data-panel="migration" data-i18n="nav_migration_short">Migration</button>
+                    <button class="nav-dropdown-link" data-panel="migration" data-i18n="nav_migration">Migration &amp; Displacement</button>
                 </div>
             </div>
             <div class="nav-item">
@@ -2962,7 +2962,7 @@ body {
                     <button class="nav-dropdown-link" data-panel="downloads" data-i18n="nav_downloads">Downloads</button>
                     <button class="nav-dropdown-link" data-panel="social-feed" data-i18n="nav_social_feed">Social Media Feed</button>
                     <button class="nav-dropdown-link" data-panel="live-news" data-i18n="nav_live_news">Live News</button>
-                    <button class="nav-dropdown-link" data-panel="about">About &amp; Changelog</button>
+                    <button class="nav-dropdown-link" data-panel="about" data-i18n="nav_about">About</button>
                 </div>
             </div>
         </div>
@@ -3188,7 +3188,7 @@ body {
                     </div>
                     <div class="quick-link" onclick="showPanel('school-closure')">
                         <div class="quick-link-icon" style="background: #F5F3FF; color: #7C3AED;"><span class="si si-library" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_school_t">School Status</h4><p data-i18n="ql_school_d">GRAP predictor</p></div>
+                        <div><h4 data-i18n="ql_school_t">School Status</h4><p data-i18n="ql_school_d">School closure forecast</p></div>
                     </div>
                 </div>
                 <div class="grid-4 mt-2">
@@ -3365,7 +3365,7 @@ body {
                 </div>
                 <div>
                     <div class="footer-title" data-i18n="footer_tools_action">Tools & Action</div>
-                    <a class="footer-link" href="#" onclick="showPanel('tools');return false;">RTI Templates</a>
+                    <a class="footer-link" href="#" onclick="showPanel('rti-assistant');return false;">RTI Templates</a>
                     <a class="footer-link" href="#" onclick="showPanel('citizen-action');return false;">Citizen Action</a>
                     <a class="footer-link" href="#" onclick="showPanel('resources');return false;">Resources</a>
                     <a class="footer-link" href="#" onclick="showPanel('downloads');return false;">Downloads</a>
@@ -3488,12 +3488,12 @@ body {
             // Dropdown items
             dd_health: "Health Impact", dd_economic: "Economic Cost", dd_children: "Children's Health",
             dd_indoor: "Indoor Air", dd_trends: "Historical Trends",
-            dd_compare: "City Comparison", dd_map: "Live Map", dd_forecast: "AQI Forecast",
-            dd_policy: "Policy Tracker", dd_budget: "Budget Tracker", dd_accountability: "Political",
+            dd_compare: "City Comparison", dd_map: "Live Map", dd_forecast: "Air Quality Forecast",
+            dd_policy: "Policy Tracker", dd_budget: "Budget Tracker", dd_accountability: "Political Accountability",
             dd_corporate: "Industrial Sources", dd_mission: "Mission Tracker", dd_progress: "Clean Air Wins",
             dd_actions: "Take Action", dd_citizen: "Citizen Plan", dd_legal: "Legal Framework",
-            dd_voices: "Citizen Voices", dd_migration: "Migration",
-            dd_tools: "Tools", dd_resources: "Reading List", dd_downloads: "Downloads", dd_about: "About & Changelog",
+            dd_voices: "Citizen Voices", dd_migration: "Migration & Displacement",
+            dd_tools: "Tools", dd_resources: "Reading List", dd_downloads: "Downloads", dd_about: "About",
             // Mobile nav groups
             navgroup_myair: "My Air", navgroup_citydata: "City Data", navgroup_health: "Health & Trends",
             mg_data: "Data & Analysis", mg_monitor: "Monitoring", mg_account: "Accountability",
@@ -6905,8 +6905,8 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
         { id: 'trends', title: 'Historical Trends', desc: 'Timeline 1981 to present, key milestones', keywords: 'history timeline trends historical air act 1981 ncap' },
         { id: 'compare', title: 'City Comparison', desc: 'Metro AQI rankings, live data table', keywords: 'city cities comparison metro delhi mumbai kolkata bangalore chennai' },
         { id: 'map', title: 'Live Map', desc: 'Interactive station markers, real-time', keywords: 'map live stations markers leaflet geographic' },
-        { id: 'forecast', title: 'AQI Forecast', desc: 'Predictive models, seasonal patterns', keywords: 'forecast prediction weather seasonal imd winter' },
-        { id: 'policy', title: 'Policy Effectiveness', desc: 'NCAP targets vs reality, GRAP, CAQM', keywords: 'policy ncap grap caqm government regulation target effectiveness' },
+        { id: 'forecast', title: 'Air Quality Forecast', desc: 'Predictive models, seasonal patterns', keywords: 'forecast prediction weather seasonal imd winter' },
+        { id: 'policy', title: 'Policy Tracker', desc: 'NCAP targets vs reality, GRAP, CAQM', keywords: 'policy ncap grap caqm government regulation target effectiveness' },
         { id: 'budget', title: 'Budget Tracker', desc: 'NCAP funds, utilisation rates, spending', keywords: 'budget money funding ncap finance commission spending utilisation' },
         { id: 'accountability', title: 'Political Accountability', desc: 'MoEFCC, state compliance, RTI', keywords: 'political accountability moefcc minister state compliance rti parliament' },
         { id: 'corporate', title: 'Industrial Sources', desc: 'Factory emissions, corporate responsibility', keywords: 'industry industrial factory corporate emissions thermal power plant brick kiln' },
@@ -6931,12 +6931,12 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
         { id: 'exposure-report', title: 'Exposure Report', desc: 'Personal annual air pollution exposure analysis', keywords: 'exposure report personal annual cigarette life expectancy' },
         { id: 'rti-assistant', title: 'RTI Assistant', desc: 'Generate ready-to-file RTI applications', keywords: 'rti right information filing application pollution board' },
         { id: 'purifier-calc', title: 'Purifier Calculator', desc: 'Find the right air purifier for your room', keywords: 'purifier calculator cadr room filter air cleaner' },
-        { id: 'hyperlocal', title: 'Hyperlocal', desc: 'Station-level air quality within your city', keywords: 'hyperlocal station neighborhood local area monitoring' },
+        { id: 'hyperlocal', title: 'My Neighbourhood', desc: 'Station-level air quality within your city', keywords: 'hyperlocal station neighborhood local area monitoring' },
         { id: 'pollution-calendar', title: 'Pollution Calendar', desc: 'Seasonal pollution sources and patterns', keywords: 'calendar seasonal stubble burning diwali monsoon winter inversion' },
         { id: 'migration-calc', title: 'Migration Calculator', desc: 'Health benefit of relocating to cleaner city', keywords: 'migration calculator relocate move city health benefit' },
-        { id: 'scorecards', title: 'Scorecards', desc: 'City accountability report cards', keywords: 'scorecard accountability grade report card ncap target' },
+        { id: 'scorecards', title: 'City Scorecards', desc: 'City accountability report cards', keywords: 'scorecard accountability grade report card ncap target' },
         { id: 'data-archive', title: 'Data Archive', desc: 'Download historical air quality datasets', keywords: 'data archive download historical dataset csv json research' },
-        { id: 'correlations', title: 'Correlations', desc: 'Explore pollution vs health/economic data', keywords: 'correlation scatter plot health deaths economic relationship' },
+        { id: 'correlations', title: 'Pollution Correlations', desc: 'Explore pollution vs health/economic data', keywords: 'correlation scatter plot health deaths economic relationship' },
         { id: 'glossary', title: 'Glossary', desc: 'Air quality terms and acronyms explained', keywords: 'glossary terms definitions acronym explanation pm25 aqi grap ncap who meaning' }
     ];
 
@@ -14400,7 +14400,7 @@ Signature: _______________</div>
 <!-- ═══ HYPERLOCAL COMPARISON ═══ -->
 <template id="tmpl-hyperlocal">
     <div class="container">
-        <h2 style="font-family: var(--serif); font-size: 1.75rem; margin-bottom: 0.5rem;">Hyperlocal Air Quality</h2>
+        <h2 style="font-family: var(--serif); font-size: 1.75rem; margin-bottom: 0.5rem;">My Neighbourhood</h2>
         <p style="color: var(--text-2); margin-bottom: 1.5rem;">Compare monitoring stations within your city. Not all neighborhoods breathe the same air.</p>
 
         <div class="card mb-3">
@@ -15487,7 +15487,7 @@ const ROLE_CONFIG = {
             { panel: 'go-outside', title: 'Outdoor Work Advisory', desc: 'Is it safe for outdoor workers?' },
             { panel: 'aqi-alerts', title: 'AQI Alerts', desc: 'Daily digest for your city' },
             { panel: 'corporate', title: 'Industrial Sources', desc: 'Compliance & emission data' },
-            { panel: 'forecast', title: 'AQI Forecast', desc: 'Plan ahead with predictions' },
+            { panel: 'forecast', title: 'Air Quality Forecast', desc: 'Plan ahead with predictions' },
             { panel: 'trends', title: 'Historical Trends', desc: 'Seasonal patterns for planning' }
         ]
     }


### PR DESCRIPTION
## Summary
Full audit of all 44 panel labels across desktop nav, mobile nav, panel headings, search palette, footer links, and quick-link cards. 17 fixes:

**Critical:** Footer "RTI Templates" link → wrong panel (`tools` → `rti-assistant`)

**Cryptic labels renamed:**
| Before | After |
|---|---|
| AI Brief | Accountability Brief |
| Political | Political Accountability |
| Correlations | Pollution Correlations |
| Scorecards | City Scorecards |
| GRAP predictor | School closure forecast |

**Mismatches fixed:** Hyperlocal heading → My Neighbourhood, AQI Forecast → Air Quality Forecast, Migration/About aligned across desktop+mobile

**Also:** 3 missing `data-i18n` attributes added, search palette synced, i18n strings updated.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_