### PR TITLE
docs: update ward-map blog for completed 4-layer, 9-city build

### DIFF
--- a/blog/posts/2026-06-10-how-polluted-is-your-ward.md
+++ b/blog/posts/2026-06-10-how-polluted-is-your-ward.md
@@ -8,13 +8,22 @@ When the news says "Delhi AQI is 320," it hides something important: there is no
 
 A recent series by **Unmapped** (Vaishnavi Iyer) made this beautifully clear for Bengaluru, colouring all of the city's wards by land-surface temperature, green cover, and built-up area — *"How hot is your ward? How cool is your ward?"* It's a powerful idea: zoom from the city down to the ward, and the inequality jumps out.
 
-We asked the obvious question — **can we do this for air?** — and just shipped the first version: [**How Polluted Is Your Ward?**](/index.html#ward-map), under *City Data*.
+We asked the obvious question — **can we do this for air?** — and built it: [**How Polluted Is Your Ward?**](/index.html#ward-map), under *City Data*. It grew into four layers across nine cities.
 
 ## What it shows
 
-Choose a city and every municipal ward is shaded by its current PM2.5 — **Delhi (290 wards), Bengaluru (243), and Jaipur (77)** are live, with more coming. Hover any ward for its estimate and category. A live "But…" panel calls out the spread: how many wards are in *Poor* air or worse right now, the dirtiest and cleanest ward, and the citywide range.
+Choose a city and every municipal ward is shaded four different ways, switchable with one click:
 
-On a typical Delhi afternoon, that range runs from roughly **45 to 270 µg/m³ across wards** — a 6× difference, same city, same hour. The map makes a point that a single AQI number can never make: clean air is unevenly distributed, and where you live changes what you breathe.
+- **Air quality** — each ward's PM2.5 right now
+- **Heat** — land-surface temperature on a hot-season afternoon
+- **Green cover** — how much of the ward is vegetation
+- **Built-up** — how much is concrete
+
+Nine of India's ten largest cities are live — **Delhi (290 wards), Mumbai (227), Bengaluru (243), Hyderabad (145), Chennai (201), Kolkata (141), Jaipur (77), Pune (58) and Ahmedabad (48)**. Hover any ward for its value, and a "But…" panel calls out the extremes: the dirtiest and cleanest ward, the hottest and coolest, the greenest and most paved-over.
+
+On a typical Delhi afternoon, the PM2.5 range runs from roughly **45 to 270 µg/m³ across wards** — a 6× difference, same city, same hour. The map makes a point that a single AQI number can never make: clean air is unevenly distributed, and where you live changes what you breathe.
+
+Flip to the **Heat** layer and a second story appears. In every city, the hottest fifth of wards are markedly more built-up and less green than the coolest fifth — the urban heat-island effect, visible in each city's own data. The four layers aren't separate trivia; they're the same story of unequal cities told four ways.
 
 ## The honest part: why this is harder for air than for heat
 
@@ -24,12 +33,12 @@ Here's the catch we want to be upfront about. Unmapped's heat and green maps wor
 
 That means the map shows the citywide **spread**, not a calibrated reading for every street. It's sharper where there are more monitors (Delhi) and coarser where there are few (Jaipur). We label this clearly on the panel, because hiding the method would be exactly the kind of false precision JanVayu exists to push back against. This is the same lesson as our [Data Source Selector](/index.html#source-selector): always ask *which monitor, which method*.
 
+The three satellite layers come from open, calibrated data: **heat** from Landsat 8/9 land-surface temperature (~30 m), **green** and **built-up** from ESA WorldCover 2021 (10 m). Each ward's value is computed by aggregating the satellite pixels that fall inside its boundary. Unlike the interpolated air layer, these are measured directly — every ward has true coverage.
+
 ## What's next
 
-Two upgrades are on the roadmap:
-
-1. **Satellite-derived per-ward PM2.5.** Just as Unmapped used satellite temperature, there is satellite-derived PM2.5 (modelled from aerosol optical depth at ~1 km). Aggregated to ward boundaries, it would give true full-coverage values — the methodological twin of their heat map. This is a data-pipeline job, and it's the planned successor to the live-interpolation version.
-2. **More cities.** The map is built to take any city once we have its ward boundaries — the metros next, then tier-1 and tier-2 cities.
+1. **Satellite-derived per-ward PM2.5.** The air layer is still interpolated from monitors. There is also satellite-derived PM2.5 (modelled from aerosol optical depth at ~1 km); aggregated to wards, it would give the air layer the same full coverage the heat and green layers already have. That's the next pipeline.
+2. **More cities.** Nine of the top ten are in (Surat is missing only because no open ward-boundary file exists for it yet). The map takes any city the moment we have its ward boundaries — tier-1 and tier-2 cities follow.
 
 The ambition is simple: let anyone in any Indian city zoom past the headline number and ask the real question — *how clean is the air on my street, and why is it different from the next ward over?*
 
@@ -37,4 +46,4 @@ Explore it: [**How Polluted Is Your Ward?**](/index.html#ward-map).
 
 ---
 
-*Inspiration: Vaishnavi Iyer / Unmapped, "How hot is your ward?" ward-level maps of Bengaluru. Ward boundaries: DataMeet Municipal Spatial Data (open). Live air-quality data: CPCB / WAQI station network, interpolated. Method and limitations are described on the panel itself.*
+*Inspiration: Vaishnavi Iyer / Unmapped, "How hot is your ward?" ward-level maps of Bengaluru. Ward boundaries: DataMeet Municipal Spatial Data and the Mumbai spatial-data project (open). Air quality: CPCB / WAQI station network, interpolated. Heat: USGS/NASA Landsat 8/9 surface temperature via Microsoft Planetary Computer. Green cover & built-up: ESA WorldCover 2021. Method and limitations are described on each layer of the panel itself.*


### PR DESCRIPTION
Updates the ward-map blog post to match the now-completed build. The original framed the satellite layers and extra cities as "coming"; they're live, so:

- **What it shows** — describes the four-layer toggle, the nine cities, and the heat-island linkage (hottest vs coolest fifth of wards by built-up/green).
- **What's next** — narrows to the genuine remaining work (satellite-derived PM2.5; tier-2 cities; notes Surat's missing boundary file).
- **Sources** — credits Landsat via Planetary Computer and ESA WorldCover.

Docs only.

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_