### PR TITLE
feat: link the status page from site navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2919,6 +2919,7 @@ body {
                 <a class="mobile-nav-item" href="/ask/" style="text-decoration:none; color:inherit; display:block;" data-i18n="nav_ask_janvayu">Ask JanVayu (AI)</a>
                 <a class="mobile-nav-item" href="/blog/" style="text-decoration:none; color:inherit; display:block;" data-i18n="nav_blog">Blog</a>
                 <a class="mobile-nav-item" href="/docs/" style="text-decoration:none; color:inherit; display:block;" data-i18n="nav_documentation">Documentation</a>
+                <a class="mobile-nav-item" href="/status" style="text-decoration:none; color:inherit; display:block;">System Status</a>
                 <a class="mobile-nav-item" href="https://www.zotero.org/groups/6508140/janvayu/library" target="_blank" style="text-decoration:none; color:inherit; display:block;">Full Bibliography (Zotero)</a>
                 <a class="mobile-nav-item" href="https://github.com/JanVayu/JanVayu/wiki" target="_blank" style="text-decoration:none; color:inherit; display:block;">Wiki</a>
                 <a class="mobile-nav-item" href="https://github.com/JanVayu/JanVayu/discussions" target="_blank" style="text-decoration:none; color:inherit; display:block;">Discussions</a>
@@ -3534,6 +3535,7 @@ body {
                     <a class="footer-link" href="/ask/" data-i18n="footer_ask">Ask JanVayu (AI)</a>
                     <a class="footer-link" href="/blog/" data-i18n="footer_blog">Blog</a>
                     <a class="footer-link" href="/docs/" data-i18n="footer_docs">Docs</a>
+                    <a class="footer-link" href="/status">System Status</a>
                     <a class="footer-link" href="https://www.zotero.org/groups/6508140/janvayu/library" target="_blank">Full Bibliography (Zotero) ↗</a>
                     <a class="footer-link" href="https://github.com/JanVayu/JanVayu" target="_blank">GitHub ↗</a>
                 </div>


### PR DESCRIPTION
## Summary

Surfaces the status page (`/status`) in the site navigation so it's discoverable, not just a direct URL.

- **Footer → "Tools & Action"** column: adds a **System Status** link (next to Ask JanVayu / Blog / Docs).
- **Mobile nav → "External"** group: adds a **System Status** link (next to Documentation / Wiki).

Both are plain internal links to `/status` with no `data-i18n` key (matching neighbours like Walkthrough/Wiki/Discussions), so the translation-key sync checks are unaffected. 2-line change.

https://claude.ai/code/session_01GyT2c6HX7AH9do4zKHkqab

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyT2c6HX7AH9do4zKHkqab)_