### PR TITLE
fix: site-wide formatting sweep — grid fixes + table wraps

### DIFF
--- a/index.html
+++ b/index.html
@@ -6610,6 +6610,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                     ${isImprovement ? 'Life expectancy gain per person' : 'Life expectancy would DECREASE'}
                 </div>
             </div>
+            <div class="table-wrap">
             <table class="data-table" style="font-size: 0.8rem;">
                 <thead><tr><th></th><th>${fromName}</th><th>${toName}</th><th>Difference</th></tr></thead>
                 <tbody>
@@ -6619,6 +6620,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                     <tr><td>Family Impact (${family} people)</td><td colspan="2"></td><td style="font-weight: 700; color: ${isImprovement ? 'var(--green-600)' : 'var(--red)'};">${isImprovement ? '+' : ''}${(lifeGain * family).toFixed(1)} life-years</td></tr>
                 </tbody>
             </table>
+            </div>
             <div class="alert ${isImprovement ? 'alert-success' : 'alert-danger'} mt-2" style="font-size: 0.8rem;">
                 ${isImprovement
                     ? `Moving from ${fromName} to ${toName} would reduce your family's PM2.5 exposure by ${percentBetter}%, equivalent to gaining ${(lifeGain * family).toFixed(1)} life-years collectively.`
@@ -11995,7 +11997,7 @@ Signature: _______________</div>
                     <h3 style="font-family: var(--serif); font-size: 1.25rem; margin: 0; color: var(--ink);">Latest from Zotero</h3>
                     <span id="zotero-count" class="badge badge-info" style="margin-left: 0.25rem;"></span>
                 </div>
-                <div id="zotero-items" class="grid-3" style="gap: 0.75rem;"></div>
+                <div id="zotero-items" class="grid-2" style="gap: 0.75rem;"></div>
             </div>
             <div id="zotero-loading" style="display: none; text-align: center; padding: 1.5rem; margin-bottom: 2rem;">
                 <div style="display: inline-block; width: 24px; height: 24px; border: 3px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
@@ -12034,7 +12036,7 @@ Signature: _______________</div>
 
                     <!-- New May 2026 additions -->
                     <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); margin-bottom: 0.5rem; font-weight: 700;">Added this cycle (Apr&ndash;May 2026)</div>
-                    <div class="grid-3" style="gap: 0.75rem; margin-bottom: 1.25rem;">
+                    <div class="grid-2" style="gap: 0.75rem; margin-bottom: 1.25rem;">
                         <div class="resource-card" data-keywords="crea monthly snapshot april 2026 khora modinagar caaqms ranking india">
                             <a href="https://energyandcleanair.org/india-monthly-ambient-air-quality-snapshot-april-2026/" target="_blank" rel="noopener">
                                 <div class="resource-type">Monthly Snapshot <span class="badge badge-danger">May 2026</span></div>
@@ -12074,7 +12076,7 @@ Signature: _______________</div>
 
                     <!-- Anchor reports (carried over from v26.5.2) -->
                     <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); margin-bottom: 0.5rem; font-weight: 700;">Anchor reports</div>
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="lancet countdown 2025 health climate india pm25 mortality 1.72 million">
                             <a href="https://www.thelancet.com/countdown-health-climate" target="_blank" rel="noopener">
                                 <div class="resource-type">Annual Report <span class="badge badge-danger">May 2026</span></div>
@@ -12129,7 +12131,7 @@ Signature: _______________</div>
                     </span>
                 </div>
                 <div class="card-body">
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="iqair world air quality report 2024 india delhi">
                             <a href="https://www.iqair.com/world-air-quality-report" target="_blank">
                                 <div class="resource-type">Annual Report <span class="badge badge-danger">2024</span></div>
@@ -12184,7 +12186,7 @@ Signature: _______________</div>
                     </span>
                 </div>
                 <div class="card-body">
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="cse centre science environment sunita narain anumita roychowdhury">
                             <a href="https://www.cseindia.org/" target="_blank">
                                 <div class="resource-type">Research Org <span class="badge badge-success">Key</span></div>
@@ -12243,7 +12245,7 @@ Signature: _______________</div>
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem; padding: 0.75rem; background: rgba(124,58,237,0.05); border-radius: 6px;">
                         <strong>Collaboration with Dr. Sarath Guttikunda:</strong> India's most comprehensive air quality research repository. All data freely available — supporting "one topic, one voice, one tone, one ask."
                     </p>
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="40 by 2040 delhi target cost inaction delay calculator">
                             <a href="https://urbanemissions.info/blog-pieces/40-by-2040-cost-of-inaction-and-delays-in-reaching-delhis-air-quality-target/" target="_blank">
                                 <div class="resource-type">Interactive Tool <span class="badge badge-danger">KEY</span></div>
@@ -12301,7 +12303,7 @@ Signature: _______________</div>
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem; padding: 0.75rem; background: rgba(27,107,74,0.05); border-radius: 6px;">
                         Comprehensive resources for citizen advocacy — emergency measures, legal framework, transport policy, and analysis.
                     </p>
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="emcap emergency measures citizens action plan winter transport construction">
                             <a href="https://caqm.nic.in/WriteReadData/LINKS/GRAP2024b7a80bff-e2e6-49e1-a191-28bfe6d1ba52.pdf" target="_blank">
                                 <div class="resource-type">Citizen Action <span class="badge badge-danger">Essential</span></div>
@@ -12590,7 +12592,7 @@ Signature: _______________</div>
             <div class="card mb-2 card-accent-blue" data-resource-category="policy action">
                 <div class="card-header" style="background: rgba(59,130,246,0.06);"><span class="card-title" style="color: #2563EB;"> Policy Research &amp; Climate Events (2025-26)</span></div>
                 <div class="card-body resource-list">
-                    <div class="grid-3" style="gap: 0.75rem;">
+                    <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="impri ncap clean air programme policy enforcement">
                             <a href="https://www.impriindia.com/insights/policy-update/national-clear-air-programme/" target="_blank">
                                 <div class="resource-type">Policy Analysis <span class="badge badge-info">IMPRI</span></div>
@@ -14226,6 +14228,7 @@ Signature: _______________</div>
         <div class="card mt-3">
             <div class="card-header"><span class="card-title">GRAP Stages & School Impact</span></div>
             <div class="card-body">
+                <div class="table-wrap">
                 <table class="data-table" style="font-size: 0.8rem;">
                     <thead><tr><th>Stage</th><th>AQI Range</th><th>School Action</th><th>Other Measures</th></tr></thead>
                     <tbody>
@@ -14235,6 +14238,7 @@ Signature: _______________</div>
                         <tr><td><span class="badge" style="background: #7C3AED; color: white;">IV</span></td><td>450+</td><td>All schools closed, online classes mandatory</td><td>Truck ban, 50% WFH for offices</td></tr>
                     </tbody>
                 </table>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
Site-wide formatting sweep fixing cramped layouts:

**8 grid-3 → grid-2** (resource cards with long titles/descriptions were wrapping every 2-3 words):
- Zotero items, May 2026 updates, Anchor reports, 2025-26 reports, Expert orgs, UrbanEmissions, Citizen action docs, Policy Research & Climate Events

**2 table-wrap additions** (tables that would overflow on mobile):
- Migration calculator comparison table
- GRAP Stages & School Impact table

29 grid-3 instances retained (stat cards, short content — appropriate). 16 grid-4 instances verified.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_