### PR TITLE
feat: email outage alerts via Netlify scheduled function

### DIFF
--- a/.github/workflows/function-health.yml
+++ b/.github/workflows/function-health.yml
@@ -53,7 +53,6 @@ jobs:
             --force 2>/dev/null || true
 
       - name: Sync tracking issue
-        id: sync
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -68,10 +67,6 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           printf '\n\n[Workflow run](%s)\n' "$RUN_URL" >> "$BODY_FILE"
 
-          # transition: "down" = just went down, "recovered" = just came back,
-          # "" = no state change. Email is sent only on a transition, so a
-          # prolonged outage triggers exactly one alert, not one every 15 min.
-          transition=""
           if [ "$DOWN" != "0" ]; then
             if [ -n "$EXISTING" ]; then
               echo "Outage ongoing — commenting on issue #$EXISTING"
@@ -82,7 +77,6 @@ jobs:
                 --title "🔴 Live function outage detected" \
                 --label "$OUTAGE_LABEL" \
                 --body-file "$BODY_FILE"
-              transition="down"
             fi
           else
             if [ -n "$EXISTING" ]; then
@@ -96,63 +90,9 @@ jobs:
               } > recovered.md
               gh issue comment "$EXISTING" --body-file recovered.md
               gh issue close "$EXISTING" --reason completed
-              transition="recovered"
             else
               echo "All healthy — nothing to do."
             fi
-          fi
-          echo "transition=$transition" >> "$GITHUB_OUTPUT"
-
-      # Immediate email alert on a state change, via Resend (the same provider
-      # the daily digest uses). Sends one email when an outage starts and one
-      # when it recovers. No-ops silently if RESEND_API_KEY isn't configured as
-      # a repository secret.
-      - name: Email alert on state change
-        if: steps.sync.outputs.transition != ''
-        env:
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          # Comma-separated list of recipients.
-          ALERT_EMAIL: ${{ vars.ALERT_EMAIL || 'contribute@janvayu.in,varna.sr@gmail.com' }}
-          RESEND_FROM: ${{ vars.RESEND_FROM || 'JanVayu Status <alerts@janvayu.in>' }}
-          TRANSITION: ${{ steps.sync.outputs.transition }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          if [ -z "${RESEND_API_KEY:-}" ]; then
-            echo "RESEND_API_KEY not set — skipping email alert."
-            exit 0
-          fi
-
-          if [ "$TRANSITION" = "down" ]; then
-            SUBJECT="🔴 JanVayu: a live service is DOWN"
-          else
-            SUBJECT="✅ JanVayu: all services recovered"
-          fi
-
-          # Build an HTML body from the latest probe report.
-          REPORT_HTML=$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' report.md)
-          HTML="<h2>${SUBJECT}</h2><p>Status page: <a href=\"https://www.janvayu.in/status\">janvayu.in/status</a> · <a href=\"${RUN_URL}\">workflow run</a></p><pre style=\"font-family:monospace;font-size:13px\">${REPORT_HTML}</pre>"
-
-          # Compose JSON safely with jq. ALERT_EMAIL is a comma-separated list,
-          # split into a trimmed array of recipients.
-          jq -n \
-            --arg from "$RESEND_FROM" \
-            --arg to "$ALERT_EMAIL" \
-            --arg subject "$SUBJECT" \
-            --arg html "$HTML" \
-            '{from:$from,
-              to:($to | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))),
-              subject:$subject, html:$html}' > payload.json
-
-          CODE=$(curl -s -o resp.json -w "%{http_code}" -X POST https://api.resend.com/emails \
-                   -H "Authorization: Bearer ${RESEND_API_KEY}" \
-                   -H "Content-Type: application/json" \
-                   --data @payload.json)
-          echo "Resend responded HTTP $CODE"
-          if [ "$CODE" -ge 300 ]; then
-            echo "::warning::Alert email failed (HTTP $CODE): $(cat resp.json)"
-          else
-            echo "Alert email sent to $ALERT_EMAIL"
           fi
 
       - name: Fail the job when endpoints are down

--- a/.github/workflows/function-health.yml
+++ b/.github/workflows/function-health.yml
@@ -111,7 +111,8 @@ jobs:
         if: steps.sync.outputs.transition != ''
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          ALERT_EMAIL: ${{ vars.ALERT_EMAIL || 'contribute@janvayu.in' }}
+          # Comma-separated list of recipients.
+          ALERT_EMAIL: ${{ vars.ALERT_EMAIL || 'contribute@janvayu.in,varna.sr@gmail.com' }}
           RESEND_FROM: ${{ vars.RESEND_FROM || 'JanVayu Status <alerts@janvayu.in>' }}
           TRANSITION: ${{ steps.sync.outputs.transition }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -132,13 +133,16 @@ jobs:
           REPORT_HTML=$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' report.md)
           HTML="<h2>${SUBJECT}</h2><p>Status page: <a href=\"https://www.janvayu.in/status\">janvayu.in/status</a> · <a href=\"${RUN_URL}\">workflow run</a></p><pre style=\"font-family:monospace;font-size:13px\">${REPORT_HTML}</pre>"
 
-          # Compose JSON safely with jq.
+          # Compose JSON safely with jq. ALERT_EMAIL is a comma-separated list,
+          # split into a trimmed array of recipients.
           jq -n \
             --arg from "$RESEND_FROM" \
             --arg to "$ALERT_EMAIL" \
             --arg subject "$SUBJECT" \
             --arg html "$HTML" \
-            '{from:$from, to:[$to], subject:$subject, html:$html}' > payload.json
+            '{from:$from,
+              to:($to | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))),
+              subject:$subject, html:$html}' > payload.json
 
           CODE=$(curl -s -o resp.json -w "%{http_code}" -X POST https://api.resend.com/emails \
                    -H "Authorization: Bearer ${RESEND_API_KEY}" \

--- a/.github/workflows/function-health.yml
+++ b/.github/workflows/function-health.yml
@@ -53,6 +53,7 @@ jobs:
             --force 2>/dev/null || true
 
       - name: Sync tracking issue
+        id: sync
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -67,6 +68,10 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           printf '\n\n[Workflow run](%s)\n' "$RUN_URL" >> "$BODY_FILE"
 
+          # transition: "down" = just went down, "recovered" = just came back,
+          # "" = no state change. Email is sent only on a transition, so a
+          # prolonged outage triggers exactly one alert, not one every 15 min.
+          transition=""
           if [ "$DOWN" != "0" ]; then
             if [ -n "$EXISTING" ]; then
               echo "Outage ongoing — commenting on issue #$EXISTING"
@@ -77,6 +82,7 @@ jobs:
                 --title "🔴 Live function outage detected" \
                 --label "$OUTAGE_LABEL" \
                 --body-file "$BODY_FILE"
+              transition="down"
             fi
           else
             if [ -n "$EXISTING" ]; then
@@ -90,9 +96,59 @@ jobs:
               } > recovered.md
               gh issue comment "$EXISTING" --body-file recovered.md
               gh issue close "$EXISTING" --reason completed
+              transition="recovered"
             else
               echo "All healthy — nothing to do."
             fi
+          fi
+          echo "transition=$transition" >> "$GITHUB_OUTPUT"
+
+      # Immediate email alert on a state change, via Resend (the same provider
+      # the daily digest uses). Sends one email when an outage starts and one
+      # when it recovers. No-ops silently if RESEND_API_KEY isn't configured as
+      # a repository secret.
+      - name: Email alert on state change
+        if: steps.sync.outputs.transition != ''
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          ALERT_EMAIL: ${{ vars.ALERT_EMAIL || 'contribute@janvayu.in' }}
+          RESEND_FROM: ${{ vars.RESEND_FROM || 'JanVayu Status <alerts@janvayu.in>' }}
+          TRANSITION: ${{ steps.sync.outputs.transition }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RESEND_API_KEY:-}" ]; then
+            echo "RESEND_API_KEY not set — skipping email alert."
+            exit 0
+          fi
+
+          if [ "$TRANSITION" = "down" ]; then
+            SUBJECT="🔴 JanVayu: a live service is DOWN"
+          else
+            SUBJECT="✅ JanVayu: all services recovered"
+          fi
+
+          # Build an HTML body from the latest probe report.
+          REPORT_HTML=$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' report.md)
+          HTML="<h2>${SUBJECT}</h2><p>Status page: <a href=\"https://www.janvayu.in/status\">janvayu.in/status</a> · <a href=\"${RUN_URL}\">workflow run</a></p><pre style=\"font-family:monospace;font-size:13px\">${REPORT_HTML}</pre>"
+
+          # Compose JSON safely with jq.
+          jq -n \
+            --arg from "$RESEND_FROM" \
+            --arg to "$ALERT_EMAIL" \
+            --arg subject "$SUBJECT" \
+            --arg html "$HTML" \
+            '{from:$from, to:[$to], subject:$subject, html:$html}' > payload.json
+
+          CODE=$(curl -s -o resp.json -w "%{http_code}" -X POST https://api.resend.com/emails \
+                   -H "Authorization: Bearer ${RESEND_API_KEY}" \
+                   -H "Content-Type: application/json" \
+                   --data @payload.json)
+          echo "Resend responded HTTP $CODE"
+          if [ "$CODE" -ge 300 ]; then
+            echo "::warning::Alert email failed (HTTP $CODE): $(cat resp.json)"
+          else
+            echo "Alert email sent to $ALERT_EMAIL"
           fi
 
       - name: Fail the job when endpoints are down

--- a/netlify/functions/health-monitor.mjs
+++ b/netlify/functions/health-monitor.mjs
@@ -1,0 +1,176 @@
+// Netlify Scheduled Function: Live health monitor with email alerts.
+//
+// Runs every 15 minutes, probes the public site + serverless functions, and
+// emails an alert the moment a service goes DOWN (HTTP 5xx / unreachable) and
+// again when everything RECOVERS. Uses Resend with the RESEND_API_KEY already
+// configured in Netlify (same provider as the daily digest), so no extra
+// secrets are needed.
+//
+// State is persisted in Netlify Blobs so email fires only on a transition —
+// a prolonged outage sends exactly one alert, not one every 15 minutes. This
+// complements the GitHub Actions monitor (which keeps a tracking issue in
+// sync) and the public status page at /status.
+
+import { getStore } from "@netlify/blobs";
+import { Resend } from "resend";
+
+const BASE_URL = process.env.URL || "https://www.janvayu.in";
+const PROBE_TIMEOUT_MS = 12000;
+
+// Recipients: comma-separated, defaults to the JanVayu inbox + maintainer.
+const RECIPIENTS = (process.env.ALERT_EMAIL || "contribute@janvayu.in,varna.sr@gmail.com")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const FROM_ADDRESS = process.env.RESEND_FROM || "JanVayu Status <alerts@janvayu.in>";
+
+// Each probe: POST {} to a function hits its own validation (4xx = alive)
+// without spending Groq tokens; the site uses a plain GET. 5xx / network
+// error = DOWN.
+const CHECKS = [
+  { name: "Website", method: "GET", url: `${BASE_URL}/` },
+  { name: "Ask JanVayu chatbot (air-query)", method: "POST", url: `${BASE_URL}/.netlify/functions/air-query` },
+  { name: "reference-data", method: "POST", url: `${BASE_URL}/.netlify/functions/reference-data` },
+  { name: "health-advisory", method: "POST", url: `${BASE_URL}/.netlify/functions/health-advisory` },
+  { name: "accountability-brief", method: "POST", url: `${BASE_URL}/.netlify/functions/accountability-brief` },
+  { name: "rankings", method: "POST", url: `${BASE_URL}/.netlify/functions/rankings` },
+  { name: "historical-aqi", method: "POST", url: `${BASE_URL}/.netlify/functions/historical-aqi` },
+  { name: "anomaly-check", method: "POST", url: `${BASE_URL}/.netlify/functions/anomaly-check` },
+];
+
+function getBlobStore(name) {
+  const siteID = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
+  const token = process.env.BLOB_TOKEN;
+  if (siteID && token) {
+    return getStore({ name, siteID, token, consistency: "strong" });
+  }
+  return getStore({ name, consistency: "strong" });
+}
+
+async function probe(check) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+  const started = Date.now();
+  try {
+    const opts = { method: check.method, signal: ctrl.signal, cache: "no-store" };
+    if (check.method === "POST") {
+      opts.headers = { "Content-Type": "application/json" };
+      opts.body = "{}";
+    }
+    const res = await fetch(check.url, opts);
+    return { ...check, status: res.status, down: res.status >= 500, ms: Date.now() - started };
+  } catch (e) {
+    return { ...check, status: "unreachable", down: true, ms: Date.now() - started, error: e.message };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function buildEmailHTML(subject, results) {
+  const rows = results
+    .map((r) => {
+      const ok = !r.down;
+      const color = ok ? "#16A34A" : "#DC2626";
+      const label = ok ? "Operational" : "DOWN";
+      return `<tr>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee">${r.name}</td>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee;font-family:monospace">${r.status}</td>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee;color:${color};font-weight:700">${label}</td>
+      </tr>`;
+    })
+    .join("");
+  return `<div style="font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:640px">
+    <h2 style="margin:0 0 4px">${subject}</h2>
+    <p style="color:#555;margin:0 0 16px">
+      Checked ${new Date().toUTCString()} ·
+      <a href="https://www.janvayu.in/status" style="color:#7C3AED">Status page</a>
+    </p>
+    <table style="border-collapse:collapse;width:100%;font-size:14px">
+      <thead><tr>
+        <th align="left" style="padding:6px 10px;border-bottom:2px solid #ddd">Service</th>
+        <th align="left" style="padding:6px 10px;border-bottom:2px solid #ddd">HTTP</th>
+        <th align="left" style="padding:6px 10px;border-bottom:2px solid #ddd">Status</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <p style="color:#888;font-size:12px;margin-top:18px">
+      Automated alert from the JanVayu health monitor. You receive this only when
+      a service changes state (down or recovered), not on every check.
+    </p>
+  </div>`;
+}
+
+async function sendAlert(transition, results) {
+  const RESEND_API_KEY = process.env.RESEND_API_KEY;
+  if (!RESEND_API_KEY) {
+    console.log("RESEND_API_KEY not set — skipping alert email.");
+    return;
+  }
+  const down = results.filter((r) => r.down);
+  const subject =
+    transition === "down"
+      ? `🔴 JanVayu: ${down.length} service${down.length === 1 ? "" : "s"} DOWN — ${down.map((d) => d.name).join(", ")}`
+      : "✅ JanVayu: all services recovered";
+
+  const resend = new Resend(RESEND_API_KEY);
+  try {
+    await resend.emails.send({
+      from: FROM_ADDRESS,
+      to: RECIPIENTS,
+      subject,
+      html: buildEmailHTML(subject, results),
+    });
+    console.log(`Alert email (${transition}) sent to ${RECIPIENTS.join(", ")}`);
+  } catch (e) {
+    console.log(`Failed to send alert email: ${e.message}`);
+  }
+}
+
+export default async () => {
+  const results = await Promise.all(CHECKS.map(probe));
+  const downServices = results.filter((r) => r.down).map((r) => r.name);
+  const healthy = downServices.length === 0;
+  const now = new Date().toISOString();
+
+  const store = getBlobStore("janvayu-feeds");
+  let prev = null;
+  try {
+    prev = await store.get("health-monitor-state", { type: "json" });
+  } catch {
+    prev = null;
+  }
+  // First run with no prior state is treated as previously-healthy, so an
+  // alert only fires if we are currently down.
+  const prevHealthy = prev ? !!prev.healthy : true;
+
+  let transition = "";
+  if (prevHealthy && !healthy) transition = "down";
+  else if (!prevHealthy && healthy) transition = "recovered";
+
+  if (transition) {
+    await sendAlert(transition, results);
+  }
+
+  await store.setJSON("health-monitor-state", {
+    healthy,
+    downServices,
+    lastChecked: now,
+    since: transition || !prev ? now : prev.since,
+    lastTransition: transition || (prev && prev.lastTransition) || null,
+  });
+
+  console.log(
+    `health-monitor: ${healthy ? "all healthy" : "DOWN: " + downServices.join(", ")}` +
+      (transition ? ` (transition: ${transition}, emailed ${RECIPIENTS.join(", ")})` : "")
+  );
+
+  return new Response(
+    JSON.stringify({ healthy, downServices, transition, checked: now }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+};
+
+export const config = {
+  schedule: "*/15 * * * *", // every 15 minutes
+};


### PR DESCRIPTION
## Summary

Adds **immediate email alerting** for outages — sent the moment a service goes down, and again on recovery — to `contribute@janvayu.in` **and** `varna.sr@gmail.com`.

### Why a Netlify function (not GitHub Actions)
`RESEND_API_KEY` already lives in the **Netlify** environment (the daily digest uses it), but GitHub Actions can't read Netlify env vars, and adding it as an Actions secret wasn't possible from this session. Running the alerter as a **Netlify scheduled function** uses the existing key — so **email works on deploy with zero extra secret setup**.

## Changes
- **`netlify/functions/health-monitor.mjs`** — scheduled every 15 min. Probes the site + 7 functions (POST `{}` → 4xx alive / 5xx down, zero Groq tokens). Emails via Resend **only on a state transition**, so a prolonged outage sends exactly one alert plus one recovery email. State persists in Netlify Blobs.
  - Recipients default to `contribute@janvayu.in,varna.sr@gmail.com` (override with the `ALERT_EMAIL` env var); sender from `RESEND_FROM`.
- **Reverted** the email step that an earlier commit added to `function-health.yml`. The GitHub Actions monitor keeps doing the `status: outage` tracking-issue lifecycle; the `/status` page is unchanged.

## Layered monitoring after this lands
| Layer | Role | Channel |
|---|---|---|
| `/status` page | At-a-glance live health | Web |
| GitHub Actions monitor | Tracking-issue open/close + workflow-failure email | GitHub |
| **Netlify health-monitor (this PR)** | **Immediate down/recovery alert** | **Email** |
| CI `guard-netlify-functions` | Blocks the 502 bug class from shipping | PR gate |

No action required to enable email — the key is already in Netlify.

https://claude.ai/code/session_01GyT2c6HX7AH9do4zKHkqab