### PR TITLE
feat: hourly ozone↔temperature chart (any city), national framing, + launch blog

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -10,6 +10,7 @@ Data, research, policy accountability, and what the numbers mean for 1.4 billion
 
 | Date | Post | Topic |
 |------|------|-------|
+| 10 Jun 2026 | [The Same Sun, a Different City: Why Your Neighbourhood's Heat Is an Air-Quality Story](posts/2026-06-10-urban-heat-island.md) | Health |
 | 8 May 2026 | [Quality You Can Measure: Lighthouse, axe, Lazy-Loading, Mobile](posts/2026-05-08-quality-and-performance.md) | Platform |
 | 8 May 2026 | [Six Learning Games: Jeopardy, Quiz, Source Matcher, Snakes & Ladders, Jodi Match, Tambola](posts/2026-05-08-learning-games.md) | Platform |
 | 6 May 2026 | [Data Refresh, May 2026: Latest Numbers, Updated Hero](posts/2026-05-06-data-corrections-may.md) | Data |

--- a/blog/_sidebar.md
+++ b/blog/_sidebar.md
@@ -2,6 +2,9 @@
 
 - [**JanVayu Blog**](README.md)
 
+- **June 2026**
+  - [The Same Sun, a Different City: Why Your Neighbourhood's Heat Is an Air-Quality Story](posts/2026-06-10-urban-heat-island.md)
+
 - **May 2026**
   - [The Number Everyone Quotes but Nobody Understands: What AQI Actually Is](posts/2026-05-27-understanding-aqi.md)
   - [When a Politician Says 'AQI Improved 20%', Ask: Which Monitor?](posts/2026-05-27-data-source-selector.md)

--- a/blog/posts/2026-06-10-urban-heat-island.md
+++ b/blog/posts/2026-06-10-urban-heat-island.md
@@ -1,0 +1,50 @@
+# The Same Sun, a Different City: Why Your Neighbourhood's Heat Is an Air-Quality Story
+
+**Published:** 10 June 2026 | **Author:** Team JanVayu | **Reading time:** 5 min
+
+---
+
+On one summer afternoon, a thermal survey of Delhi recorded **52°C in Mubarakpur** and **34°C in Mehrauli** — at the same hour, under the same sun, just kilometres apart. That is an 18°C gap inside a single city. The sun did not change. The ground did.
+
+This is the **urban heat island effect**, and we have just added a panel about it to JanVayu — [Urban Heat Island](/index.html#urban-heat), under *Health & Trends*. But a fair question came up while we built it, and it is worth answering in the open: **what is heat doing on an air-quality website?**
+
+## Heat and dirty air are not two problems. They are one.
+
+They share chemistry, weather, causes, and victims.
+
+**Heat cooks ozone.** Ground-level ozone is not emitted by any tailpipe or chimney. It is *manufactured* in the air when nitrogen oxides and volatile organic compounds react in sunlight — and that reaction runs faster as the air gets hotter. The classic measurement of this, Bloomer et al. (2009), found ozone rising roughly **3 parts per billion for every 1°C** of warming across two decades of data. Atmospheric chemists call it the "climate penalty." A 50°C street simply makes more ozone than a 35°C one from the very same traffic.
+
+**Hot days are still days.** Heatwaves arrive on stagnant, high-pressure weather systems. The same motionless air that refuses to carry heat away also refuses to disperse smoke, dust and exhaust — so pollution piles up instead of blowing through. Jacob & Winner (2009) showed that a warming climate is also a more stagnant one.
+
+**The cooling spiral.** Hotter colonies run more air conditioners. That pulls more electricity from a coal-heavy grid — more PM2.5, more SO₂ — and every AC dumps its waste heat back onto the street. Salamanca et al. (2014) measured AC exhaust raising night-time street temperatures by **more than 1°C**. Heat makes pollution makes heat.
+
+**One canopy, two jobs.** Tree cover lowers temperature *and* traps particulate matter on its leaves (Nowak et al., 2014). Strip the green from a neighbourhood and you remove the shade and the filter in a single stroke.
+
+And the victims overlap. On a hot, polluted day, heat and dirty air attack the heart and lungs through the same pathways. A nine-city European study (Analitis et al., 2014) found heat-wave deaths were **54% higher on high-ozone days**; a 620-city, 36-country analysis (Stafoggia et al., 2023) confirmed the two compound each other worldwide. The densest, least-green, lowest-income colonies carry the most of both — while being least able to afford an AC or an air purifier.
+
+## The science of the divide
+
+A January 2026 white paper from **Artha Global** — *Mapping Heat Inequality Across Neighbourhoods in Delhi* (Sircar et al.) — surveyed **2,368 households across all 70 of Delhi's assembly constituencies** and pinned numbers to the picture:
+
+- Raising built-up area from **25% to 55%** added **+0.6°C** of experienced heat.
+- Raising tree cover from just **3% to 11%** removed **−1°C**.
+
+The conclusion is quietly radical: **trees cool more powerfully than concrete heats.** Green cover is not landscaping. It is the most effective thermal infrastructure a neighbourhood can have — and, crucially, **it cannot be retrofitted once a colony is fully built.** There is no room left for the canopy that would have cooled it. The decision is made on the planning table, not afterwards.
+
+## Delhi is the example. The physics is national.
+
+We lead with Delhi because it has the most detailed neighbourhood-level heat data in the country. But none of the chemistry above is Delhi-specific. The afternoon ozone peak rides the afternoon heat peak in Mumbai, Hyderabad, Ahmedabad, Lucknow, Jaipur — every fast-building Indian city paving over its green cover.
+
+So we made it checkable. The new panel includes a **live chart** that plots today's hourly ozone against hourly air temperature for **any Indian city you choose** (data from the free, key-less Open-Meteo API). Pick your city and watch the two curves climb together through the morning and crest in the afternoon. That shared peak is the climate penalty, happening today, where you live.
+
+There is also an interactive estimator: set your neighbourhood's built-up percentage and tree cover, and it returns how much hotter or cooler you run than a typical Delhi block, using the Artha Global coefficients.
+
+## Why this belongs in the archive
+
+JanVayu is a record of India's air crisis. Heat belongs in that record because cooling a neighbourhood and cleaning its air are increasingly **the same project**. Plant the canopy and you get shade *and* a filter. Pave it over and you lose both — and you cannot get them back.
+
+Explore it: [**Urban Heat Island on JanVayu**](/index.html#urban-heat).
+
+---
+
+*Sources: Sircar, N. et al. (2026), "Mapping Heat Inequality Across Neighbourhoods in Delhi," Artha Global; surface-temperature map via India Today; Bloomer, B.J. et al. (2009), Geophysical Research Letters 36, L09803; Jacob, D.J. & Winner, D.A. (2009), Atmospheric Environment 43(1):51–63; Analitis, A. et al. (2014), Epidemiology 25(1):15–22; Stafoggia, M. et al. (2023), Environment International 181:108258; Salamanca, F. et al. (2014), J. Geophysical Research: Atmospheres 119:5949–5965; Nowak, D.J. et al. (2014), Environmental Pollution 193:119–129. Live hourly ozone and temperature via Open-Meteo (CAMS).*

--- a/index.html
+++ b/index.html
@@ -4498,114 +4498,128 @@ body {
         }
     };
 
-    // ── Urban Heat: live ozone-vs-temperature scatter ──
-    // Demonstrates the "climate penalty" (Bloomer 2009) with live station data:
-    // for each Indian city we pull the current O3 sub-index and air temperature
-    // from WAQI and plot O3 (y) against temperature (x). A positive fit slope
-    // means hotter cities are carrying more ozone right now.
+    // ── Urban Heat: today's hourly ozone vs temperature for one city ──
+    // Demonstrates the "climate penalty" (Bloomer 2009) at the scale of a single
+    // day: ground-level ozone is photochemical, so it builds up as sunlight and
+    // heat peak in the afternoon and falls overnight. We pull hourly surface
+    // ozone (CAMS) and 2 m air temperature for today from the free, key-less
+    // Open-Meteo API and draw both curves on a dual axis.
     let uhChart = null;
-    let uhChartCache = null; // { ts, points }
-    async function fetchOzoneTemp(cityKey) {
-        const city = CITIES[cityKey];
-        if (!city) return null;
-        try {
-            const url = `https://api.waqi.info/feed/geo:${city.lat};${city.lon}/?token=${WAQI_TOKEN}`;
-            const res = await fetch(url, { method: 'GET', mode: 'cors' });
-            if (!res.ok) return null;
-            const data = await res.json();
-            if (data.status !== 'ok' || !data.data || !data.data.iaqi) return null;
-            const o3 = Number(data.data.iaqi.o3?.v);
-            const t = Number(data.data.iaqi.t?.v);
-            if (isNaN(o3) || isNaN(t) || o3 <= 0) return null;
-            return { city: city.name, x: Math.round(t * 10) / 10, y: Math.round(o3) };
-        } catch (e) { return null; }
+    const uhChartCache = {}; // cityKey -> { ts, hours, ozone, temp }
+    async function fetchOzoneHours(city) {
+        const aqUrl = `https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${city.lat}&longitude=${city.lon}&hourly=ozone&timezone=auto&forecast_days=1`;
+        const wxUrl = `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&hourly=temperature_2m&timezone=auto&forecast_days=1`;
+        const [aqRes, wxRes] = await Promise.all([fetch(aqUrl), fetch(wxUrl)]);
+        if (!aqRes.ok || !wxRes.ok) throw new Error('Open-Meteo request failed');
+        const aq = await aqRes.json();
+        const wx = await wxRes.json();
+        const times = aq?.hourly?.time || [];
+        const ozone = aq?.hourly?.ozone || [];
+        const temp = wx?.hourly?.temperature_2m || [];
+        if (!times.length || !ozone.length || !temp.length) throw new Error('No hourly data');
+        const hours = times.map(t => t.slice(11, 16)); // "HH:MM"
+        return { hours, ozone, temp };
     }
     window.initUrbanHeatChart = async function initUrbanHeatChart(force) {
-        const canvas = document.getElementById('uhOzoneTempChart');
+        const canvas = document.getElementById('uhOzoneHourChart');
         const status = document.getElementById('uh-chart-status');
+        const sel = document.getElementById('uh-chart-city');
         if (!canvas) return;
+        // Populate the city selector once
+        if (sel && sel.options.length === 0) {
+            INDIAN_CITIES.forEach(k => {
+                const opt = document.createElement('option');
+                opt.value = k; opt.textContent = CITIES[k]?.name || k;
+                sel.appendChild(opt);
+            });
+            sel.value = 'delhi';
+        }
+        const cityKey = (sel && sel.value) || 'delhi';
+        const city = CITIES[cityKey];
         try { await ensureChartJs(); }
         catch (e) { if (status) status.textContent = 'Chart library could not load.'; return; }
 
-        let points;
-        if (!force && uhChartCache && (Date.now() - uhChartCache.ts < 10 * 60 * 1000)) {
-            points = uhChartCache.points;
+        let series;
+        const cached = uhChartCache[cityKey];
+        if (!force && cached && (Date.now() - cached.ts < 30 * 60 * 1000)) {
+            series = cached;
         } else {
-            if (status) status.innerHTML = '<span class="pulse"></span> Loading live station readings…';
-            const results = await Promise.allSettled(INDIAN_CITIES.map(fetchOzoneTemp));
-            points = results.filter(r => r.status === 'fulfilled' && r.value).map(r => r.value);
-            // De-dupe by city, keep a clean spread
-            const seen = new Set();
-            points = points.filter(p => (seen.has(p.city) ? false : (seen.add(p.city), true)));
-            uhChartCache = { ts: Date.now(), points };
+            if (status) status.innerHTML = '<span class="pulse"></span> Loading today&rsquo;s hourly readings…';
+            try {
+                series = await fetchOzoneHours(city);
+                series.ts = Date.now();
+                uhChartCache[cityKey] = series;
+            } catch (e) {
+                if (uhChart) { try { uhChart.destroy(); } catch (err) {} uhChart = null; }
+                if (status) status.textContent = 'Could not load hourly data right now. Try the Refresh button in a moment.';
+                return;
+            }
         }
-
-        if (!points || points.length < 4) {
-            if (uhChart) { try { uhChart.destroy(); } catch (e) {} uhChart = null; }
-            if (status) status.textContent = points && points.length
-                ? `Only ${points.length} station(s) are reporting both ozone and temperature right now — not enough for a trend. Try again later in the day.`
-                : 'No stations are reporting both ozone and temperature right now. Try the Refresh button later in the day.';
-            return;
-        }
-
-        // Least-squares fit for the trend line
-        const n = points.length;
-        const mx = points.reduce((s, p) => s + p.x, 0) / n;
-        const my = points.reduce((s, p) => s + p.y, 0) / n;
-        let num = 0, den = 0;
-        points.forEach(p => { num += (p.x - mx) * (p.y - my); den += (p.x - mx) * (p.x - mx); });
-        const slope = den ? num / den : 0;
-        const intercept = my - slope * mx;
-        const xs = points.map(p => p.x);
-        const minX = Math.min(...xs), maxX = Math.max(...xs);
-        const trend = [{ x: minX, y: slope * minX + intercept }, { x: maxX, y: slope * maxX + intercept }];
 
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
         const gridColor = isDark ? '#334155' : '#E2E8F0';
+        // Mark the current hour so people can read "where we are now"
+        const nowHH = new Date().getHours();
+        const nowIdx = series.hours.findIndex(h => parseInt(h, 10) === nowHH);
+
         if (uhChart) { try { uhChart.destroy(); } catch (e) {} uhChart = null; }
         uhChart = new Chart(canvas, {
-            type: 'scatter',
+            type: 'line',
             data: {
+                labels: series.hours,
                 datasets: [
                     {
-                        label: 'Cities (now)',
-                        data: points,
-                        pointRadius: 6, pointHoverRadius: 8,
-                        backgroundColor: points.map(p => getAQIColor(p.y)),
-                        borderColor: '#fff', borderWidth: 1
+                        label: 'Ozone (µg/m³)', yAxisID: 'yOzone',
+                        data: series.ozone,
+                        borderColor: '#EA580C', backgroundColor: 'rgba(234,88,12,0.12)',
+                        borderWidth: 2.5, pointRadius: 0, tension: 0.35, fill: true
                     },
                     {
-                        type: 'line', label: 'Trend',
-                        data: trend, parsing: false,
-                        borderColor: slope >= 0 ? '#DC2626' : '#16A34A',
-                        borderWidth: 2, borderDash: [6, 4],
-                        pointRadius: 0, fill: false, tension: 0
+                        label: 'Air temperature (°C)', yAxisID: 'yTemp',
+                        data: series.temp,
+                        borderColor: '#DC2626', backgroundColor: 'transparent',
+                        borderWidth: 2, borderDash: [5, 4], pointRadius: 0, tension: 0.35, fill: false
                     }
                 ]
             },
             options: {
                 responsive: true, maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
                 plugins: {
-                    legend: { display: false },
-                    tooltip: { callbacks: { label: (ctx) => ctx.raw.city
-                        ? `${ctx.raw.city}: ${ctx.raw.x}°C, ozone ${ctx.raw.y}`
-                        : `${Math.round(ctx.raw.y)} at ${Math.round(ctx.raw.x)}°C` } }
+                    legend: { display: true, labels: { boxWidth: 14, font: { size: 11 } } },
+                    tooltip: { callbacks: { title: (items) => items.length ? `${items[0].label} today` : '' } }
                 },
                 scales: {
-                    x: { title: { display: true, text: 'Air temperature (°C)' }, grid: { color: gridColor } },
-                    y: { title: { display: true, text: 'Ozone (AQI sub-index)' }, grid: { color: gridColor }, beginAtZero: true }
+                    x: {
+                        grid: { display: false },
+                        ticks: { maxTicksLimit: 12, font: { size: 10 } },
+                        title: { display: true, text: 'Hour of day (local time)' }
+                    },
+                    yOzone: {
+                        position: 'left', beginAtZero: true,
+                        grid: { color: gridColor },
+                        title: { display: true, text: 'Ozone (µg/m³)', color: '#EA580C' },
+                        ticks: { color: '#EA580C' }
+                    },
+                    yTemp: {
+                        position: 'right',
+                        grid: { drawOnChartArea: false },
+                        title: { display: true, text: 'Temperature (°C)', color: '#DC2626' },
+                        ticks: { color: '#DC2626' }
+                    }
                 }
             }
         });
 
         if (status) {
-            const dir = slope > 0.05 ? 'up' : (slope < -0.05 ? 'down' : 'flat');
-            const msg = dir === 'up'
-                ? `Across ${n} cities reporting now, ozone rises about ${slope.toFixed(1)} index points per °C — hotter air, more ozone.`
-                : dir === 'down'
-                ? `Across ${n} cities reporting now, the live slope is slightly negative — a snapshot can run against the long-run trend (cleaner-but-hotter cities, time-of-day effects).`
-                : `Across ${n} cities reporting now, the live slope is roughly flat.`;
-            status.textContent = msg;
+            // Find the afternoon ozone peak to narrate the relationship
+            let peakI = 0;
+            for (let i = 1; i < series.ozone.length; i++) if (series.ozone[i] > series.ozone[peakI]) peakI = i;
+            const peakHour = series.hours[peakI];
+            const nowO3 = nowIdx >= 0 ? Math.round(series.ozone[nowIdx]) : null;
+            const nowT = nowIdx >= 0 ? Math.round(series.temp[nowIdx]) : null;
+            status.textContent = `${city.name} today: ozone peaks around ${peakHour}, riding the afternoon heat`
+                + (nowO3 != null ? ` — right now it's ${nowT}°C with ozone near ${nowO3} µg/m³.` : '.');
         }
     };
 
@@ -10746,7 +10760,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-sun" style="color: #EA580C; margin-right: 0.4rem;"></span>Urban Heat Island &mdash; The Temperature Divide</h2>
         <p style="font-size: 1.125rem; font-family: var(--serif); font-style: italic; color: var(--text-2); margin-bottom: 0.75rem;">The same sun. The same city. Dozens of different temperatures.</p>
-        <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="On the same hot day, one part of Delhi can be 18&deg;C hotter than another. The difference is not the sun &mdash; it is what is on the ground. Concrete, tin roofs and bare land trap heat. Trees, parks and water keep an area cool. This is called the urban heat island effect, and it sits right next to the air you breathe.">On a single summer afternoon, neighbourhoods just kilometres apart in Delhi can differ by nearly <strong>18&deg;C</strong>. The sun is the same everywhere &mdash; what changes is the <strong>ground</strong>. Concrete, asphalt, tin roofs and bare land absorb and radiate heat; tree canopy, parks and water bodies cool the air around them. This is the <strong>urban heat island effect</strong>, and it is the close cousin of the air quality crisis: the same dense, green-starved colonies that trap heat also trap pollution.</p>
+        <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="On the same hot day, one part of Delhi can be 18&deg;C hotter than another. The difference is not the sun &mdash; it is what is on the ground. Concrete, tin roofs and bare land trap heat. Trees, parks and water keep an area cool. This is called the urban heat island effect, and it sits right next to the air you breathe.">On a single summer afternoon, neighbourhoods just kilometres apart in Delhi can differ by nearly <strong>18&deg;C</strong>. The sun is the same everywhere &mdash; what changes is the <strong>ground</strong>. Concrete, asphalt, tin roofs and bare land absorb and radiate heat; tree canopy, parks and water bodies cool the air around them. This is the <strong>urban heat island effect</strong>, and it is the close cousin of the air quality crisis: the same dense, green-starved colonies that trap heat also trap pollution. <strong>Delhi is the worked example below</strong> because it has the most detailed neighbourhood-level data &mdash; but the same physics plays out in Mumbai, Hyderabad, Ahmedabad, Lucknow and every fast-building Indian city. The live chart further down lets you check any of them.</p>
     </div>
 
     <!-- ═══ Section 1: The Delhi heat map ═══ -->
@@ -10850,15 +10864,18 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
 
     <!-- ═══ Section 5: Live evidence chart ═══ -->
     <div class="card mb-3" style="border-left: 4px solid #EA580C;">
-        <div class="card-header" style="display:flex; justify-content:space-between; align-items:center; gap:0.75rem;">
-            <span class="card-title">Live evidence: ozone climbs with temperature</span>
-            <button type="button" onclick="window.initUrbanHeatChart &amp;&amp; window.initUrbanHeatChart(true)" style="font-size:0.75rem; font-weight:600; color:var(--accent); background:var(--green-50); border:1px solid var(--border); border-radius:6px; padding:0.3rem 0.7rem; cursor:pointer;"><span class="si si-spark" style="margin-right:3px;"></span>Refresh</button>
+        <div class="card-header" style="display:flex; justify-content:space-between; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+            <span class="card-title">Live evidence: ozone tracks the day&rsquo;s heat</span>
+            <div style="display:flex; align-items:center; gap:0.5rem;">
+                <select id="uh-chart-city" onchange="window.initUrbanHeatChart &amp;&amp; window.initUrbanHeatChart(true)" aria-label="Choose a city" style="font-size:0.8125rem; padding:0.3rem 0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg-card); color:var(--text-2);"></select>
+                <button type="button" onclick="window.initUrbanHeatChart &amp;&amp; window.initUrbanHeatChart(true)" style="font-size:0.75rem; font-weight:600; color:var(--accent); background:var(--green-50); border:1px solid var(--border); border-radius:6px; padding:0.3rem 0.7rem; cursor:pointer;"><span class="si si-spark" style="margin-right:3px;"></span>Refresh</button>
+            </div>
         </div>
         <div class="card-body">
-            <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Each dot is an Indian city right now. Across to the right is hotter air; up is more ozone. The dots tend to climb from bottom-left to top-right &mdash; hotter cities are carrying more ozone, live, today. This is the 'heat cooks ozone' link happening in real time.">Each dot is an Indian city, refreshed live from monitoring stations. Hotter air is to the right; more ozone is up. Watch the cloud tilt upward to the right &mdash; that climb <em>is</em> the &lsquo;heat cooks ozone&rsquo; relationship, happening today across the country.</p>
-            <div style="position:relative; height:340px; width:100%;"><canvas id="uhOzoneTempChart"></canvas></div>
-            <div id="uh-chart-status" style="text-align:center; font-size:0.8125rem; color:var(--text-3); margin-top:0.6rem;"><span class="pulse"></span> Loading live station readings&hellip;</div>
-            <p style="font-size: 0.75rem; color: var(--text-3); margin:0.75rem 0 0;"><em>Live data from WAQI / AQICN station feeds. Ozone is shown as the US-EPA AQI sub-index; temperature is from the same station. A city appears only when its station is currently reporting both values, so the set of dots changes through the day. The line is a least-squares fit &mdash; a positive slope is the &lsquo;climate penalty&rsquo;<sup>3</sup> in action. A single live snapshot mixes many local factors, so treat the trend as illustrative, not a controlled measurement.</em></p>
+            <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Pick any Indian city. The orange line is ozone hour by hour today; the red dashed line is the air temperature. Both climb through the morning and peak together in the afternoon &mdash; ground-level ozone is literally cooked by the day's heat and sunlight, then fades overnight. This pattern shows up in city after city, not just Delhi.">Pick any Indian city. The orange line is ozone, hour by hour today; the red dashed line is air temperature. Both climb through the morning and <strong>peak together in the afternoon</strong> &mdash; ground-level ozone is literally cooked by the day&rsquo;s heat and sunlight, then fades overnight. The same shape appears city after city, nationwide.</p>
+            <div style="position:relative; height:340px; width:100%;"><canvas id="uhOzoneHourChart"></canvas></div>
+            <div id="uh-chart-status" style="text-align:center; font-size:0.8125rem; color:var(--text-3); margin-top:0.6rem;"><span class="pulse"></span> Loading today&rsquo;s hourly readings&hellip;</div>
+            <p style="font-size: 0.75rem; color: var(--text-3); margin:0.75rem 0 0;"><em>Hourly surface ozone (CAMS) and 2&thinsp;m air temperature for today, from the free <a href="https://open-meteo.com/" target="_blank" rel="noopener" style="color:var(--accent);">Open-Meteo</a> API. The afternoon ozone peak riding on the temperature peak is the &lsquo;climate penalty&rsquo;<sup>3</sup> at the scale of a single day. Ozone here is a modelled hourly estimate, not a ground-station reading.</em></p>
         </div>
     </div>
 


### PR DESCRIPTION
Follow-ups to the Urban Heat Island panel (#139):

### 1. Cleaner live chart — hourly ozone vs temperature, any city
Replaces the cross-section scatter with **today's hourly surface ozone vs 2&thinsp;m air temperature** for a user-selected city, on a dual axis. Both curves climb through the morning and peak together in the afternoon — a clear, reliably-upward teaching visual of the "climate penalty." Data from the free, key-less **Open-Meteo** API (CAMS hourly ozone + weather). Adds a city dropdown, 30-min per-city cache, and a graceful fallback.

### 2. National framing
This is a national site, so the intro now states plainly that **Delhi is the data-rich worked example of a nationwide phenomenon**, and the live chart works for any Indian city.

### 3. Launch blog post
New post **"The Same Sun, a Different City: Why Your Neighbourhood's Heat Is an Air-Quality Story"** (`blog/posts/2026-06-10-urban-heat-island.md`), registered in the sidebar and README. It answers the "what is heat doing on an air-quality site?" question with the cited science and links to the panel.

No new dependencies. CSP only sets `frame-ancestors`, so the Open-Meteo calls are unaffected.

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_