### PR TITLE
Add: fill the three empty spots in the homepage quick-nav grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3383,6 +3383,10 @@ body {
                         <div class="quick-link-icon" style="background: #ECFDF5; color: #16A34A;"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_testimony_t">Citizen Testimony</h4><p data-i18n="ql_testimony_d">100+ voices, 13 languages</p></div>
                     </div>
+                    <div class="quick-link" onclick="loadPanel('ward-map')">
+                        <div class="quick-link-icon" style="background: #ECFEFF; color: #0891B2;"><span class="si si-pin" style="width:20px;height:20px;"></span></div>
+                        <div><h4>Your Ward</h4><p>How polluted is your ward? Air, heat &amp; green cover</p></div>
+                    </div>
                 </div>
                 <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('go-outside')">
@@ -3411,6 +3415,14 @@ body {
                         <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-book" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_walk_t">Walkthrough <span style="font-size: 0.55rem; padding: 1px 6px; border-radius: 999px; background: var(--accent); color: #fff; vertical-align: middle; margin-left: 4px;">NEW</span></h4><p data-i18n="ql_walk_d">64-slide guided tour (MMSF Fellows deck)</p></div>
                     </a>
+                    <a class="quick-link" href="/ask/" style="text-decoration: none; color: inherit;">
+                        <div class="quick-link-icon" style="background: #F5F3FF; color: #7C3AED;"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
+                        <div><h4>Ask JanVayu</h4><p>AI air-quality assistant &mdash; 33 cities, 10 languages</p></div>
+                    </a>
+                    <div class="quick-link" onclick="showPanel('rankings')">
+                        <div class="quick-link-icon" style="background: #FEF2F2; color: #DC2626;"><span class="si si-bar-chart" style="width:20px;height:20px;"></span></div>
+                        <div><h4>City Rankings</h4><p>Cleanest &amp; most polluted &mdash; live, 7-day, 30-day</p></div>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary

The dashboard **Quick navigation** section is a set of 4-column (`grid-4`) rows, but the card counts left three empty cells (row 2 had 3 cards, row 4 had 2). Filled them with three flagship destinations that weren't yet in the grid, so it now reads as a complete 4×4:

- **Your Ward** — the Ward Atlas ("How polluted is your ward?") via `loadPanel('ward-map')`
- **Ask JanVayu** — the AI air-quality assistant (`/ask/`)
- **City Rankings** — cleanest & most polluted, live/7d/30d (`showPanel('rankings')`)

## Type of Change

- [x] Content update

## Checklist

- [x] Uses existing `.quick-link` markup and proven icon classes (`si-pin`, `si-chat`, `si-bar-chart`)
- [x] Rendered and visually verified via headless Chromium — 16 cards, no gaps, 4×4 aligned
- [x] No secrets included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_