### PR TITLE
Refactor: defer Leaflet CSS off the critical path (v26.6.60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.60] - 2026-07-15
+
+### Performance — Leaflet CSS off the critical path (streamlining, batch 3)
+
+The Leaflet stylesheet was loaded render-blocking in `<head>` even though Leaflet's JS was already lazy-loaded via `ensureLeaflet()`. The CSS is now injected on demand inside `ensureLeaflet()` when a map first opens (Live Map, Ward Atlas, Farm Fire Tracker — all go through it), removing a blocking cross-origin request from every page load. Verified: the stylesheet is absent from `<head>` on load and injected on map open, no errors.
+
 ## [v26.6.59] - 2026-07-15
 
 ### Performance — Learning Games script deferred (streamlining, batch 2)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.59"
+version: "26.6.60"

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
     <!-- Leaflet CSS is small and used cheaply; keep eager.
          Leaflet JS + heatmap plugin and Chart.js are loaded lazily
          via window.ensureLeaflet() / window.ensureChartJs() — see below. -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+    <!-- Leaflet CSS is injected on demand by ensureLeaflet() (was render-blocking here). -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <script>
@@ -355,6 +355,14 @@
           }
           if (!_leafletPromise) {
             _leafletPromise = (async () => {
+              // Load Leaflet's stylesheet on demand (was render-blocking in <head>).
+              if (!document.getElementById('leaflet-css')) {
+                const link = document.createElement('link');
+                link.id = 'leaflet-css';
+                link.rel = 'stylesheet';
+                link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+                document.head.appendChild(link);
+              }
               await loadScript('https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', SRI.leaflet);
               await loadScript('https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js', SRI.leafletHeat);
             })().catch((e) => { _leafletPromise = null; throw e; });
@@ -15879,6 +15887,12 @@ Yours faithfully,
         <div class="card-header"><span class="card-title"><span class="si si-sm si-article" style="color: var(--accent);"></span> Version History</span></div>
         <div class="card-body" style="max-height: 500px; overflow-y: auto;">
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.60 &mdash; 15 July 2026</div>
+                    <strong>Performance: Leaflet CSS off the critical path</strong><br>
+                    &bull; The Leaflet map stylesheet was render-blocking in <code>&lt;head&gt;</code> even though its JS already loaded lazily; it's now injected on demand by <code>ensureLeaflet()</code> when a map first opens. One fewer blocking cross-origin request on every page load.
+                </div>
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.59 &mdash; 15 July 2026</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.59",
+  "version": "26.6.60",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://www.janvayu.in/</loc>
-    <lastmod>2026-07-15T17:42:37+05:30</lastmod>
+    <lastmod>2026-07-15T17:52:52+05:30</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.janvayu.in/" />


### PR DESCRIPTION
## Summary

Streamlining batch 3. The Leaflet stylesheet was loaded **render-blocking in `<head>`** even though Leaflet's JS was already lazy-loaded via `ensureLeaflet()`. The CSS is now injected on demand inside `ensureLeaflet()` when a map first opens — all three map surfaces (Live Map, Ward Atlas, Farm Fire Tracker) go through it — removing a blocking cross-origin request from every page load.

## Verification (local server + headless Chromium)

- `#leaflet-css` is **absent from `<head>` on load** (no longer render-blocking).
- On opening the Map panel, the stylesheet is **injected on demand**; no console errors. (Leaflet's JS can't fully load in the sandbox since unpkg is unreachable there — same as the pre-existing lazy JS load — so this is a no-regression change to the CSS path.)

## Type of Change

- [x] Refactor (no behaviour change)

## Checklist

- [x] All map inits (`initMap`, `initWardMap`, `initFireTracker`) confirmed to `await ensureLeaflet()` first
- [x] Verified the stylesheet defers and injects correctly
- [x] No secrets included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_