### PR TITLE
Refactor: shared CORS/HTTP helper for Netlify Functions (v26.6.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.67] - 2026-07-15
+
+### Refactor — shared CORS/HTTP helper for Netlify Functions
+
+Introduced `netlify/functions/lib/http.mjs` as the single source of truth for the CORS headers and OPTIONS preflight handling that was copy-pasted across the serverless functions (joining the existing shared `lib/blob.mjs` and `lib/calc.mjs`). Nine functions were migrated:
+
+- `reference-data`, `zotero-library`, `status-history` — the standard 3-key CORS block → `corsHeaders()` + `preflight()`.
+- `accountability-brief`, `anomaly-check`, `feed-ingest`, `health-advisory`, `terra-collab`, `workshop-submit` — the JSON-response header shape (custom `Access-Control-Allow-Headers`, no `Allow-Methods`) → a dedicated `jsonCorsHeaders()` helper that reproduces each function's headers exactly, so behaviour is unchanged.
+
+Also normalised the six JSON functions' 204 preflight bodies from `""` to `null` (WHATWG-correct; identical on the wire since a 204 carries no body). Functions with idiosyncratic header shapes (`data-api`, `push-subscribe`, `air-query`, …) were deliberately left untouched to avoid changing live-endpoint behaviour.
+
+Verified in Node: `node --check` on every changed file passes; a harness invoking each migrated handler with an `OPTIONS` request confirms byte-identical preflight status + headers for all nine; a real `GET` on `reference-data` returns 200 with the correct CORS headers and body; and the full `node --test` suite (12 tests) passes.
+
 ## [v26.6.66] - 2026-07-15
 
 ### Performance — eight content panels lazy-loaded; index.html now under 1 MB

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.66"
+version: "26.6.67"

--- a/netlify/functions/accountability-brief.mjs
+++ b/netlify/functions/accountability-brief.mjs
@@ -1,3 +1,4 @@
+import { jsonCorsHeaders } from "./lib/http.mjs";
 // Netlify Function: Ward-Level Accountability Brief
 // Generates structured briefs for ward councillors, journalists, and resident groups
 
@@ -84,14 +85,10 @@ async function fetchCityAQI(cityKey) {
 }
 
 export default async function handler(req) {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Content-Type": "application/json",
-  };
+  const headers = jsonCorsHeaders();
 
   if (req.method === "OPTIONS") {
-    return new Response("", { status: 204, headers });
+    return new Response(null, { status: 204, headers });
   }
 
   if (req.method !== "POST") {

--- a/netlify/functions/anomaly-check.mjs
+++ b/netlify/functions/anomaly-check.mjs
@@ -1,3 +1,4 @@
+import { jsonCorsHeaders } from "./lib/http.mjs";
 // Netlify Function: Anomaly Detection
 // Checks major cities for PM2.5 spikes, optionally explains via Groq
 
@@ -54,15 +55,10 @@ async function fetchCityAQI(cityKey) {
 }
 
 export default async function handler(req) {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Content-Type": "application/json",
-    "Cache-Control": "public, max-age=600",
-  };
+  const headers = jsonCorsHeaders({ extra: { "Cache-Control": "public, max-age=600" } });
 
   if (req.method === "OPTIONS") {
-    return new Response("", { status: 204, headers });
+    return new Response(null, { status: 204, headers });
   }
 
   const results = await Promise.allSettled(

--- a/netlify/functions/feed-ingest.mjs
+++ b/netlify/functions/feed-ingest.mjs
@@ -3,6 +3,7 @@
 // Keys: twitter-agent, youtube, news-enhanced (separate from existing feed keys)
 
 import { getBlobStore } from "./lib/blob.mjs";
+import { jsonCorsHeaders } from "./lib/http.mjs";
 
 
 function deduplicateByKey(existing, incoming, keyFn) {
@@ -28,14 +29,10 @@ function deduplicateByKey(existing, incoming, keyFn) {
 }
 
 export default async (req) => {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type, x-api-key",
-    "Content-Type": "application/json",
-  };
+  const headers = jsonCorsHeaders({ allowHeaders: "Content-Type, x-api-key" });
 
   if (req.method === "OPTIONS") {
-    return new Response("", { status: 204, headers });
+    return new Response(null, { status: 204, headers });
   }
 
   if (req.method !== "POST") {

--- a/netlify/functions/health-advisory.mjs
+++ b/netlify/functions/health-advisory.mjs
@@ -1,3 +1,4 @@
+import { jsonCorsHeaders } from "./lib/http.mjs";
 // Netlify Function: Personalised Health Advisory
 // Accepts user profile + city, fetches live AQI, sends to Groq for advisory
 
@@ -77,14 +78,10 @@ async function fetchCityAQI(cityKey) {
 }
 
 export default async function handler(req) {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Content-Type": "application/json",
-  };
+  const headers = jsonCorsHeaders();
 
   if (req.method === "OPTIONS") {
-    return new Response("", { status: 204, headers });
+    return new Response(null, { status: 204, headers });
   }
 
   if (req.method !== "POST") {

--- a/netlify/functions/lib/http.mjs
+++ b/netlify/functions/lib/http.mjs
@@ -1,0 +1,52 @@
+// Shared HTTP/CORS helpers for Netlify Functions — the single source of truth
+// for the CORS headers and OPTIONS preflight handling that was previously
+// copy-pasted into every function.
+//
+// All endpoints are read-open (Access-Control-Allow-Origin: "*") so the static
+// front-end, the status page and third-party data consumers can call them from
+// any host. `methods` varies per endpoint (most are GET-only; a few POST), so
+// each caller passes its own verb list and it is preserved verbatim.
+
+// Build the standard CORS header set, merging any endpoint-specific extras
+// (e.g. "Cache-Control", "Content-Type"). Extras win on key collision.
+export function corsHeaders(methods = "GET, OPTIONS", extra = {}) {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": methods,
+    "Access-Control-Allow-Headers": "Content-Type",
+    ...extra,
+  };
+}
+
+// If the request is a CORS preflight, return a 204 Response with the CORS
+// headers; otherwise return null so the caller continues. A 204 carries no
+// body by definition, so we pass `null` (also required by the strict WHATWG
+// Response constructor — an empty-string body throws in some runtimes).
+export function preflight(request, methods = "GET, OPTIONS", extra = {}) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders(methods, extra) });
+  }
+  return null;
+}
+
+// JSON Response helper: serialises `body`, sets Content-Type + CORS headers,
+// and merges any endpoint-specific extras.
+export function jsonResponse(body, { status = 200, methods = "GET, OPTIONS", headers = {} } = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders(methods, headers) },
+  });
+}
+
+// Header set for the JSON POST/GET endpoints that respond with
+// Content-Type: application/json and a custom Access-Control-Allow-Headers list
+// (e.g. an API key), and deliberately do NOT advertise Allow-Methods. Kept as a
+// distinct helper so migrating those functions is behaviour-preserving.
+export function jsonCorsHeaders({ allowHeaders = "Content-Type", extra = {} } = {}) {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": allowHeaders,
+    "Content-Type": "application/json",
+    ...extra,
+  };
+}

--- a/netlify/functions/reference-data.mjs
+++ b/netlify/functions/reference-data.mjs
@@ -10,16 +10,13 @@
 // having them hardcoded in air-query.mjs.
 
 import { readFile } from "node:fs/promises";
+import { corsHeaders, preflight } from "./lib/http.mjs";
 
 // Do NOT declare `__dirname`/`__filename`: Netlify's esbuild bundler injects
 // its own shims for these, so redeclaring them throws "Identifier already
 // declared" at load time (502). Resolve the data file via import.meta.url.
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
+const CORS_HEADERS = corsHeaders("GET, OPTIONS");
 
 const VALID_DATASETS = ["cpcb_stations", "ncap_cities", "iqair_annual"];
 
@@ -37,9 +34,7 @@ async function loadData() {
 
 export default async function handler(request) {
   // Handle CORS preflight
-  if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
-  }
+  const __pf = preflight(request, "GET, OPTIONS"); if (__pf) return __pf;
 
   try {
     const url = new URL(request.url);

--- a/netlify/functions/status-history.mjs
+++ b/netlify/functions/status-history.mjs
@@ -12,12 +12,9 @@
 // the strip becomes fully real as the monitor accrues history.
 
 import { getBlobStore } from "./lib/blob.mjs";
+import { corsHeaders, preflight } from "./lib/http.mjs";
 
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
+const CORS = corsHeaders("GET, OPTIONS");
 
 const DAYS = 90;
 
@@ -29,9 +26,7 @@ const SEED_DEGRADED_END = "2026-06-07";
 const ymd = (d) => d.toISOString().slice(0, 10);
 
 export default async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("", { status: 204, headers: CORS });
-  }
+  const __pf = preflight(req, "GET, OPTIONS"); if (__pf) return __pf;
 
   let recorded = {};
   try {

--- a/netlify/functions/terra-collab.mjs
+++ b/netlify/functions/terra-collab.mjs
@@ -20,6 +20,7 @@
 
 import { Resend } from "resend";
 import { getStore } from "@netlify/blobs";
+import { jsonCorsHeaders } from "./lib/http.mjs";
 
 const SECRET = process.env.TERRA_COLLAB_SECRET || "";
 const STORE_NAME = "janvayu-feeds";
@@ -116,12 +117,8 @@ https://www.janvayu.in/TerraStudioCollab/`;
 }
 
 export default async function handler(req) {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type, X-Collab-Secret",
-    "Content-Type": "application/json",
-  };
-  if (req.method === "OPTIONS") return new Response("", { status: 204, headers });
+  const headers = jsonCorsHeaders({ allowHeaders: "Content-Type, X-Collab-Secret" });
+  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers });
 
   if (!SECRET) {
     return new Response(JSON.stringify({

--- a/netlify/functions/workshop-submit.mjs
+++ b/netlify/functions/workshop-submit.mjs
@@ -13,6 +13,7 @@
 
 import { Resend } from "resend";
 import { getBlobStore } from "./lib/blob.mjs";
+import { jsonCorsHeaders } from "./lib/http.mjs";
 
 const TO_EMAIL = process.env.WORKSHOP_INBOX_EMAIL || "contribute@janvayu.in";
 const FROM_EMAIL = process.env.RESEND_FROM || "JanVayu <alerts@janvayu.in>";
@@ -112,13 +113,9 @@ async function parseBody(req) {
 }
 
 export default async function handler(req) {
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Content-Type": "application/json",
-  };
+  const headers = jsonCorsHeaders();
 
-  if (req.method === "OPTIONS") return new Response("", { status: 204, headers });
+  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers });
   if (req.method !== "POST") return new Response(JSON.stringify({ error: "POST required" }), { status: 405, headers });
 
   const fields = await parseBody(req);

--- a/netlify/functions/zotero-library.mjs
+++ b/netlify/functions/zotero-library.mjs
@@ -7,6 +7,7 @@
 // for 6 hours to avoid hitting the Zotero API on every request.
 
 import { getBlobStore } from "./lib/blob.mjs";
+import { corsHeaders, preflight } from "./lib/http.mjs";
 
 const ZOTERO_GROUP_ID = "6508140";
 const ZOTERO_API_URL = `https://api.zotero.org/groups/${ZOTERO_GROUP_ID}/items?format=json&limit=50&sort=dateModified&direction=desc`;
@@ -15,11 +16,7 @@ const BLOB_STORE_NAME = "janvayu-cache";
 const CACHE_KEY = "zotero-library";
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
+const CORS_HEADERS = corsHeaders("GET, OPTIONS");
 
 
 /**
@@ -95,9 +92,7 @@ async function fetchFromZotero() {
 
 export default async function handler(request) {
   // Handle CORS preflight
-  if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
-  }
+  const __pf = preflight(request, "GET, OPTIONS"); if (__pf) return __pf;
 
   try {
     const store = getBlobStore(BLOB_STORE_NAME);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.48",
+  "version": "26.6.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.48",
+      "version": "26.6.67",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.66",
+  "version": "26.6.67",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {


### PR DESCRIPTION
## What

Adds `netlify/functions/lib/http.mjs` as the single source of truth for the CORS headers and OPTIONS preflight handling that was copy-pasted across the serverless functions — joining the existing shared `lib/blob.mjs` and `lib/calc.mjs`.

Nine functions migrated:

| Functions | Pattern | Now uses |
|---|---|---|
| `reference-data`, `zotero-library`, `status-history` | standard 3-key CORS block | `corsHeaders()` + `preflight()` |
| `accountability-brief`, `anomaly-check`, `feed-ingest`, `health-advisory`, `terra-collab`, `workshop-submit` | JSON-response headers (custom `Allow-Headers`, no `Allow-Methods`) | `jsonCorsHeaders()` — reproduces each function's headers **exactly** |

Also normalised the six JSON functions' 204 preflight bodies from `""` → `null` (WHATWG-correct; identical on the wire since a 204 carries no body).

Functions with idiosyncratic header shapes (`data-api`'s bespoke `corsHeaders()` with `Cache-Control`, `push-subscribe`'s dual header objects, the large `air-query`) were **deliberately left untouched** to avoid changing live-endpoint behaviour for negligible gain.

`package-lock.json` version field synced to match `package.json` (no dependency changes).

## Verification

All run in Node (Netlify runtime not reachable from CI sandbox, but preflight paths return before any network/blob call so they exercise fully):

- `node --check` passes on every changed file
- A harness invokes each migrated handler with an `OPTIONS` request and asserts **byte-identical** preflight status + headers for all nine (9 pass, 0 fail)
- A real `GET` on `reference-data` returns `200` with correct CORS headers and body — confirms the migrated `...CORS_HEADERS` spreads still work end-to-end
- Full `node --test` suite passes (12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_