### PR TITLE
fix: restore Ask JanVayu chatbot (502) + add health monitor & CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,39 @@ jobs:
             exit 1
           fi
 
+  # Guard against the class of bug that took the chatbot (air-query) down for
+  # ~2 weeks in May 2026: declaring `__dirname`/`__filename` at the top level
+  # of a Netlify function. Netlify's esbuild bundler injects its own shims for
+  # those identifiers, so a manual `const __dirname = ...` is a redeclaration
+  # that throws "Identifier already declared" at load time → every request 502s.
+  guard-netlify-functions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Reject top-level __dirname / __filename redeclarations
+        run: |
+          MATCHES=$(grep -rnE '^[[:space:]]*(const|let|var)[[:space:]]+(__dirname|__filename)[[:space:]]*=' \
+                      netlify/functions || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::A Netlify function redeclares __dirname/__filename. This collides with the esbuild shim and 502s at load. Use new URL('./data/file.json', import.meta.url) instead."
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "OK — no __dirname/__filename redeclarations in netlify/functions"
+
+      - name: Syntax-check all functions
+        run: |
+          shopt -s nullglob
+          fail=0
+          for f in netlify/functions/*.mjs netlify/functions/*.js; do
+            if ! node --check "$f"; then
+              echo "::error file=$f::Syntax error"
+              fail=1
+            fi
+          done
+          exit $fail
+
   check-links:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/function-health.yml
+++ b/.github/workflows/function-health.yml
@@ -1,0 +1,102 @@
+name: Function Health Monitor
+
+# Probes the live site + serverless functions every 15 minutes and keeps a
+# single tracking issue in sync with reality:
+#   - opens / comments on a "status: outage" issue when a function is DOWN
+#     (HTTP 5xx or unreachable — e.g. the air-query chatbot 502 of May 2026)
+#   - closes the issue automatically once everything recovers
+#
+# Probe details live in scripts/health-check.sh. POST probes use an empty body
+# so functions hit their own validation and spend no Groq tokens.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 minutes
+  workflow_dispatch:          # manual trigger
+    inputs:
+      base_url:
+        description: 'Base URL to probe (defaults to production)'
+        required: false
+        default: 'https://www.janvayu.in'
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: function-health
+  cancel-in-progress: false
+
+env:
+  OUTAGE_LABEL: 'status: outage'
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run health check
+        id: check
+        run: |
+          BASE_URL="${{ github.event.inputs.base_url || 'https://www.janvayu.in' }}" \
+            bash scripts/health-check.sh report.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Ensure outage label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "$OUTAGE_LABEL" --color B60205 \
+            --description "An automated health check found a live endpoint down" \
+            --force 2>/dev/null || true
+
+      - name: Sync tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          DOWN="${{ steps.check.outputs.exit_code }}"
+
+          # Find an already-open outage issue, if any.
+          EXISTING=$(gh issue list --label "$OUTAGE_LABEL" --state open \
+                       --json number --jq '.[0].number // empty')
+
+          BODY_FILE=report.md
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          printf '\n\n[Workflow run](%s)\n' "$RUN_URL" >> "$BODY_FILE"
+
+          if [ "$DOWN" != "0" ]; then
+            if [ -n "$EXISTING" ]; then
+              echo "Outage ongoing — commenting on issue #$EXISTING"
+              gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+            else
+              echo "New outage — opening tracking issue"
+              gh issue create \
+                --title "🔴 Live function outage detected" \
+                --label "$OUTAGE_LABEL" \
+                --body-file "$BODY_FILE"
+            fi
+          else
+            if [ -n "$EXISTING" ]; then
+              echo "Recovered — closing issue #$EXISTING"
+              {
+                echo "## ✅ Recovered"
+                echo ""
+                echo "All monitored endpoints are healthy again. Closing automatically."
+                echo ""
+                cat "$BODY_FILE"
+              } > recovered.md
+              gh issue comment "$EXISTING" --body-file recovered.md
+              gh issue close "$EXISTING" --reason completed
+            else
+              echo "All healthy — nothing to do."
+            fi
+          fi
+
+      - name: Fail the job when endpoints are down
+        if: steps.check.outputs.exit_code != '0'
+        run: |
+          echo "::error::One or more live endpoints are DOWN — see the tracking issue."
+          exit 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -190,6 +190,40 @@
   status = 301
   force = true
 
+# Status page (force = true to override SPA fallback)
+[[redirects]]
+  from = "/status"
+  to = "/status/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/status/"
+  to = "/status/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/status/*"
+  to = "/status/:splat"
+  status = 200
+  force = true
+
+# Host-based routing for the status subdomain. Requires status.askjanvayu.in
+# to be added as a domain alias on the Netlify site with DNS pointing at it
+# (same mechanism as the janvayu.in -> www.janvayu.in redirect above).
+[[redirects]]
+  from = "https://status.askjanvayu.in/"
+  to = "/status/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://status.askjanvayu.in/*"
+  to = "/status/:splat"
+  status = 200
+  force = true
+
 # SPA fallback — must come AFTER specific file rules
 [[redirects]]
   from = "/*"

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -1,9 +1,12 @@
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const REF_DATA = JSON.parse(readFileSync(join(__dirname, 'data', 'reference-data.json'), 'utf8'));
+// Resolve the bundled data file relative to this module. We intentionally do
+// NOT declare `__dirname`/`__filename` here: Netlify's esbuild bundler injects
+// its own shims for those identifiers, and redeclaring them throws
+// "Identifier '__dirname' has already been declared" at load time (502).
+const REF_DATA = JSON.parse(
+  readFileSync(new URL('./data/reference-data.json', import.meta.url), 'utf8')
+);
 
 // Netlify Function: Natural Language Query Interface for JanVayu
 // Accepts a question + city, fetches live AQI, sends to Groq for analysis.

--- a/netlify/functions/reference-data.mjs
+++ b/netlify/functions/reference-data.mjs
@@ -10,11 +10,10 @@
 // having them hardcoded in air-query.mjs.
 
 import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// Do NOT declare `__dirname`/`__filename`: Netlify's esbuild bundler injects
+// its own shims for these, so redeclaring them throws "Identifier already
+// declared" at load time (502). Resolve the data file via import.meta.url.
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -28,8 +27,10 @@ let cachedData = null;
 
 async function loadData() {
   if (cachedData) return cachedData;
-  const filePath = join(__dirname, "data", "reference-data.json");
-  const raw = await readFile(filePath, "utf-8");
+  const raw = await readFile(
+    new URL("./data/reference-data.json", import.meta.url),
+    "utf-8"
+  );
   cachedData = JSON.parse(raw);
   return cachedData;
 }

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# health-check.sh — liveness probe for JanVayu's live site + serverless functions.
+#
+# Detects the "function crashed / down" class of outage (HTTP 5xx or no
+# response) — e.g. the May 2026 chatbot 502 caused by a module load error.
+# Benign 4xx responses (e.g. 405 "POST required", 400 "question required")
+# count as UP because they prove the function loaded and is handling requests.
+#
+# For serverless functions we send a POST with an empty JSON body ({}). A
+# healthy function returns a 4xx validation error (e.g. 400 "question and city
+# are required") *before* any Groq/WAQI call, so the probe is zero-cost and
+# spends no Groq tokens; a function that failed to load returns 5xx. (OPTIONS
+# is NOT used: Netlify returns 502 for unsupported methods on healthy v2
+# functions, which would be a false alarm.)
+#
+# Usage:
+#   scripts/health-check.sh                 # probe production (www.janvayu.in)
+#   BASE_URL=http://localhost:8888 scripts/health-check.sh
+#   scripts/health-check.sh report.md       # also write a Markdown report
+#
+# Exit code: 0 if everything is UP, 1 if any endpoint is DOWN.
+
+set -uo pipefail
+
+BASE_URL="${BASE_URL:-https://www.janvayu.in}"
+REPORT_FILE="${1:-}"
+TIMEOUT="${TIMEOUT:-30}"
+
+# Each entry: "Label|METHOD|path-or-url"
+# A path (starting with /) is appended to BASE_URL; a full URL is used as-is.
+CHECKS=(
+  "Site homepage|GET|/"
+  "Ask JanVayu PWA page|GET|/ask/"
+  "Chatbot backend (air-query)|POST|/.netlify/functions/air-query"
+  "reference-data|POST|/.netlify/functions/reference-data"
+  "health-advisory|POST|/.netlify/functions/health-advisory"
+  "accountability-brief|POST|/.netlify/functions/accountability-brief"
+  "rankings|POST|/.netlify/functions/rankings"
+  "historical-aqi|POST|/.netlify/functions/historical-aqi"
+  "anomaly-check|POST|/.netlify/functions/anomaly-check"
+)
+
+failures=0
+report=""
+report+="# JanVayu health check\n\n"
+report+="Base URL: \`${BASE_URL}\`\n"
+report+="Checked at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\n\n"
+report+="| Endpoint | Method | Status | Result |\n"
+report+="|----------|--------|--------|--------|\n"
+
+for entry in "${CHECKS[@]}"; do
+  IFS='|' read -r label method target <<< "$entry"
+  case "$target" in
+    http*) url="$target" ;;
+    *)     url="${BASE_URL}${target}" ;;
+  esac
+
+  # POST probes send an empty JSON body so the function reaches its own
+  # validation (4xx) without invoking Groq/WAQI.
+  if [ "$method" = "POST" ]; then
+    code=$(curl -s -o /dev/null -m "$TIMEOUT" -w "%{http_code}" \
+                -X POST -H "Content-Type: application/json" -d '{}' "$url" 2>/dev/null)
+  else
+    code=$(curl -s -o /dev/null -m "$TIMEOUT" -w "%{http_code}" \
+                -X "$method" "$url" 2>/dev/null)
+  fi
+  rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    status="unreachable (curl $rc)"; result="DOWN"
+  elif [ "$code" -ge 500 ] || [ "$code" -eq 000 ]; then
+    status="$code"; result="DOWN"
+  else
+    status="$code"; result="UP"
+  fi
+
+  if [ "$result" = "DOWN" ]; then
+    failures=$((failures + 1))
+    icon="❌"
+  else
+    icon="✅"
+  fi
+
+  printf '%s  %-32s %-7s -> %s\n' "$icon" "$label" "$method" "$status"
+  report+="| ${label} | ${method} | ${status} | ${icon} ${result} |\n"
+done
+
+report+="\n"
+if [ "$failures" -gt 0 ]; then
+  report+="**${failures} endpoint(s) DOWN** (HTTP 5xx or unreachable).\n"
+else
+  report+="All endpoints healthy.\n"
+fi
+
+if [ -n "$REPORT_FILE" ]; then
+  printf '%b' "$report" > "$REPORT_FILE"
+fi
+
+if [ "$failures" -gt 0 ]; then
+  echo ""
+  echo "RESULT: $failures endpoint(s) DOWN"
+  exit 1
+fi
+
+echo ""
+echo "RESULT: all endpoints healthy"
+exit 0

--- a/status/index.html
+++ b/status/index.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ask JanVayu — System Status</title>
+  <meta name="description" content="Live operational status of the Ask JanVayu chatbot, live AQI data, and serverless functions.">
+  <meta name="robots" content="all">
+  <link rel="icon" href="https://www.janvayu.in/favicon.svg" type="image/svg+xml">
+  <meta property="og:title" content="Ask JanVayu — System Status">
+  <meta property="og:description" content="Live operational status of the Ask JanVayu chatbot and air-quality services.">
+  <meta property="og:type" content="website">
+  <style>
+    :root {
+      --bg: #0f1115;
+      --card: #171a21;
+      --card-border: #242935;
+      --text: #e6e8ec;
+      --muted: #9aa3b2;
+      --up: #16A34A;
+      --up-dim: rgba(22,163,74,.15);
+      --down: #DC2626;
+      --down-dim: rgba(220,38,38,.13);
+      --degraded: #D97706;
+      --degraded-dim: rgba(217,119,6,.14);
+      --accent: #7C3AED;
+      --radius: 14px;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f6f7f9; --card: #ffffff; --card-border: #e6e8ec;
+        --text: #1a1d24; --muted: #5b6472;
+        --up-dim: rgba(22,163,74,.10); --down-dim: rgba(220,38,38,.08);
+        --degraded-dim: rgba(217,119,6,.10);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; background: var(--bg); color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.5; -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 760px; margin: 0 auto; padding: 32px 20px 64px; }
+    header { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; }
+    header .brand { font-weight: 800; font-size: 1.15rem; letter-spacing: -.01em; }
+    header .brand span { color: var(--accent); }
+    header .tag { margin-left: auto; font-size: .8rem; color: var(--muted); }
+
+    .banner {
+      border-radius: var(--radius); padding: 22px 24px; margin-bottom: 12px;
+      display: flex; align-items: center; gap: 16px; border: 1px solid var(--card-border);
+      background: var(--card);
+    }
+    .banner .dot { width: 16px; height: 16px; border-radius: 50%; flex: none; }
+    .banner h1 { margin: 0; font-size: 1.35rem; letter-spacing: -.02em; }
+    .banner p { margin: 2px 0 0; color: var(--muted); font-size: .9rem; }
+    .banner.up    { border-color: rgba(22,163,74,.4);  background: var(--up-dim); }
+    .banner.up .dot { background: var(--up); box-shadow: 0 0 0 4px var(--up-dim); }
+    .banner.down  { border-color: rgba(220,38,38,.45); background: var(--down-dim); }
+    .banner.down .dot { background: var(--down); box-shadow: 0 0 0 4px var(--down-dim); }
+    .banner.degraded { border-color: rgba(217,119,6,.45); background: var(--degraded-dim); }
+    .banner.degraded .dot { background: var(--degraded); box-shadow: 0 0 0 4px var(--degraded-dim); }
+
+    .meta { display: flex; justify-content: space-between; align-items: center;
+            font-size: .8rem; color: var(--muted); margin: 14px 2px 22px; flex-wrap: wrap; gap: 8px; }
+    .meta button {
+      background: none; border: 1px solid var(--card-border); color: var(--muted);
+      border-radius: 8px; padding: 5px 12px; font-size: .8rem; cursor: pointer; font: inherit;
+    }
+    .meta button:hover { color: var(--text); border-color: var(--muted); }
+
+    .components { border: 1px solid var(--card-border); border-radius: var(--radius); overflow: hidden; background: var(--card); }
+    .row { display: flex; align-items: center; gap: 14px; padding: 16px 20px; border-top: 1px solid var(--card-border); }
+    .row:first-child { border-top: none; }
+    .row .info { min-width: 0; }
+    .row .name { font-weight: 600; font-size: .98rem; }
+    .row .desc { color: var(--muted); font-size: .8rem; margin-top: 1px; }
+    .row .right { margin-left: auto; display: flex; align-items: center; gap: 12px; flex: none; }
+    .row .latency { color: var(--muted); font-size: .78rem; font-variant-numeric: tabular-nums; min-width: 52px; text-align: right; }
+    .pill { font-size: .74rem; font-weight: 700; padding: 4px 10px; border-radius: 999px; white-space: nowrap; }
+    .pill.up { color: var(--up); background: var(--up-dim); }
+    .pill.down { color: var(--down); background: var(--down-dim); }
+    .pill.degraded { color: var(--degraded); background: var(--degraded-dim); }
+    .pill.checking { color: var(--muted); background: rgba(154,163,178,.12); }
+    .sdot { width: 10px; height: 10px; border-radius: 50%; flex: none; background: var(--muted); }
+    .sdot.up { background: var(--up); } .sdot.down { background: var(--down); } .sdot.degraded { background: var(--degraded); }
+
+    .uptime { margin-top: 26px; }
+    .uptime h2 { font-size: .9rem; color: var(--muted); font-weight: 600; margin: 0 2px 10px; }
+    .bars { display: flex; gap: 2px; }
+    .bars i { flex: 1; height: 30px; border-radius: 2px; background: var(--card-border); }
+    .bars i.up { background: var(--up); } .bars i.down { background: var(--down); } .bars i.degraded { background: var(--degraded); }
+
+    footer { margin-top: 38px; text-align: center; color: var(--muted); font-size: .8rem; }
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+    .spin { animation: sp 1s linear infinite; display: inline-block; }
+    @keyframes sp { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div class="brand">Ask <span>JanVayu</span></div>
+      <div class="tag">System Status</div>
+    </header>
+
+    <div id="banner" class="banner degraded">
+      <div class="dot"></div>
+      <div>
+        <h1 id="banner-title">Checking systems…</h1>
+        <p id="banner-sub">Running live health checks.</p>
+      </div>
+    </div>
+
+    <div class="meta">
+      <span id="last-checked">Last checked: —</span>
+      <button id="refresh" type="button">↻ Refresh now</button>
+    </div>
+
+    <div class="components" id="components"></div>
+
+    <div class="uptime" id="uptime" hidden>
+      <h2 id="uptime-title">90-day uptime</h2>
+      <div class="bars" id="bars"></div>
+    </div>
+
+    <footer>
+      Probed live from your browser · auto-refreshes every 60s<br>
+      <a href="https://www.janvayu.in">janvayu.in</a> ·
+      <a href="https://www.janvayu.in/ask/">Ask JanVayu</a> ·
+      <a href="https://github.com/JanVayu/JanVayu">GitHub</a>
+    </footer>
+  </div>
+
+  <script>
+    // Probe production functions directly. Functions send
+    // Access-Control-Allow-Origin: * so this works from any host
+    // (e.g. status.askjanvayu.in). POST probes send an empty body so each
+    // function hits its own validation (4xx) without spending Groq tokens.
+    const API = "https://www.janvayu.in";
+    const TIMEOUT_MS = 12000;
+
+    const COMPONENTS = [
+      { name: "Website", desc: "janvayu.in — main site & CDN", type: "site", url: API + "/" },
+      { name: "Ask JanVayu chatbot", desc: "AI air-quality assistant (air-query)", type: "fn", url: API + "/.netlify/functions/air-query" },
+      { name: "Live AQI rankings", desc: "City rankings feed (rankings)", type: "fn", url: API + "/.netlify/functions/rankings" },
+      { name: "Historical AQI", desc: "Monthly PM2.5 history (historical-aqi)", type: "fn", url: API + "/.netlify/functions/historical-aqi" },
+      { name: "Reference data", desc: "CPCB / NCAP reference (reference-data)", type: "fn", url: API + "/.netlify/functions/reference-data" },
+      { name: "Health advisory", desc: "Personalised advice (health-advisory)", type: "fn", url: API + "/.netlify/functions/health-advisory" },
+      { name: "Accountability brief", desc: "Institutional response brief", type: "fn", url: API + "/.netlify/functions/accountability-brief" },
+      { name: "Anomaly check", desc: "Data anomaly detection", type: "fn", url: API + "/.netlify/functions/anomaly-check" },
+    ];
+
+    const elComponents = document.getElementById("components");
+    const elBanner = document.getElementById("banner");
+    const rows = COMPONENTS.map((c) => {
+      const row = document.createElement("div");
+      row.className = "row";
+      row.innerHTML =
+        '<div class="sdot"></div>' +
+        '<div class="info"><div class="name"></div><div class="desc"></div></div>' +
+        '<div class="right"><span class="latency"></span><span class="pill checking">Checking…</span></div>';
+      row.querySelector(".name").textContent = c.name;
+      row.querySelector(".desc").textContent = c.desc;
+      elComponents.appendChild(row);
+      return row;
+    });
+
+    function setRow(i, state, latency) {
+      const row = rows[i];
+      const dot = row.querySelector(".sdot");
+      const pill = row.querySelector(".pill");
+      const lat = row.querySelector(".latency");
+      dot.className = "sdot " + state;
+      pill.className = "pill " + state;
+      pill.textContent = state === "up" ? "Operational" : state === "down" ? "Down" : "Degraded";
+      lat.textContent = latency != null ? latency + " ms" : "";
+    }
+
+    async function probe(c) {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+      const started = performance.now();
+      try {
+        let down;
+        if (c.type === "site") {
+          // Cross-origin HTML has no CORS header; use no-cors to test reachability.
+          await fetch(c.url, { method: "GET", mode: "no-cors", cache: "no-store", signal: ctrl.signal });
+          down = false; // resolved without throwing = reachable
+        } else {
+          const res = await fetch(c.url, {
+            method: "POST", mode: "cors", cache: "no-store",
+            headers: { "Content-Type": "application/json" },
+            body: "{}", signal: ctrl.signal,
+          });
+          down = res.status >= 500; // 4xx = alive (validation); 5xx = crashed
+        }
+        return { state: down ? "down" : "up", latency: Math.round(performance.now() - started) };
+      } catch (e) {
+        return { state: "down", latency: null };
+      } finally {
+        clearTimeout(t);
+      }
+    }
+
+    let busy = false;
+    async function runAll() {
+      if (busy) return;
+      busy = true;
+      const btn = document.getElementById("refresh");
+      btn.innerHTML = '<span class="spin">↻</span> Checking…';
+      rows.forEach((r) => {
+        r.querySelector(".pill").className = "pill checking";
+        r.querySelector(".pill").textContent = "Checking…";
+        r.querySelector(".sdot").className = "sdot";
+      });
+
+      const results = await Promise.all(COMPONENTS.map(probe));
+      results.forEach((r, i) => setRow(i, r.state, r.latency));
+
+      const down = results.filter((r) => r.state === "down").length;
+      const total = results.length;
+      let cls, title, sub;
+      if (down === 0) {
+        cls = "up"; title = "All Systems Operational";
+        sub = total + " of " + total + " services healthy.";
+      } else if (down >= total) {
+        cls = "down"; title = "Major Outage";
+        sub = "All monitored services are unreachable.";
+      } else {
+        cls = "degraded"; title = down === 1 ? "Partial Outage — 1 service down" : "Partial Outage — " + down + " services down";
+        sub = (total - down) + " of " + total + " services healthy.";
+      }
+      elBanner.className = "banner " + cls;
+      document.getElementById("banner-title").textContent = title;
+      document.getElementById("banner-sub").textContent = sub;
+      document.getElementById("last-checked").textContent =
+        "Last checked: " + new Date().toLocaleString();
+      btn.innerHTML = "↻ Refresh now";
+      busy = false;
+    }
+
+    document.getElementById("refresh").addEventListener("click", runAll);
+    runAll();
+    setInterval(runAll, 60000);
+
+    // Optional historical uptime strip — rendered only if a history.json
+    // (published by the Function Health Monitor workflow) is present.
+    fetch("./history.json", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((h) => {
+        if (!h || !Array.isArray(h.days) || !h.days.length) return;
+        const bars = document.getElementById("bars");
+        document.getElementById("uptime-title").textContent =
+          (h.days.length) + "-day uptime";
+        h.days.forEach((d) => {
+          const i = document.createElement("i");
+          i.className = d.status || "up";
+          i.title = d.date + (d.note ? " — " + d.note : "");
+          bars.appendChild(i);
+        });
+        document.getElementById("uptime").hidden = false;
+      })
+      .catch(() => {});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

The **Ask JanVayu chatbot** (`/ask`) has been returning **HTTP 502 on every request since 2026-05-26** (~2 weeks). This PR fixes it, and adds monitoring + a CI guard so this class of outage is caught early and can't ship again.

## Root cause

The chatbot backend `air-query.mjs` (and the `reference-data` endpoint) crashed at module load with:

```
SyntaxError: Identifier '__dirname' has already been declared
```

Netlify's esbuild bundler injects its own `__dirname`/`__filename` shims into bundled ESM functions, so the manual `const __dirname = ...` added in `7e117d0` ("wire reference-data.json into chatbot") was a redeclaration that threw **before the handler ever ran** — every request 502'd.

Confirmed live: functions that declare `__dirname` were down (`air-query`, `reference-data` → 502); functions that don't (`health-advisory`, `rankings` → 200) were fine.

## Changes

**Fix** — resolve the bundled data file via `new URL('./data/reference-data.json', import.meta.url)` instead of `__dirname`; removed the now-unused `fileURLToPath`/`dirname`/`join` imports from both functions. Verified both modules import and read their data file cleanly even with `__dirname`/`__filename` pre-injected into `globalThis` (the exact failing condition).

**Monitoring** — `scripts/health-check.sh` + `.github/workflows/function-health.yml` probe the live site + 9 functions every 15 min (and on demand) and keep one `status: outage` tracking issue in sync (opens/comments while down, auto-closes on recovery). Function probes POST an empty body to hit each function's own validation (4xx) and spend **zero Groq tokens**. OPTIONS is deliberately not used (Netlify 502s unsupported methods on healthy v2 functions = false alarm).

**Prevention** — `ci.yml` gains `guard-netlify-functions`, which fails any build that reintroduces a top-level `__dirname`/`__filename` in a function and `node --check`s every function. Verified it catches the original buggy file and passes the fixed tree.

## Verification

- `node --check` passes on all functions; real `import()` of both fixed modules succeeds with shims pre-injected.
- `scripts/health-check.sh` against production currently reports exactly `air-query` + `reference-data` as down (no false positives); after this deploys they should return 4xx/2xx.
- Guard regex catches `359e9f4:air-query.mjs` and is clean on this branch.

## After merge

Netlify auto-deploys from `main`. Once deployed, re-run `scripts/health-check.sh` (or the Function Health Monitor workflow) — the chatbot should be UP.

https://claude.ai/code/session_01GyT2c6HX7AH9do4zKHkqab

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyT2c6HX7AH9do4zKHkqab)_