### PR TITLE
fix: make link audit pass — real broken links + lychee --root-dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept 200,204,301,302,403,429 --exclude "localhost|127.0.0.1|example.com|twitter.com|x.com|linkedin.com|facebook.com|instagram.com|t.me|wa.me|play.google.com|apps.apple.com|mailto:" --timeout 30 --max-retries 2 "**/*.html" "**/*.md"
+          args: --accept 200,204,301,302,403,429 --root-dir "${{ github.workspace }}" --exclude "localhost|127.0.0.1|example.com|twitter.com|x.com|linkedin.com|facebook.com|instagram.com|t.me|wa.me|play.google.com|apps.apple.com|cpcb.nic.in|mailto:" --timeout 30 --max-retries 2 "**/*.html" "**/*.md"
           fail: false
 
       - name: Surface broken-link count in PR summary

--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           args: |
             --accept 200,204,301,302,403,429
-            --exclude "localhost|127.0.0.1|example.com|twitter.com|x.com|linkedin.com|facebook.com|instagram.com|t.me|wa.me|play.google.com|apps.apple.com|mailto:"
+            --root-dir "${{ github.workspace }}"
+            --exclude "localhost|127.0.0.1|example.com|twitter.com|x.com|linkedin.com|facebook.com|instagram.com|t.me|wa.me|play.google.com|apps.apple.com|cpcb.nic.in|mailto:"
             --timeout 30
             --max-retries 2
             "**/*.html" "**/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.36] - 2026-06-30
+
+### Fixed — link audit now passes (real broken links + lychee config)
+
+The weekly link audit, fixed in v26.6.34, started actually running and then failed — surfacing genuine issues plus a config gap:
+
+- **Real broken links fixed**: the per-pollutant SEO pages (`/pm25`, `/so2`, `/no2`, `/co`, `/o3`, `/pm10`) linked `/about` in their footers, but About is a SPA route — corrected to `/#about`. The `/walkthrough/` page linked a `JanVayu_Walkthrough_with_notes.pdf` that isn't in the repo — repointed to the committed `JanVayu_MMSF_Walkthrough.pdf`.
+- **lychee config**: added `--root-dir` so valid root-relative links (`/`, `/blog/`, `/pm25/`, `/favicon.svg`…) resolve to files instead of erroring, and excluded `cpcb.nic.in` (a government site that reliably times out / blocks crawlers). Applied to both `link-audit.yml` and the advisory `ci.yml` pass.
+
 ## [v26.6.35] - 2026-06-25
 
 ### Changed — Urban Heat Island panel reframed (air-first, national)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-06-25"
-version: "26.6.35"
+version: "26.6.36"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260635-v35';
+const CACHE_NAME = 'ask-janvayu-20260636-v36';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/co/index.html
+++ b/co/index.html
@@ -110,7 +110,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/no2/index.html
+++ b/no2/index.html
@@ -108,7 +108,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/o3/index.html
+++ b/o3/index.html
@@ -108,7 +108,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.35",
+  "version": "26.6.36",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/pm10/index.html
+++ b/pm10/index.html
@@ -111,7 +111,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/pm25/index.html
+++ b/pm25/index.html
@@ -112,7 +112,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/so2/index.html
+++ b/so2/index.html
@@ -108,7 +108,7 @@
 <footer>
   <div>JanVayu is an independent, citizen-led air quality accountability platform for India. Part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>.</div>
   <div style="margin-top: 6px;">Data from <a href="https://aqicn.org">WAQI / aqicn.org</a>, <a href="https://cpcb.nic.in">CPCB</a>, and <a href="https://sensor.community">Sensor.Community</a>.</div>
-  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/about">About</a></div>
+  <div style="margin-top: 8px;">© 2026 JanVayu · <a href="/">Dashboard</a> · <a href="/blog/">Blog</a> · <a href="/#about">About</a></div>
 </footer>
 <script>
 (async () => {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260635';
+const CACHE_VERSION = 'janvayu-20260636';
 const SHELL_ASSETS = [
   '/',
   '/index.html',

--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -442,7 +442,7 @@ footer .legal { font-size: 0.78rem; color: #A1A1AA; }
             <a class="btn" href="JanVayu_Walkthrough.pdf" target="_blank" rel="noopener">
                 Open PDF <small>64 pages</small>
             </a>
-            <a class="btn" href="JanVayu_Walkthrough_with_notes.pdf" target="_blank" rel="noopener">
+            <a class="btn" href="JanVayu_MMSF_Walkthrough.pdf" target="_blank" rel="noopener">
                 PDF with speaker notes
             </a>
         </div>


### PR DESCRIPTION
**This is the CI failure you're seeing**, and here's the full diagnosis + fix.

### Why it's failing
The weekly **Link Audit** workflow (which I un-broke in v26.6.34 by removing an invalid lychee flag) is now *actually running* — and it failed on its first real pass for three reasons:
1. **lychee can't resolve root-relative links** (`/`, `/blog/`, `/pm25/`, `/favicon.svg`…) without a `--root-dir`, so it errored on all of them — **false positives**.
2. **Two genuinely broken links** it correctly caught.
3. A flaky **`cpcb.nic.in`** timeout (government site, blocks crawlers).

It also keeps auto-filing "broken links detected" issues on each failure (latest: #170).

### Fixes
- **Real broken links:** `/about` in the 6 per-pollutant page footers (`pm25/so2/no2/co/o3/pm10`) → `/#about` (About is a SPA route, not a file). The `/walkthrough/` page linked `JanVayu_Walkthrough_with_notes.pdf`, which isn't in the repo → repointed to the committed `JanVayu_MMSF_Walkthrough.pdf`.
- **lychee config:** added `--root-dir "${{ github.workspace }}"` so valid root-relative links resolve to files, and excluded `cpcb.nic.in`. Applied to both `link-audit.yml` and the advisory `ci.yml` pass.

After this, the audit should pass (no real broken links left). I'll trigger it manually post-merge to confirm, and close the false-alarm issue.

v26.6.36. YAML validates.

https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT

---
_Generated by [Claude Code](https://claude.ai/code/session_019AC9HiXTa54drpYzBydYrT)_