### PR TITLE
chore: add GitHub Discussions category templates (Ideas, Q&A)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,26 @@
+title: "[Idea] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape JanVayu — a citizen-led archive of India's air quality crisis.
+        Use this to propose a feature, a dataset, or a city you'd like added. For bugs, please open an **Issue** instead.
+  - type: textarea
+    id: idea
+    attributes:
+      label: What's the idea?
+      description: What should JanVayu do, and who does it help?
+      placeholder: e.g. Add a ward-level air map for <city>, or a school-closure alert for parents...
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why does it matter?
+      description: The air-quality or accountability problem this addresses.
+  - type: input
+    id: sources
+    attributes:
+      label: Data sources (if any)
+      description: Links to open data, papers, or boundary files that would make it possible.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,19 @@
+title: "[Question] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask anything about JanVayu — the data, the methodology, or how a particular number was calculated.
+        Tip: the in-app assistant at [janvayu.in/ask](https://www.janvayu.in/ask) answers most live-data and ward-level questions instantly.
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+  - type: input
+    id: city
+    attributes:
+      label: City / ward (if relevant)
+      placeholder: e.g. Delhi — Ballimaran ward


### PR DESCRIPTION
Sets up GitHub **Discussions** so it's organized the moment the feature is switched on.

- Adds `.github/DISCUSSION_TEMPLATE/ideas.yml` and `q-a.yml` — structured category forms (bind to the standard **Ideas** and **Q&A** category slugs). They match the repo's existing issue-form style and point Q&A at the in-app assistant.
- The issue-template `config.yml` already has a "Questions & Discussion" contact link, so this completes that intent.

**Note:** enabling Discussions and posting the first thread can't be done via the API/tools available here — that's a quick manual step in **Settings → Features → Discussions**. I've drafted ready-to-paste welcome + announcement posts to go with it.

Community-health files only; no site/runtime change.

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_