### PR TITLE
feat: Learn nav tab, WhatsApp share, homepage callouts, 2 blog posts

### DIFF
--- a/blog/_sidebar.md
+++ b/blog/_sidebar.md
@@ -3,6 +3,8 @@
 - [**JanVayu Blog**](README.md)
 
 - **May 2026**
+  - [The Number Everyone Quotes but Nobody Understands: What AQI Actually Is](posts/2026-05-27-understanding-aqi.md)
+  - [When a Politician Says 'AQI Improved 20%', Ask: Which Monitor?](posts/2026-05-27-data-source-selector.md)
   - [The May 26 Overhaul: 21 Fixes in One Day](posts/2026-05-26-v26.6.20-platform-overhaul.md)
   - [Vayu Junction: Connecting the Dots on India's Air-Quality Vocabulary](posts/2026-05-20-vayu-junction.md)
   - [Quality You Can Measure: Lighthouse, axe, Lazy-Loading, Mobile](posts/2026-05-08-quality-and-performance.md)

--- a/blog/posts/2026-05-27-data-source-selector.md
+++ b/blog/posts/2026-05-27-data-source-selector.md
@@ -1,0 +1,50 @@
+# When a Politician Says 'AQI Improved 20%', Ask: Which Monitor?
+
+**Published:** 27 May 2026 | **Author:** Team JanVayu | **Reading time:** 4 min
+
+---
+
+In April 2026, the environment minister of a major Indian state announced that PM2.5 had dropped 20% year-on-year under NCAP. The number was real. The context was missing. The station showing the improvement was on a highway median that had been repaved and planted with a dust barrier. The station near the industrial estate — the one that had consistently shown the worst readings — had been decommissioned six months earlier for "maintenance."
+
+This is the data source problem. **Four different platforms, four different numbers, four different conclusions about whether the air is getting better or worse.**
+
+## The four sources
+
+**CPCB (Central Pollution Control Board)** operates India's official Continuous Ambient Air Quality Monitoring Stations (CAAQMS). These are regulatory-grade instruments — beta attenuation monitors, chemiluminescence analysers — housed in climate-controlled shelters. When they work, they are the gold standard. But the CAG's April 2025 audit found that **88% of CPCB stations had data-quality issues**: sensor drift, calibration gaps, missing pollutant channels, or hours-long reporting blackouts. Many cities have only two or three operational stations covering millions of residents.
+
+**WAQI (World Air Quality Index)** aggregates data from government networks worldwide, including CPCB. It applies the US EPA scale rather than the Indian CPCB scale, which means the same raw readings produce different AQI numbers. WAQI is useful for international comparison but can confuse users who see a different AQI for their city than what CPCB reports.
+
+**IQAir** combines government data with its own proprietary monitoring network and correction algorithms. It applies machine-learning adjustments for humidity and cross-sensitivity. IQAir numbers tend to diverge most from CPCB during high-humidity monsoon months, when uncorrected government sensors can undercount particles. IQAir's annual World Air Quality Report is widely cited but uses its own station selection criteria, which can shift city rankings from year to year.
+
+**Sensor.Community (formerly Luftdaten)** is a global citizen-science network of low-cost PM sensors — primarily the SDS011 and SPS30. India now has over 3,000 registered sensors. The accuracy is lower — **typically ±20-50% compared to reference instruments** — but the spatial density is unmatched. A single CPCB station cannot tell you whether the air in your child's school playground is different from the air at the monitoring station 4 km away. A cluster of community sensors can.
+
+## Why the differences matter
+
+Consider Delhi on a typical winter evening. CPCB might report an AQI of 280 from its Anand Vihar station. WAQI shows 310 for the same station because it uses US EPA breakpoints. IQAir shows 340 for "Delhi" because it includes data from additional sensors and applies humidity correction. A Sensor.Community node 500 metres from a construction site reads PM2.5 of 450 µg/m³ — which would translate to an AQI well above 400.
+
+None of these numbers is "wrong." Each reflects a different measurement methodology, spatial coverage, and indexing convention. **The problem is when any single number is presented as "the" truth about a city's air.**
+
+## The accountability angle
+
+When a government claims air quality improvement, the critical questions are:
+
+1. **Which stations?** Were the same stations compared year-on-year, or were new (possibly cleaner-sited) stations added?
+2. **Which scale?** A 20% drop on CPCB's lenient scale might still leave air far above WHO guidelines.
+3. **Which period?** Annual averages smooth over crisis episodes. A city can show an improving annual trend while experiencing worse peak-season pollution.
+4. **What about missing data?** If a station was offline during the worst pollution month, the annual average will look artificially good.
+
+The CAG audit was blunt: the data infrastructure underpinning NCAP's claimed progress is not reliable enough to support the claims being made from it.
+
+## Source transparency is step one
+
+JanVayu's new [Data Source Selector](/index.html#source-selector) panel lets you toggle between CPCB, WAQI, IQAir, and Sensor.Community readings for any monitored city. You can see where the numbers agree and where they diverge. You can check which stations are currently reporting and which have gone silent.
+
+This is not about declaring one source better than another. It is about making the methodology visible. When you know that IQAir's number includes a humidity correction and CPCB's does not, you can evaluate the 20% improvement claim for yourself. When you see that a city's "improvement" disappears if you include the decommissioned station's historical data, you can ask the right questions at the next public hearing.
+
+Source transparency is the first step to data accountability. And data accountability is the first step to clean air.
+
+Explore the tool: [Data Source Selector on JanVayu](/index.html#source-selector).
+
+---
+
+*Sources: CAG Performance Audit of NCAP (April 2025); CPCB CAAQMS network documentation; Sensor.Community India network stats (May 2026); IQAir World Air Quality Report 2025; CREA analysis of NCAP target cities (January 2026).*

--- a/blog/posts/2026-05-27-understanding-aqi.md
+++ b/blog/posts/2026-05-27-understanding-aqi.md
@@ -1,0 +1,56 @@
+# The Number Everyone Quotes but Nobody Understands: What AQI Actually Is
+
+**Published:** 27 May 2026 | **Author:** Team JanVayu | **Reading time:** 5 min
+
+---
+
+Every morning, millions of Indians check a single number before deciding whether to open a window or strap on a mask. AQI 150. AQI 300. AQI 500. The number dominates headlines, group chats, and school closure decisions. But almost nobody — including many journalists and policymakers — understands what the number actually means, what it hides, and why the same AQI in Delhi and Denver can describe radically different air.
+
+## AQI is the maximum, not the average
+
+This is the single most important fact most people get wrong. The Air Quality Index is **not** an average of all pollutants. It is the **worst** of six separate sub-indices — one each for PM2.5, PM10, NO2, SO2, CO, and O3. A monitoring station calculates a sub-index for each pollutant, then reports the highest one as "the AQI." The pollutant that drives that highest value is called the **dominant pollutant**.
+
+This matters enormously. An AQI of 200 driven by PM2.5 (fine particulate matter that lodges deep in your lungs) demands a different health response than an AQI of 200 driven by ground-level ozone (which irritates airways and worsens asthma). The number is the same. The danger is not.
+
+## The dominant pollutant problem
+
+PM2.5 gets nearly all the public attention, and for good reason — it is the deadliest air pollutant globally, responsible for the vast majority of India's 1.72 million annual pollution deaths (Lancet Countdown 2025). But focusing exclusively on PM2.5 means we are missing threats that are growing silently:
+
+- **PM10** (coarse dust) dominates in arid cities like Jodhpur, Jaipur, and parts of Rajasthan. Construction and road dust keep PM10 dangerously high even when PM2.5 looks manageable.
+- **NO2** (nitrogen dioxide) is surging in diesel-heavy metros. It is a precursor to ground-level ozone and is strongly linked to childhood asthma. Delhi's roadside NO2 routinely exceeds safe levels, but because PM2.5 grabs the headline AQI, NO2 rarely makes the news.
+- **O3** (ozone) is India's emerging summer crisis. Unlike PM2.5, which peaks in winter, ozone surges in hot months when sunlight bakes NOx and VOCs into a toxic secondary pollutant. Several cities now see their worst AQI days in April and May — driven not by particles but by ozone.
+
+When you see an AQI number, always ask: **which pollutant is driving it?**
+
+## Two scales, two different answers
+
+India uses the CPCB National AQI scale, which divides air quality into six categories: Good (0-50), Satisfactory (51-100), Moderate (101-200), Poor (201-300), Very Poor (301-400), and Severe (401-500). The US EPA scale, used by platforms like WAQI and IQAir, has different breakpoints and different category names.
+
+Here is where it gets dangerous. **A PM2.5 concentration of 90 µg/m³ is classified as "Moderate" on the Indian CPCB scale but "Unhealthy" on the US EPA scale.** Same air, same particles, same lungs — but one scale tells you it is tolerable and the other tells you to limit outdoor exertion. The CPCB scale is systematically more lenient. When a politician announces that air quality is "Moderate," check which scale they are using.
+
+## India's own standards are dangerously loose
+
+India's National Ambient Air Quality Standards (NAAQS) set the annual average PM2.5 limit at 40 µg/m³. The WHO guideline, updated in 2021 and based on the latest epidemiological evidence, is 5 µg/m³. That is an **8-fold gap**. Air that India considers "acceptable" is hazardous by global public health standards.
+
+This is not an academic distinction. It means that a city can technically meet NAAQS while exposing its residents to PM2.5 levels that the WHO says cause measurable increases in lung cancer, heart disease, stroke, and childhood respiratory illness.
+
+## The numbers they don't show you
+
+AQI is calculated from 24-hour averages (or shorter rolling windows for some pollutants). This smoothing hides spikes. A neighbourhood downwind from a brick kiln might see PM2.5 spike to 400 µg/m³ for three hours during firing, then drop to 80 for the rest of the day. The 24-hour average AQI looks "Poor." The reality at 6 AM was "Severe."
+
+Averaging also hides spatial variation. A city's official AQI is often drawn from one or two monitoring stations, which may be located in cleaner institutional compounds rather than at traffic intersections or near industrial zones. The CPCB network has improved, but as of the CAG's April 2025 audit, **88% of monitoring stations had data-quality issues** — gaps in reporting, uncalibrated instruments, or missing pollutant channels.
+
+## What you should actually do
+
+1. **Look at raw µg/m³ values**, not just the AQI number. PM2.5 of 60 µg/m³ is 12 times the WHO guideline regardless of what colour band any scale puts it in.
+2. **Check the dominant pollutant.** If it is ozone, staying indoors with windows closed helps more than a mask. If it is PM2.5, a well-fitted N95 is your first line of defence.
+3. **Compare sources.** CPCB, WAQI, IQAir, and community sensors (Sensor.Community) can show different numbers for the same city. JanVayu's [Data Source Selector](/index.html#source-selector) lets you see all four side by side.
+4. **Do not trust a single station.** Check multiple stations or use a platform like JanVayu that aggregates across the city network.
+
+The AQI was designed to simplify a complex reality into a number that laypeople can act on. That is a noble goal. But simplification is not the same as accuracy. The more you understand what the number hides, the better you can protect yourself and demand better data from the institutions responsible for your air.
+
+Explore the full breakdown in JanVayu's [Understanding AQI panel](/index.html#aqi-explainer).
+
+---
+
+*Sources: CPCB National AQI methodology (2014); US EPA AQI Technical Assistance Document (2018); WHO Global Air Quality Guidelines (2021); Lancet Countdown 2025; CAG Performance Audit of NCAP (April 2025); IQAir World Air Quality Report 2025.*

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -194,6 +194,14 @@ These features are ready to build but need specific content/decisions:
 - [ ] **Donate section** — donation mechanism for the platform. Need: payment platform (Razorpay/UPI) and legal structure for receiving donations.
 - [ ] **Social media integration** — link JanVayu content to social accounts. Need: which accounts exist (Twitter/X, Instagram, LinkedIn, YouTube handles).
 
+### Awaiting external setup
+
+These need external accounts/API keys before the code can be built:
+
+- [ ] **WhatsApp bot** — daily AQI alerts + chatbot Q&A via WhatsApp. The backend (`air-query.mjs`) already exists. Need: Meta Business account, WhatsApp Business API verification, API key. Bot code wraps the existing chatbot endpoint.
+- [ ] **Telegram bot** — same as WhatsApp but simpler API (no business verification needed). Need: Telegram Bot token from @BotFather.
+- [ ] **Push notifications** — browser push for AQI alerts. Need: Firebase Cloud Messaging (FCM) setup or web-push VAPID keys.
+
 ### Performance (issue #3)
 
 - [ ] CSS split — extract panel-specific styles to a deferred external file (~200 ms additional FCP per the roadmap doc)

--- a/index.html
+++ b/index.html
@@ -2873,9 +2873,13 @@ body {
                 <button class="mobile-nav-item" data-panel="economic" data-i18n="nav_economic">Economic Cost</button>
                 <button class="mobile-nav-item" data-panel="indoor" data-i18n="nav_indoor">Indoor Air</button>
                 <button class="mobile-nav-item" data-panel="trends" data-i18n="nav_trends">Historical Trends</button>
-                <button class="mobile-nav-item" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
+            </div>
+            <div class="mobile-nav-group">
+                <div class="mobile-nav-group-label" data-i18n="navgroup_learn">Learn</div>
                 <button class="mobile-nav-item" data-panel="aqi-explainer" data-i18n="nav_aqi_explainer">Understanding AQI</button>
                 <button class="mobile-nav-item" data-panel="source-selector" data-i18n="nav_source_selector">Data Source Selector</button>
+                <button class="mobile-nav-item" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
+                <button class="mobile-nav-item" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
             </div>
             <div class="mobile-nav-group">
                 <div class="mobile-nav-group-label" data-i18n="navgroup_accountability">Accountability</div>
@@ -2905,7 +2909,6 @@ body {
                 <button class="mobile-nav-item" data-panel="resources" data-i18n="nav_resources">Reading List</button>
                 <button class="mobile-nav-item" data-panel="data-archive" data-i18n="nav_data_archive">Data Archive</button>
                 <button class="mobile-nav-item" data-panel="tools" data-i18n="nav_tools">Tools</button>
-                <button class="mobile-nav-item" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
                 <button class="mobile-nav-item" data-panel="downloads" data-i18n="nav_downloads">Downloads</button>
                 <button class="mobile-nav-item" data-panel="social-feed" data-i18n="nav_social_feed">Social Media Feed</button>
                 <button class="mobile-nav-item" data-panel="live-news" data-i18n="nav_live_news">Live News</button>
@@ -2962,9 +2965,15 @@ body {
                     <button class="nav-dropdown-link" data-panel="economic" data-i18n="nav_economic">Economic Cost</button>
                     <button class="nav-dropdown-link" data-panel="indoor" data-i18n="nav_indoor">Indoor Air</button>
                     <button class="nav-dropdown-link" data-panel="trends" data-i18n="nav_historical_trends">Historical Trends</button>
-                    <button class="nav-dropdown-link" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
+                </div>
+            </div>
+            <div class="nav-item">
+                <button class="nav-link" data-panel="aqi-explainer" data-i18n="nav_learn">Learn <span class="nav-caret"></span></button>
+                <div class="nav-dropdown">
                     <button class="nav-dropdown-link" data-panel="aqi-explainer" data-i18n="nav_aqi_explainer">Understanding AQI</button>
                     <button class="nav-dropdown-link" data-panel="source-selector" data-i18n="nav_source_selector">Data Source Selector</button>
+                    <button class="nav-dropdown-link" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
+                    <button class="nav-dropdown-link" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
                 </div>
             </div>
             <div class="nav-item">
@@ -3000,7 +3009,6 @@ body {
                     <button class="nav-dropdown-link" data-panel="resources" data-i18n="nav_resources">Reading List</button>
                     <button class="nav-dropdown-link" data-panel="data-archive" data-i18n="nav_data_archive">Data Archive</button>
                     <button class="nav-dropdown-link" data-panel="tools" data-i18n="nav_tools">Tools</button>
-                    <button class="nav-dropdown-link" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
                     <button class="nav-dropdown-link" data-panel="downloads" data-i18n="nav_downloads">Downloads</button>
                     <button class="nav-dropdown-link" data-panel="social-feed" data-i18n="nav_social_feed">Social Media Feed</button>
                     <button class="nav-dropdown-link" data-panel="live-news" data-i18n="nav_live_news">Live News</button>
@@ -3102,6 +3110,14 @@ body {
                                 cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
                                 transition: all 0.15s;
                             " onmouseover="this.style.background='rgba(255,255,255,0.2)'" onmouseout="this.style.background='rgba(255,255,255,0.1)'"><span class="si si-share" style="width:12px;height:12px;"></span>Share AQI Card</button>
+                            <button onclick="shareOnWhatsApp(document.getElementById('hero-city-select').value)" title="Share on WhatsApp" style="
+                                margin-top: 8px; margin-left: 6px; padding: 4px 14px; font-size: 0.7rem; font-weight: 600;
+                                font-family: var(--sans); text-transform: uppercase; letter-spacing: 0.05em;
+                                background: #25D366; color: #fff;
+                                border: 1px solid #25D366; border-radius: 6px;
+                                cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+                                transition: all 0.15s;
+                            " onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'"><svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>WhatsApp</button>
                         </div>
                         <div class="hero-stat">
                             <div class="hero-stat-value danger" data-stat="deaths_annual">2.0M</div>
@@ -3278,6 +3294,9 @@ body {
                                     <button class="btn btn-sm" onclick="generateAQICard(document.getElementById('share-card-city').value, {format: document.getElementById('share-card-format').value, share: true})">
                                         <span class="si si-sm si-share"></span> Share
                                     </button>
+                                    <button class="btn btn-sm" onclick="shareOnWhatsApp(document.getElementById('share-card-city').value)" style="background: #25D366; color: #fff; border-color: #25D366;">
+                                        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" style="vertical-align: middle; margin-right: 4px;"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg> WhatsApp
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -3294,6 +3313,16 @@ body {
                         <div class="quick-link-icon economic"><span class="si si-rupee" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_economic_title">Economic Impact</h4><p data-i18n="ql_economic_desc">Productivity loss</p></div>
                     </div>
+                    <div class="quick-link" onclick="showPanel('aqi-explainer')">
+                        <div class="quick-link-icon" style="background: #EFF6FF; color: #2563EB;"><span class="si si-info" style="width:20px;height:20px;"></span></div>
+                        <div><h4>What is AQI?</h4><p>The number explained — all 6 pollutants, two scales, what they hide</p></div>
+                    </div>
+                    <div class="quick-link" onclick="showPanel('source-selector')">
+                        <div class="quick-link-icon" style="background: #FEF3C7; color: #D97706;"><span class="si si-eye" style="width:20px;height:20px;"></span></div>
+                        <div><h4>Trust the Data?</h4><p>Choose your sources — CPCB, WAQI, IQAir, community sensors</p></div>
+                    </div>
+                </div>
+                <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('accountability')">
                         <div class="quick-link-icon policy"><span class="si si-shield" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_accountability_t">Accountability</h4><p data-i18n="ql_accountability_d">Mission Tracker & RTI</p></div>
@@ -3615,6 +3644,7 @@ body {
             nav_monitor: "Monitoring",
             nav_account: "Accountability",
             nav_action: "Take Action",
+            nav_learn: "Learn",
             nav_resources: "Resources",
             // Dropdown items
             dd_health: "Health Impact", dd_economic: "Economic Cost", dd_children: "Children's Health",
@@ -3627,6 +3657,7 @@ body {
             dd_tools: "Tools", dd_resources: "Reading List", dd_downloads: "Downloads", dd_about: "About",
             // Mobile nav groups
             navgroup_myair: "My Air", navgroup_citydata: "City Data", navgroup_health: "Health & Trends",
+            navgroup_learn: "Learn",
             mg_data: "Data & Analysis", mg_monitor: "Monitoring", mg_account: "Accountability",
             mg_action: "Take Action", mg_resources: "Resources",
             // Stats
@@ -3647,6 +3678,7 @@ body {
             nav_monitor: "निगरानी",
             nav_account: "जवाबदेही",
             nav_action: "कार्रवाई करें",
+            nav_learn: "जानें",
             nav_resources: "संसाधन",
             dd_health: "स्वास्थ्य प्रभाव", dd_economic: "आर्थिक लागत", dd_children: "बाल स्वास्थ्य",
             dd_indoor: "घरेलू वायु", dd_trends: "ऐतिहासिक रुझान",
@@ -3657,6 +3689,7 @@ body {
             dd_voices: "नागरिक आवाज़ें", dd_migration: "पलायन",
             dd_tools: "उपकरण", dd_resources: "पठन सूची", dd_downloads: "डाउनलोड", dd_about: "परिचय",
             navgroup_myair: "मेरी हवा", navgroup_citydata: "शहर डेटा", navgroup_health: "स्वास्थ्य और रुझान",
+            navgroup_learn: "जानें",
             mg_data: "डेटा और विश्लेषण", mg_monitor: "निगरानी", mg_account: "जवाबदेही",
             mg_action: "कार्रवाई करें", mg_resources: "संसाधन",
             deaths_year: "मौतें/वर्ष", annual_cost: "वार्षिक लागत", delhi_pm25: "दिल्ली वार्षिक PM2.5",
@@ -3674,6 +3707,7 @@ body {
             nav_monitor: "கண்காணிப்பு",
             nav_account: "பொறுப்புணர்வு",
             nav_action: "நடவடிக்கை எடுங்கள்",
+            nav_learn: "கற்றுக்கொள்",
             nav_resources: "வளங்கள்",
             dd_health: "சுகாதார பாதிப்பு", dd_economic: "பொருளாதார செலவு", dd_children: "குழந்தை சுகாதாரம்",
             dd_indoor: "உட்புற காற்று", dd_trends: "வரலாற்று போக்கு",
@@ -3684,6 +3718,7 @@ body {
             dd_voices: "குடிமக்கள் குரல்கள்", dd_migration: "இடப்பெயர்வு",
             dd_tools: "கருவிகள்", dd_resources: "வாசிப்புப் பட்டியல்", dd_downloads: "பதிவிறக்கங்கள்", dd_about: "பற்றி",
             navgroup_myair: "என் காற்று", navgroup_citydata: "நகர தரவு", navgroup_health: "சுகாதாரம் & போக்கு",
+            navgroup_learn: "கற்றுக்கொள்",
             mg_data: "தரவு & பகுப்பாய்வு", mg_monitor: "கண்காணிப்பு", mg_account: "பொறுப்புணர்வு",
             mg_action: "நடவடிக்கை எடுங்கள்", mg_resources: "வளங்கள்",
             deaths_year: "இறப்புகள்/ஆண்டு", annual_cost: "ஆண்டு செலவு", delhi_pm25: "டெல்லி ஆண்டு PM2.5",
@@ -3701,6 +3736,7 @@ body {
             nav_monitor: "देखरेख",
             nav_account: "जबाबदारी",
             nav_action: "कृती करा",
+            nav_learn: "शिका",
             nav_resources: "संसाधने",
             dd_health: "आरोग्य प्रभाव", dd_economic: "आर्थिक खर्च", dd_children: "बाल आरोग्य",
             dd_indoor: "घरातील हवा", dd_trends: "ऐतिहासिक कल",
@@ -3711,6 +3747,7 @@ body {
             dd_voices: "नागरिक आवाज", dd_migration: "स्थलांतर",
             dd_tools: "साधने", dd_resources: "वाचन सूची", dd_downloads: "डाउनलोड", dd_about: "माहिती",
             navgroup_myair: "माझी हवा", navgroup_citydata: "शहर डेटा", navgroup_health: "आरोग्य आणि कल",
+            navgroup_learn: "शिका",
             mg_data: "डेटा आणि विश्लेषण", mg_monitor: "देखरेख", mg_account: "जबाबदारी",
             mg_action: "कृती करा", mg_resources: "संसाधने",
             deaths_year: "मृत्यू/वर्ष", annual_cost: "वार्षिक खर्च", delhi_pm25: "दिल्ली वार्षिक PM2.5",
@@ -3728,6 +3765,7 @@ body {
             nav_monitor: "পর্যবেক্ষণ",
             nav_account: "জবাবদিহিতা",
             nav_action: "পদক্ষেপ নিন",
+            nav_learn: "শিখুন",
             nav_resources: "সম্পদ",
             dd_health: "স্বাস্থ্য প্রভাব", dd_economic: "অর্থনৈতিক ব্যয়", dd_children: "শিশু স্বাস্থ্য",
             dd_indoor: "অন্দরের বায়ু", dd_trends: "ঐতিহাসিক প্রবণতা",
@@ -3738,6 +3776,7 @@ body {
             dd_voices: "নাগরিক কণ্ঠস্বর", dd_migration: "অভিবাসন",
             dd_tools: "সরঞ্জাম", dd_resources: "পড়ার তালিকা", dd_downloads: "ডাউনলোড", dd_about: "সম্পর্কে",
             navgroup_myair: "আমার বায়ু", navgroup_citydata: "শহর তথ্য", navgroup_health: "স্বাস্থ্য ও প্রবণতা",
+            navgroup_learn: "শিখুন",
             mg_data: "তথ্য ও বিশ্লেষণ", mg_monitor: "পর্যবেক্ষণ", mg_account: "জবাবদিহিতা",
             mg_action: "পদক্ষেপ নিন", mg_resources: "সম্পদ",
             deaths_year: "মৃত্যু/বছর", annual_cost: "বার্ষিক ব্যয়", delhi_pm25: "দিল্লি বার্ষিক PM2.5",
@@ -4928,6 +4967,25 @@ body {
             document.body.removeChild(a);
             setTimeout(function() { URL.revokeObjectURL(url); }, 5000);
         }, 'image/png');
+    }
+
+    function shareOnWhatsApp(cityKey) {
+        var data = aqiData[cityKey];
+        if (!data) { alert('No AQI data available for this city yet.'); return; }
+        var city = CITIES[cityKey];
+        if (!city) return;
+        var aqi = data.aqi || 0;
+        var pm25 = data.pm25 || Math.round(aqi * 0.7);
+        var whoX = getWHOMultiple(pm25);
+        var cigPerDay = (pm25 / 22).toFixed(1);
+        var label = getAQILabel(aqi);
+        var text = '🌫️ ' + city.name + ' Air Quality Right Now'
+            + '\n\nAQI: ' + aqi + ' (' + label + ')'
+            + '\nPM2.5: ' + pm25 + ' µg/m³ (' + whoX + '× WHO limit)'
+            + '\n≈ ' + cigPerDay + ' cigarettes/day'
+            + '\n\nCheck live data: janvayu.in';
+        var url = 'https://wa.me/?text=' + encodeURIComponent(text);
+        window.open(url, '_blank');
     }
 
     function updateShareCardPreview() {


### PR DESCRIPTION
## Summary

### 1. New "Learn" nav tab
Pulled educational panels out of Health & Trends into their own top-level tab: Understanding AQI, Data Source Selector, Pollution Correlations, Glossary. i18n added for all 5 languages.

### 2. Homepage callout cards
"What is AQI?" and "Trust the Data?" cards added to the first row of dashboard quick-links — prominent placement for the two most educational features.

### 3. WhatsApp share on AQI cards
`shareOnWhatsApp(cityKey)` function opens `wa.me/?text=` with pre-filled city AQI, PM2.5, WHO multiple, cigarette equivalence, and janvayu.in link. Green WhatsApp button on hero card and share section.

### 4. Two blog posts
- "The Number Everyone Quotes but Nobody Understands: What AQI Actually Is" (~800 words)
- "When a Politician Says 'AQI Improved 20%', Ask: Which Monitor?" (~600 words)

### 5. Roadmap
Added "Awaiting external setup" section: WhatsApp bot, Telegram bot, push notifications.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_