### PR TITLE
Add: Terra.do and Terra.do Studio to Janhit Partners

### DIFF
--- a/index.html
+++ b/index.html
@@ -17439,6 +17439,22 @@ Yours faithfully,
                     </div>
                 </a>
 
+                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #0F766E;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #0F766E; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.82rem; flex-shrink: 0;">Terra</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">Terra.do</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">The climate-education and careers platform whose community and cohorts JanVayu works with.</span>
+                    </div>
+                </a>
+
+                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #0D9488;">
+                    <div style="width: 48px; height: 48px; border-radius: 50%; background: #0D9488; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.7rem; flex-shrink: 0; text-align: center; line-height: 1.1;">Terra<br>Studio</div>
+                    <div>
+                        <strong style="display: block; color: var(--ink);">Terra.do Studio</strong>
+                        <span style="font-size: 0.85rem; color: var(--text-2); line-height: 1.5;">Terra.do's venture-building studio, running an active collaboration workspace with JanVayu.</span>
+                    </div>
+                </a>
+
             </div>
             <p style="font-size: 0.8rem; color: var(--text-3); margin-top: 1rem;">Partner logos are being finalised. To be listed here, correct an entry, or partner with JanVayu, write to <a href="mailto:contribute@janvayu.in">contribute@janvayu.in</a>.</p>
         </div>


### PR DESCRIPTION
## Summary

Adds two more cards to the Janhit Partners grid in the About panel:

- **Terra.do** — the climate-education and careers platform
- **Terra.do Studio** — Terra.do's venture-building studio, which runs the active `/TerraStudioCollab/` workspace with JanVayu (backed by `terra-collab.mjs`)

Grid is now 6 cards (3×2, collapses to single column on mobile). Monogram tiles until logos are supplied.

## Type of Change

- [x] Content update

## Checklist

- [x] No secrets included
- [x] Rendered and visually verified via headless Chromium (3×2 layout holds)
- [x] Reuses existing card/info-box styles

## Related Issues

- Extends the Janhit Partners section (#178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_