### PR TITLE
feat: ward atlas polish — search/locate, correlation view, two-finger pan (v26.6.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.25] - 2026-06-11
+
+### Added — Ward Atlas polish ([#151](https://github.com/JanVayu/JanVayu/issues/151))
+
+- **Ward search + "My ward"**: type-ahead search (datalist of every ward name) zooms to and highlights the chosen ward; a geolocation button finds the nearest ward to the user.
+- **Correlation view**: a per-ward scatter (Chart.js) of the active layer's metric vs how built-up the ward is (green uses built; built uses green), with the Pearson *r* and a plain-language read-out. Surfaces the heat-island relationship quantitatively — e.g. Delhi built-up vs surface temp *r* ≈ +0.69, green vs temp *r* ≈ −0.70 — and honestly reports weak/no correlation where it exists (e.g. Bengaluru ≈ 0).
+- **Two-finger pan on touch**: the tall mobile ward map no longer traps page scroll — one finger scrolls the page, two fingers move the map, with an on-map hint.
+
+### Notes — roadmap items still blocked on data
+
+- **Satellite-derived per-ward PM2.5** ([#149](https://github.com/JanVayu/JanVayu/issues/149)) remains open: no openly-fetchable ~1 km PM2.5 raster (ACAG is behind a portal; Planetary Computer hosts only Sentinel-3 aerosol optical depth, not a calibrated PM2.5 product).
+- **Surat** ([#150](https://github.com/JanVayu/JanVayu/issues/150)) remains open: no open ward-boundary file found.
+
 ## [v26.6.24] - 2026-06-11
 
 ### Added — Ward-Level Atlas ("How Polluted Is Your Ward?")

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-06-24"
-version: "26.6.24"
+date-released: "2026-06-11"
+version: "26.6.25"

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -353,5 +353,5 @@ Building on the Phase 5.14 ward atlas. Tracked on [GitHub Issues](https://github
 - [ ] **Satellite-derived per-ward PM2.5** ([#149](https://github.com/JanVayu/JanVayu/issues/149)) — replace the interpolated air layer with modelled satellite PM2.5 (aerosol optical depth, ~1 km) aggregated to wards, giving the air layer the same full coverage the heat/green/built-up layers already have.
 - [ ] **Surat (10th metro)** ([#150](https://github.com/JanVayu/JanVayu/issues/150)) — no open, curl-verifiable ward-polygon file exists yet; add once a source is found or digitised from the SMC GIS portal.
 - [ ] **Tier-1 / tier-2 cities** — extend the atlas city-by-city as ward boundaries are sourced (Lucknow, Kanpur, Nagpur, Indore, Bhopal, Patna, …).
-- [ ] **Ward Atlas polish** ([#151](https://github.com/JanVayu/JanVayu/issues/151)) — ward search / locate-me, two-finger pan on touch, a correlation view (PM2.5 vs built-up / green / heat), and time-aware (seasonal-median) heat.
+- [~] **Ward Atlas polish** ([#151](https://github.com/JanVayu/JanVayu/issues/151)) — ✅ ward search / locate-me, ✅ two-finger pan on touch, ✅ correlation view (active layer vs built-up / green, with Pearson *r*); ⏳ time-aware (seasonal-median) heat still to do.
 - [ ] **Per-ward share cards** — extend the Shareable AQI Cards generator to ward snapshots ("My ward vs the city").

--- a/index.html
+++ b/index.html
@@ -4772,6 +4772,49 @@ body {
         wardRenderStats(layer, vals, dom);
         wardRenderMethod(layer);
         wardRenderStatus(layer);
+        wardRenderCorrelation(layer);
+    }
+
+    // Per-ward scatter: the active metric (y) vs how built-up the ward is (x) —
+    // green uses x=built (concrete vs greenery); built uses x=green to avoid x==y.
+    let wardCorrChart = null;
+    async function wardRenderCorrelation(layer) {
+        const card = document.getElementById('ward-corr-card');
+        const canvas = document.getElementById('ward-corr-chart');
+        if (!card || !canvas || !wardState.geo) return;
+        const yProp = WARD_LAYERS[layer].prop;
+        const xProp = layer === 'built' ? 'green' : 'built';
+        const xLabel = xProp === 'green' ? 'Green cover %' : 'Built-up %';
+        const yLabels = { pm25: 'Est. PM2.5 µg/m³', lst: 'Surface temp °C', green: 'Green cover %', built: 'Built-up %' };
+        const pts = [];
+        wardState.geo.features.forEach(f => {
+            const p = f.properties, x = p[xProp], y = p[yProp];
+            if (x != null && y != null && !isNaN(x) && !isNaN(y)) pts.push({ x: +x, y: +y, name: p.name });
+        });
+        if (pts.length < 5) { card.style.display = 'none'; return; }
+        card.style.display = '';
+        document.getElementById('ward-corr-title').textContent = `${yLabels[layer]} vs ${xLabel}`;
+        // Pearson r for the caption
+        const n = pts.length, mx = pts.reduce((s, q) => s + q.x, 0) / n, my = pts.reduce((s, q) => s + q.y, 0) / n;
+        let sxy = 0, sxx = 0, syy = 0;
+        pts.forEach(q => { const dx = q.x - mx, dy = q.y - my; sxy += dx * dy; sxx += dx * dx; syy += dy * dy; });
+        const r = (sxx && syy) ? sxy / Math.sqrt(sxx * syy) : 0;
+        const dir = r > 0.15 ? 'rises with' : r < -0.15 ? 'falls as you add' : 'shows little link to';
+        document.getElementById('ward-corr-note').innerHTML = `Each dot is a ward. <strong>${yLabels[layer].replace(/ µg.*| °C| %/, '')}</strong> ${dir} ${xLabel.toLowerCase().replace(' %', '')} &mdash; correlation <strong>r = ${r.toFixed(2)}</strong>.`;
+        try { await ensureChartJs(); } catch (e) { card.style.display = 'none'; return; }
+        if (wardCorrChart) { try { wardCorrChart.destroy(); } catch (e) {} wardCorrChart = null; }
+        wardCorrChart = new Chart(canvas.getContext('2d'), {
+            type: 'scatter',
+            data: { datasets: [{ data: pts, backgroundColor: 'rgba(124,58,237,0.55)', pointRadius: 3, pointHoverRadius: 5 }] },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                plugins: { legend: { display: false }, tooltip: { callbacks: { label: c => `${c.raw.name}: ${c.raw.x}, ${c.raw.y}` } } },
+                scales: {
+                    x: { title: { display: true, text: xLabel, font: { size: 10 } }, ticks: { font: { size: 9 } } },
+                    y: { title: { display: true, text: yLabels[layer], font: { size: 10 } }, ticks: { font: { size: 9 } } }
+                }
+            }
+        });
     }
 
     function wardRenderLegend(layer, dom) {
@@ -4922,7 +4965,56 @@ body {
         try { wardMap.fitBounds(wardLayer.getBounds(), { padding: [12, 12] }); } catch (e) {}
         setTimeout(() => { try { wardMap.invalidateSize(); } catch (e) {} }, 200);
 
+        // Two-finger pan on touch: one finger scrolls the page, two fingers move the map
+        if (L.Browser && L.Browser.touch) {
+            wardMap.dragging.disable();
+            const c = wardMap.getContainer();
+            c.addEventListener('touchstart', e => { e.touches.length >= 2 ? wardMap.dragging.enable() : wardMap.dragging.disable(); }, { passive: true });
+            c.addEventListener('touchend', e => { if (e.touches.length < 2) wardMap.dragging.disable(); }, { passive: true });
+            const hint = L.control({ position: 'bottomleft' });
+            hint.onAdd = function () { const d = L.DomUtil.create('div'); d.style.cssText = 'background:rgba(0,0,0,0.55);color:#fff;font-size:0.65rem;padding:2px 6px;border-radius:4px;'; d.textContent = 'Use two fingers to move the map'; return d; };
+            hint.addTo(wardMap);
+        }
+
+        // Populate ward search datalist
+        const dl = document.getElementById('ward-search-list');
+        if (dl) dl.innerHTML = geo.features.map(f => `<option value="${(f.properties.name || '').replace(/"/g, '&quot;')}">`).join('');
+        const si = document.getElementById('ward-search'); if (si) si.value = '';
+
         wardRenderLayer();
+    };
+
+    // Zoom to a ward by name; highlight + open its tooltip
+    function wardZoomToFeature(name) {
+        if (!wardLayer || !wardMap || !name) return false;
+        let target = null;
+        wardLayer.eachLayer(l => { if (!target && l.feature && (l.feature.properties.name || '').toLowerCase() === name.toLowerCase()) target = l; });
+        if (!target) return false;
+        try { wardMap.fitBounds(target.getBounds(), { maxZoom: 14, padding: [40, 40] }); } catch (e) {}
+        target.openTooltip();
+        const orig = target.options.fillOpacity;
+        target.setStyle({ weight: 3, color: '#111827', fillOpacity: 0.95 });
+        setTimeout(() => { try { wardLayer.resetStyle(target); } catch (e) {} }, 2200);
+        return true;
+    }
+    window.wardSearch = function wardSearch() {
+        const si = document.getElementById('ward-search'); if (!si) return;
+        const v = si.value.trim(); if (!v) return;
+        wardZoomToFeature(v);
+    };
+    window.wardLocateMe = function wardLocateMe() {
+        const status = document.getElementById('ward-map-status');
+        if (!navigator.geolocation) { if (status) status.textContent = 'Geolocation is not available in this browser.'; return; }
+        if (status) status.textContent = 'Locating…';
+        navigator.geolocation.getCurrentPosition(pos => {
+            const { latitude: lat, longitude: lon } = pos.coords;
+            const geo = wardState.geo; if (!geo) return;
+            // nearest ward by centroid
+            let best = null, bestD = Infinity;
+            geo.features.forEach(f => { const p = f.properties; const d = (p.cx - lon) ** 2 + (p.cy - lat) ** 2; if (d < bestD) { bestD = d; best = p; } });
+            if (best && !wardZoomToFeature(best.name)) { /* feature not found */ }
+            if (status && best) status.textContent = `Nearest ward: ${best.name}.`;
+        }, () => { if (status) status.textContent = 'Could not get your location (permission denied?).'; }, { timeout: 8000 });
     };
 
     // ── PM2.5/AQI Utilities ──
@@ -16711,7 +16803,7 @@ Yours faithfully,
 <template id="tmpl-about">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
         <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.24 | Updated 11 June 2026 | <strong>Ward-Level Atlas + Urban Heat Island</strong> &mdash; new "How Polluted Is Your Ward?" panel (City Data) colouring every municipal ward across 9 of India's top-10 cities, with a four-layer toggle: live PM2.5 (interpolated from CPCB/WAQI monitors), heat (Landsat surface temperature), green cover and built-up (ESA WorldCover). The Heat layer surfaces the urban heat-island link &mdash; hottest vs coolest wards by concrete and greenery &mdash; from each city's own data. Plus a new Urban Heat Island panel and two blog posts. See the <a href="/docs/#/wiki/Roadmap" target="_blank">roadmap</a>.<br>v26.6.19 | Updated 20 May 2026 | <strong>In-page Ask JanVayu widget refreshed</strong> &mdash; v26.6.18 updated the standalone <code>/ask/</code> PWA but missed the in-page panel at <code>tmpl-ask-janvayu</code>, which still said "in English or Hindi" and had no example questions. Now matches the PWA: full v26.6.x capability statement, 10 example chips that fill the input on tap, new language dropdown (10 languages selectable), "How it works" rewritten to describe the 4 data fetches + 7 calculators + 6 RTI templates + source-citation requirement.<br>v26.6.18 | Updated 20 May 2026 | <strong>Ask JanVayu onboarding refresh + 5 new languages</strong>. (1) Welcome subtitle rewritten across all languages to surface what the bot actually does: live AQI · calculators · rankings · trends · apportionment · RTI · multi-source. (2) Suggestion chips: 7 &rarr; 10, surfacing the new Phase A&ndash;D capabilities (rankings, apportionment, RTI drafting, trend, multi-source reliability, cigarette equivalence, migration). (3) Five new languages added: Telugu, Gujarati, Kannada, Malayalam, Punjabi &mdash; total now 10, covering ~95% of Indian mother-tongue speakers. Backend LANG_NAMES extended so Groq language-pinning works for all 10.<br>v26.6.17 | Updated 20 May 2026 | <strong>Two bugs found by live integration testing of Phases A&ndash;D</strong>. (1) Ranking responses were stripping city names because <code>rankings.mjs</code> returns <code>{key, name, aqi, pm25}</code> but the integration code used <code>c.city</code> (undefined). Fixed: <code>c.name || c.city || c.key</code>. (2) Empty Groq responses returned a useless "No response generated." string. Now the fallback surfaces the actual live data (AQI, PM2.5, nearest station) + Groq error message + retry hint. Plus the raw Groq response is logged for diagnostics. 8 queries tested end-to-end against the live endpoint &mdash; all returning useful, sourced answers.<br>v26.6.16 | Updated 20 May 2026 | <strong>Ask JanVayu Phase D &mdash; multi-source spread + divergence flagging</strong>. Closes the calibration loop. Cross-references four sources: WAQI nearest station, WAQI bounds-network (intra-city spread), Sensor.Community community sensors, and a new cached <code>IQAIR_2025_ANNUAL</code> dataset of 37 Indian cities. Computes (a) intra-city spatial spread, (b) WAQI-vs-community snapshot agreement, (c) today-vs-IQAir-baseline anomaly ratio. Flags >2× station range, >50% inter-source disagreement, >1.5× / <0.5× annual deviation. Always-on anomaly note injected even on non-multi-source queries when live PM2.5 is anomalous. <strong>Cumulative across Phases A&ndash;D</strong>: bot wires 4 tools, runs 7 calculators, knows 10 cities' apportionment, drafts 6 RTI templates, cross-references 4 sources, cites every number.<br>v26.6.15 | Updated 20 May 2026 | <strong>Ask JanVayu Phase C &mdash; source apportionment + RTI drafting</strong>. New city-level apportionment dataset (10 cities + national fallback) with citations to CEEW 2024 / TERI / IIT-Delhi DSS / CSIR-NEERI / Bose Institute / Jadavpur — bot returns precise source-mix breakdown when asked "where does the pollution come from in [city]". Six RTI templates inline (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) each with correct PIO department + address + statutory anchors. Instruction #15 tells the LLM to present templates AS-IS, not paraphrase.<br>v26.6.14 | Updated 20 May 2026 | <strong>Ask JanVayu Phase B &mdash; calculators the bot actually runs</strong>. Seven deterministic calculators wired in: cigarette equivalence (Berkeley Earth), mortality risk (Krishna et al. 2024), life-expectancy loss (AQLI 2025), migration benefit (live PM2.5 of both cities), transport exposure (WHO/CPCB multipliers), purifier CADR (AHAM formula), school-closure forecast (CAQM GRAP). Each runs deterministically when the question implies it, returns its result with a primary-source citation, and the LLM is instructed to use those numbers verbatim. Input extraction handles transport mode + hours, room sqft, destination city.<br>v26.6.13 | Updated 20 May 2026 | <strong>Ask JanVayu Phase A &mdash; tool wiring + methodology calibration</strong>. The chatbot now calls three more JanVayu endpoints based on the user's question: <code>rankings.mjs</code> for "top 5 worst" / "cleanest" / leaderboard queries; <code>historical-aqi.mjs</code> for trend / YoY / "since 2019" queries; <code>community-sensors.mjs</code> (Sensor.Community CC0) for "near my area" / hyperlocal / community-sensor queries. All three run in parallel via Promise.all with 6 s timeouts. Plus a new <code>METHODOLOGY_REFERENCE</code> prompt block covering the five biggest "why do two sources disagree" cases &mdash; CPCB-vs-US-EPA AQI scales, WAQI single station vs CPCB network, CPCB-vs-IQAir annual, Krishna-1.5M vs Lancet-1.72M, low-cost vs regulatory accuracy trade-offs. Phase B/C/D coming next.<br>v26.6.12 | Updated 20 May 2026 | <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong>. (1) <em>Station-count queries</em>: new WAQI bounds-endpoint fetch returns a real station list + count for the user's city plus the CPCB national ~533 figure. (2) <em>Sources required</em>: new <code>TOPICAL_REFERENCE</code> prompt block (monitoring network, low-cost sensors, EVs, transport, recent court orders) + hard instruction "if you cite a number without a source, you have failed". (3) <em>Delhi/Mandir-Marg bias</em>: new <code>isNationalQuery()</code> detector triggers India-wide framing for topical questions; reference data restructured to lead with national figures, not Delhi.</div>
+        <div style="font-family: var(--mono); font-size: 0.75rem; color: var(--text-3); margin-bottom: 1rem;">v26.6.25 | Updated 11 June 2026 | <strong>Ward Atlas polish</strong> &mdash; ward search + a "My ward" geolocate button, a per-ward correlation view (the active layer vs how built-up the ward is, with the Pearson <em>r</em> &mdash; e.g. Delhi heat vs concrete r&nbsp;&approx;&nbsp;+0.69), and two-finger pan so the mobile map no longer traps page scroll.<br>v26.6.24 | Updated 11 June 2026 | <strong>Ward-Level Atlas + Urban Heat Island</strong> &mdash; new "How Polluted Is Your Ward?" panel (City Data) colouring every municipal ward across 9 of India's top-10 cities, with a four-layer toggle: live PM2.5 (interpolated from CPCB/WAQI monitors), heat (Landsat surface temperature), green cover and built-up (ESA WorldCover). The Heat layer surfaces the urban heat-island link &mdash; hottest vs coolest wards by concrete and greenery &mdash; from each city's own data. Plus a new Urban Heat Island panel and two blog posts. See the <a href="/docs/#/wiki/Roadmap" target="_blank">roadmap</a>.<br>v26.6.19 | Updated 20 May 2026 | <strong>In-page Ask JanVayu widget refreshed</strong> &mdash; v26.6.18 updated the standalone <code>/ask/</code> PWA but missed the in-page panel at <code>tmpl-ask-janvayu</code>, which still said "in English or Hindi" and had no example questions. Now matches the PWA: full v26.6.x capability statement, 10 example chips that fill the input on tap, new language dropdown (10 languages selectable), "How it works" rewritten to describe the 4 data fetches + 7 calculators + 6 RTI templates + source-citation requirement.<br>v26.6.18 | Updated 20 May 2026 | <strong>Ask JanVayu onboarding refresh + 5 new languages</strong>. (1) Welcome subtitle rewritten across all languages to surface what the bot actually does: live AQI · calculators · rankings · trends · apportionment · RTI · multi-source. (2) Suggestion chips: 7 &rarr; 10, surfacing the new Phase A&ndash;D capabilities (rankings, apportionment, RTI drafting, trend, multi-source reliability, cigarette equivalence, migration). (3) Five new languages added: Telugu, Gujarati, Kannada, Malayalam, Punjabi &mdash; total now 10, covering ~95% of Indian mother-tongue speakers. Backend LANG_NAMES extended so Groq language-pinning works for all 10.<br>v26.6.17 | Updated 20 May 2026 | <strong>Two bugs found by live integration testing of Phases A&ndash;D</strong>. (1) Ranking responses were stripping city names because <code>rankings.mjs</code> returns <code>{key, name, aqi, pm25}</code> but the integration code used <code>c.city</code> (undefined). Fixed: <code>c.name || c.city || c.key</code>. (2) Empty Groq responses returned a useless "No response generated." string. Now the fallback surfaces the actual live data (AQI, PM2.5, nearest station) + Groq error message + retry hint. Plus the raw Groq response is logged for diagnostics. 8 queries tested end-to-end against the live endpoint &mdash; all returning useful, sourced answers.<br>v26.6.16 | Updated 20 May 2026 | <strong>Ask JanVayu Phase D &mdash; multi-source spread + divergence flagging</strong>. Closes the calibration loop. Cross-references four sources: WAQI nearest station, WAQI bounds-network (intra-city spread), Sensor.Community community sensors, and a new cached <code>IQAIR_2025_ANNUAL</code> dataset of 37 Indian cities. Computes (a) intra-city spatial spread, (b) WAQI-vs-community snapshot agreement, (c) today-vs-IQAir-baseline anomaly ratio. Flags >2× station range, >50% inter-source disagreement, >1.5× / <0.5× annual deviation. Always-on anomaly note injected even on non-multi-source queries when live PM2.5 is anomalous. <strong>Cumulative across Phases A&ndash;D</strong>: bot wires 4 tools, runs 7 calculators, knows 10 cities' apportionment, drafts 6 RTI templates, cross-references 4 sources, cites every number.<br>v26.6.15 | Updated 20 May 2026 | <strong>Ask JanVayu Phase C &mdash; source apportionment + RTI drafting</strong>. New city-level apportionment dataset (10 cities + national fallback) with citations to CEEW 2024 / TERI / IIT-Delhi DSS / CSIR-NEERI / Bose Institute / Jadavpur — bot returns precise source-mix breakdown when asked "where does the pollution come from in [city]". Six RTI templates inline (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) each with correct PIO department + address + statutory anchors. Instruction #15 tells the LLM to present templates AS-IS, not paraphrase.<br>v26.6.14 | Updated 20 May 2026 | <strong>Ask JanVayu Phase B &mdash; calculators the bot actually runs</strong>. Seven deterministic calculators wired in: cigarette equivalence (Berkeley Earth), mortality risk (Krishna et al. 2024), life-expectancy loss (AQLI 2025), migration benefit (live PM2.5 of both cities), transport exposure (WHO/CPCB multipliers), purifier CADR (AHAM formula), school-closure forecast (CAQM GRAP). Each runs deterministically when the question implies it, returns its result with a primary-source citation, and the LLM is instructed to use those numbers verbatim. Input extraction handles transport mode + hours, room sqft, destination city.<br>v26.6.13 | Updated 20 May 2026 | <strong>Ask JanVayu Phase A &mdash; tool wiring + methodology calibration</strong>. The chatbot now calls three more JanVayu endpoints based on the user's question: <code>rankings.mjs</code> for "top 5 worst" / "cleanest" / leaderboard queries; <code>historical-aqi.mjs</code> for trend / YoY / "since 2019" queries; <code>community-sensors.mjs</code> (Sensor.Community CC0) for "near my area" / hyperlocal / community-sensor queries. All three run in parallel via Promise.all with 6 s timeouts. Plus a new <code>METHODOLOGY_REFERENCE</code> prompt block covering the five biggest "why do two sources disagree" cases &mdash; CPCB-vs-US-EPA AQI scales, WAQI single station vs CPCB network, CPCB-vs-IQAir annual, Krishna-1.5M vs Lancet-1.72M, low-cost vs regulatory accuracy trade-offs. Phase B/C/D coming next.<br>v26.6.12 | Updated 20 May 2026 | <strong>Ask JanVayu &mdash; three bugs fixed from user testing</strong>. (1) <em>Station-count queries</em>: new WAQI bounds-endpoint fetch returns a real station list + count for the user's city plus the CPCB national ~533 figure. (2) <em>Sources required</em>: new <code>TOPICAL_REFERENCE</code> prompt block (monitoring network, low-cost sensors, EVs, transport, recent court orders) + hard instruction "if you cite a number without a source, you have failed". (3) <em>Delhi/Mandir-Marg bias</em>: new <code>isNationalQuery()</code> detector triggers India-wide framing for topical questions; reference data restructured to lead with national figures, not Delhi.</div>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu is a free website built by citizens, not the government. We track air pollution across India and hold leaders accountable for keeping the air clean.">An independent, citizen-led air quality monitoring and accountability platform for India.</p>
     </div>
     <div class="card mb-2">
@@ -18166,6 +18258,9 @@ Yours faithfully,
                     <option value="pune">Pune — 58 wards</option>
                     <option value="jaipur">Jaipur — 77 wards</option>
                 </select>
+                <input list="ward-search-list" id="ward-search" placeholder="Find a ward…" onchange="window.wardSearch &amp;&amp; window.wardSearch()" style="max-width:170px; font-size:0.82rem; padding:0.3rem 0.5rem; border:1px solid var(--border); border-radius:8px;">
+                <datalist id="ward-search-list"></datalist>
+                <button type="button" onclick="window.wardLocateMe &amp;&amp; window.wardLocateMe()" title="Find my ward" style="font-size:0.78rem; font-weight:600; padding:0.32rem 0.6rem; border-radius:14px; border:1px solid var(--border); background:var(--bg-card); color:var(--text-2); cursor:pointer;"><span class="si si-sm si-map" style="margin-right:3px;"></span>My ward</button>
             </div>
             <div style="display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center;" id="ward-layer-toggle">
                 <span style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-3); margin-right:0.2rem;">Layer</span>
@@ -18192,6 +18287,13 @@ Yours faithfully,
                 </div>
             </div>
             <div class="alert alert-info" style="margin:0;"><div id="ward-method"></div></div>
+            <div class="card mt-2" id="ward-corr-card" style="display:none;">
+                <div class="card-header"><span class="card-title" id="ward-corr-title" style="font-size:0.85rem;">Relationship</span></div>
+                <div class="card-body" style="padding:0.6rem;">
+                    <div style="height:200px;"><canvas id="ward-corr-chart" role="img" aria-label="Per-ward correlation scatter"></canvas></div>
+                    <p id="ward-corr-note" style="font-size:0.74rem; color:var(--text-3); margin:0.4rem 0 0;"></p>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.24",
+  "version": "26.6.25",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Finishes the **tractable** items of the Ward Atlas roadmap ([#151](https://github.com/JanVayu/JanVayu/issues/151)) and versions the release.

### Added
- **Ward search + "My ward"** — type-ahead search (datalist of every ward name) zooms to and highlights the chosen ward; a geolocate button finds the nearest ward to the user.
- **Correlation view** — a per-ward Chart.js scatter of the active layer's metric vs how built-up the ward is (green uses built; built uses green), with the **Pearson _r_** and a plain-language read-out. Surfaces the heat-island link quantitatively (Delhi heat-vs-built _r_ ≈ +0.69, green ≈ −0.70) and **honestly reports weak/no correlation** where it exists (Bengaluru ≈ 0).
- **Two-finger pan on touch** — one finger scrolls the page, two move the map, with an on-map hint. Fixes the tall mobile map trapping page scroll.

Version bump 26.6.24 → **26.6.25** (`package.json`, `CITATION.cff`), CHANGELOG entry, roadmap #151 marked partial, About version note.

### Still blocked on data (left open, not faked)
- **Satellite per-ward PM2.5** ([#149](https://github.com/JanVayu/JanVayu/issues/149)) — no openly-fetchable ~1 km PM2.5 raster (ACAG is portal-gated; Planetary Computer hosts only Sentinel-3 aerosol optical depth, not a calibrated PM2.5 product).
- **Surat** ([#150](https://github.com/JanVayu/JanVayu/issues/150)) — no open ward-boundary file found.

Verified non-empty diff (5 files, +120).

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_