### PR TITLE
Add: Janhit Partners section in the About panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -3564,7 +3564,7 @@ body {
                 <div>
                     <div class="footer-title">JanVayu &#2332;&#2344;&#2357;&#2366;&#2351;&#2369;</div>
                     <p class="footer-desc">Independent citizen-led air quality monitoring, health impact analysis, and government accountability tracking for India. Clean air is not a privilege, it is a right.</p>
-                    <p class="footer-credits">Part of <strong style="color:rgba(255,255,255,0.7)">AirQuality for Janhit</strong> by <a href="#" style="color:rgba(255,255,255,0.5)">MMSF Fellows, AIPC</a>. Data from WAQI, CPCB, WHO, CREA, and <a href="https://urbanemissions.info" target="_blank" style="color:rgba(255,255,255,0.5)">UrbanEmissions.info</a>.</p>
+                    <p class="footer-credits">Part of <strong style="color:rgba(255,255,255,0.7)">AirQuality for Janhit</strong> by <a href="#" onclick="showPanel('about');return false;" style="color:rgba(255,255,255,0.5)">MMSF Fellows, AIPC</a> &mdash; see <a href="#" onclick="showPanel('about');return false;" style="color:rgba(255,255,255,0.5)">Janhit Partners</a>. Data from WAQI, CPCB, WHO, CREA, and <a href="https://urbanemissions.info" target="_blank" style="color:rgba(255,255,255,0.5)">UrbanEmissions.info</a>.</p>
                 </div>
                 <div>
                     <div class="footer-title" data-i18n="footer_navigate">Navigate</div>
@@ -17398,6 +17398,49 @@ Yours faithfully,
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+    <!-- ── JANHIT PARTNERS ── -->
+    <div class="card mb-2" id="partners">
+        <div class="card-body">
+            <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 0.5rem;"><span class="si si-user" style="color: var(--accent); margin-right: 0.4rem;"></span>Janhit Partners</h3>
+            <p style="font-size: 0.9375rem; line-height: 1.7; color: var(--text-2); margin-bottom: 1.25rem; max-width: 48rem;" data-simple="The people and groups JanVayu works with on clean air for the public good.">The organisations and initiatives JanVayu works alongside in the <strong>#AQIForJanHit</strong> effort for clean air as a public good.</p>
+            <div class="grid-2" style="gap: 1rem;">
+
+                <a href="https://profcongress.in/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #1B6B4A;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #1B6B4A; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.72rem; flex-shrink: 0;">AIPC</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">All India Professionals' Congress (AIPC)</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">The civic-professional network behind the #AQIForJanHit campaign that JanVayu grew out of.</span>
+                    </div>
+                </a>
+
+                <a href="https://profcongress.in/?p=10057" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #7C3AED;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #7C3AED; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.72rem; flex-shrink: 0;">MMSF</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">Dr. Manmohan Singh Fellows Programme</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">The AIPC fellowship for mid-career professionals under which JanVayu was designed and built.</span>
+                    </div>
+                </a>
+
+                <a href="https://m.thewire.in/article/environment/citizen-groups-urge-caqm-to-take-year-round-action-on-delhi-air" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #2563EB;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #2563EB; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.95rem; flex-shrink: 0;">साँस</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">Delhi SSANS &mdash; Swasth Saans Adhikar Nagrik Samiti</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">A Delhi citizens' forum pressing the CAQM for year-round action on the capital's air pollution.</span>
+                    </div>
+                </a>
+
+                <a href="https://urbanemissions.info/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #EA580C;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #EA580C; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.9rem; flex-shrink: 0;">UE</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">UrbanEmissions.info</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">Dr. Sarath Guttikunda's air-quality science, emissions inventories and data &mdash; a JanVayu data and workshops partner.</span>
+                    </div>
+                </a>
+
+            </div>
+            <p style="font-size: 0.8rem; color: var(--text-3); margin-top: 1rem;">Partner logos are being finalised. To be listed here, correct an entry, or partner with JanVayu, write to <a href="mailto:contribute@janvayu.in">contribute@janvayu.in</a>.</p>
         </div>
     </div>
     <div class="card">


### PR DESCRIPTION
## Summary

Adds a **Janhit Partners** section to the About panel (`tmpl-about`) listing the initiatives JanVayu works alongside:

- **All India Professionals' Congress (AIPC)** — the civic-professional network behind #AQIForJanHit
- **Dr. Manmohan Singh Fellows Programme** — the AIPC fellowship JanVayu was built under
- **Delhi SSANS (Swasth Saans Adhikar Nagrik Samiti)** — Delhi citizens' CAQM forum
- **UrbanEmissions.info** — Dr. Sarath Guttikunda's air-quality science/data (existing data + workshops partner)

Monogram tiles stand in until real logos are supplied; the footer credit now links to the section. Blurbs are one neutral line each.

## Type of Change

- [x] Content update (new or updated data, articles, or resources)

## Checklist

- [x] No API keys, tokens, or secrets are included
- [x] Uses an existing, proven icon class (`si-user`) and the site's existing card/info-box styles
- [x] Rendered and visually verified via headless Chromium
- [x] Responsive (grid-2 collapses to single column on mobile)

> Follow-ups (owner): confirm the Saans entry's official link (currently interim); supply partner logos to replace the monogram placeholders.

## Related Issues

- Addresses the "Janhit Partners page" item in the Q3 roadmap (Phase 6, awaiting-input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_