### PR TITLE
chore: bump SW cache to v26.6.24

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-06-23"
-version: "26.6.23"
+date-released: "2026-06-24"
+version: "26.6.24"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260623-v26';
+const CACHE_NAME = 'ask-janvayu-20260624-v26';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.23",
+  "version": "26.6.24",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260623';
+const CACHE_VERSION = 'janvayu-20260624';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
Bump service worker cache to force browsers to pick up the redesigned AQI cards and all recent changes.

https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbxKGqWkkq2Y9sGes995VP)_