### PR TITLE
fix: ward map — guarantee the Air-quality explanation always shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Satellite-derived per-ward PM2.5** ([#149](https://github.com/JanVayu/JanVayu/issues/149), closed not-planned): no openly-fetchable ~1 km PM2.5 raster exists (ACAG is portal-gated; Planetary Computer hosts only Sentinel-3 aerosol optical depth, not a calibrated PM2.5 product). The air layer remains live-interpolated.
 - **Surat ward map** ([#150](https://github.com/JanVayu/JanVayu/issues/150), closed not-planned): no open ward-boundary file exists. Chandigarh was added as the 10th city in its place.
 
+### Fixed
+
+- Ward map: the "How this is built" explanation could be blank on first paint of the default Air-quality layer if a non-critical UI step (touch-pan / search datalist) threw before the layer rendered. The layer now renders first and those enhancements run after, guarded; the air-layer explanation is also seeded into the template so it shows even before JS runs. Service-worker cache bumped to refresh returning visitors.
+
 ## [v26.6.25] - 2026-06-11
 
 ### Added — Ward Atlas polish ([#151](https://github.com/JanVayu/JanVayu/issues/151))

--- a/index.html
+++ b/index.html
@@ -4966,23 +4966,27 @@ body {
         try { wardMap.fitBounds(wardLayer.getBounds(), { padding: [12, 12] }); } catch (e) {}
         setTimeout(() => { try { wardMap.invalidateSize(); } catch (e) {} }, 200);
 
-        // Two-finger pan on touch: one finger scrolls the page, two fingers move the map
-        if (L.Browser && L.Browser.touch) {
-            wardMap.dragging.disable();
-            const c = wardMap.getContainer();
-            c.addEventListener('touchstart', e => { e.touches.length >= 2 ? wardMap.dragging.enable() : wardMap.dragging.disable(); }, { passive: true });
-            c.addEventListener('touchend', e => { if (e.touches.length < 2) wardMap.dragging.disable(); }, { passive: true });
-            const hint = L.control({ position: 'bottomleft' });
-            hint.onAdd = function () { const d = L.DomUtil.create('div'); d.style.cssText = 'background:rgba(0,0,0,0.55);color:#fff;font-size:0.65rem;padding:2px 6px;border-radius:4px;'; d.textContent = 'Use two fingers to move the map'; return d; };
-            hint.addTo(wardMap);
-        }
-
-        // Populate ward search datalist
-        const dl = document.getElementById('ward-search-list');
-        if (dl) dl.innerHTML = geo.features.map(f => `<option value="${(f.properties.name || '').replace(/"/g, '&quot;')}">`).join('');
-        const si = document.getElementById('ward-search'); if (si) si.value = '';
-
+        // Render the active layer FIRST (colours, legend, stats, explanation, correlation)
+        // so nothing below can ever block it.
         wardRenderLayer();
+
+        // Non-critical UI enhancements — guarded so a failure here can't blank the panel.
+        try {
+            // Two-finger pan on touch: one finger scrolls the page, two fingers move the map
+            if (L.Browser && L.Browser.touch) {
+                wardMap.dragging.disable();
+                const c = wardMap.getContainer();
+                c.addEventListener('touchstart', e => { e.touches.length >= 2 ? wardMap.dragging.enable() : wardMap.dragging.disable(); }, { passive: true });
+                c.addEventListener('touchend', e => { if (e.touches.length < 2) wardMap.dragging.disable(); }, { passive: true });
+                const hint = L.control({ position: 'bottomleft' });
+                hint.onAdd = function () { const d = L.DomUtil.create('div'); d.style.cssText = 'background:rgba(0,0,0,0.55);color:#fff;font-size:0.65rem;padding:2px 6px;border-radius:4px;'; d.textContent = 'Use two fingers to move the map'; return d; };
+                hint.addTo(wardMap);
+            }
+            // Populate ward search datalist
+            const dl = document.getElementById('ward-search-list');
+            if (dl) dl.innerHTML = geo.features.map(f => `<option value="${(f.properties.name || '').replace(/"/g, '&quot;')}">`).join('');
+            const si = document.getElementById('ward-search'); if (si) si.value = '';
+        } catch (e) { console.warn('[JanVayu] ward UI enhancement:', e); }
     };
 
     // Zoom to a ward by name; highlight + open its tooltip
@@ -18288,7 +18292,7 @@ Yours faithfully,
                     <div style="color:var(--text-3); font-size:0.85rem;"><span class="pulse"></span> Loading live ward readings&hellip;</div>
                 </div>
             </div>
-            <div class="alert alert-info" style="margin:0;"><div id="ward-method"></div></div>
+            <div class="alert alert-info" style="margin:0;"><div id="ward-method"><strong>How this is built:</strong> on the <em>Air quality</em> layer, each ward&rsquo;s value is <strong>interpolated</strong> from the city&rsquo;s live CPCB/WAQI monitors (inverse-distance weighted) &mdash; the citywide <em>spread</em>, not a calibrated per-street reading, and sharper where there are more monitors. The heat / green / built-up layers, by contrast, are measured directly by satellite.</div></div>
             <div class="card mt-2" id="ward-corr-card" style="display:none;">
                 <div class="card-header"><span class="card-title" id="ward-corr-title" style="font-size:0.85rem;">Relationship</span></div>
                 <div class="card-body" style="padding:0.6rem;">

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260624';
+const CACHE_VERSION = 'janvayu-20260626';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
**Fix:** the "How this is built" explanation could be blank on the default **Air quality** layer.

### Cause
In `initWardMap`, the touch-pan setup and search-datalist population ran *between* map creation and `wardRenderLayer()`. If any of that threw on a given browser, the layer's colours, stats **and explanation** never rendered on first paint — only a manual layer-switch recovered it. (Code, deployment and service-worker were all current — this was a render-order bug, not a stale cache.)

### Fix
- `wardRenderLayer()` now runs **first** (colours, legend, stats, explanation, correlation); the touch/datalist enhancements run **after**, wrapped in `try/catch` so they can never block the render.
- The air-layer explanation is **seeded into the `#ward-method` template** so it shows even before/without JS.
- Service-worker cache bumped (`20260624` → `20260626`) to refresh returning visitors.

CHANGELOG `Fixed` note added under v26.6.26.

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_