### PR TITLE
Fix: WCAG form labels, prose-link underlines, chart alt-text (v26.6.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.68] - 2026-07-15
+
+### Accessibility — critical form labels, prose-link underlines, chart alt-text (#4)
+
+Evidence-driven WCAG 2.1 AA fixes, verified by running axe-core against the rendered panels (the same engine the `accessibility.yml` CI uses):
+
+- **Form labels (critical — `label` + `select-name`, 12 controls):** added `aria-label` to the health-calculator and urban-heat inputs/selects/ranges that had adjacent but unassociated `<label>` text (`#health-age`, `#health-pm25`, `#health-outdoor`, `#health-conditions`, `#safe-aqi`, `#safe-activity`, `#safe-health`, `#advisory-age`, `#advisory-hours`, `#advisory-city`, `#uh-builtup`, `#uh-tree`).
+- **Link-in-text-block (serious, 12):** inline links inside prose were distinguished by colour alone; added `p a, li a, dd a { text-decoration: underline }`. Button/nav/card link classes keep their own no-underline styling via higher specificity (verified: 9/9 prose links underlined, 0 buttons affected).
+- **Chart alt-text:** the one remaining unlabeled `<canvas>` (`#uhOzoneHourChart`) got a descriptive `role="img"` + `aria-label`, matching the other 13 charts.
+
+After these, axe reports **zero** `label`, `select-name`, `link-in-text-block`, or chart-labelling violations across the audited panels. (Note: axe does **not** flag heading-order in the rendered DOM — the raw h4 count was a linear-scan artefact, not a real skipped-level problem.) The remaining `color-contrast` findings are tracked for a dedicated theme-aware palette pass.
+
 ## [v26.6.67] - 2026-07-15
 
 ### Refactor — shared CORS/HTTP helper for Netlify Functions

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.67"
+version: "26.6.68"

--- a/index.html
+++ b/index.html
@@ -8228,11 +8228,11 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                     <div class="card-body">
                         <div class="form-group">
                             <label class="form-label">Your Age</label>
-                            <input type="number" class="form-input" id="health-age" value="35" min="1" max="100">
+                            <input type="number" class="form-input" id="health-age" aria-label="Your age" value="35" min="1" max="100">
                         </div>
                         <div class="form-group">
                             <label class="form-label">Annual Average PM2.5 Exposure (µg/m³)</label>
-                            <input type="number" class="form-input" id="health-pm25" value="100" min="0" max="500">
+                            <input type="number" class="form-input" id="health-pm25" aria-label="Annual average PM2.5 exposure in micrograms per cubic metre" value="100" min="0" max="500">
                             <div class="form-hint">
                                 <span style="color: var(--who-good);">●</span> WHO guideline: 5 | 
                                 <span style="color: var(--who-it1);">●</span> Delhi avg: 96 | 
@@ -8241,11 +8241,11 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                         </div>
                         <div class="form-group">
                             <label class="form-label">Hours Outdoors Daily: <span id="outdoor-display">4</span></label>
-                            <input type="range" class="form-range" id="health-outdoor" min="0" max="12" value="4">
+                            <input type="range" class="form-range" id="health-outdoor" aria-label="Hours outdoors daily" min="0" max="12" value="4">
                         </div>
                         <div class="form-group">
                             <label class="form-label">Pre-existing Conditions</label>
-                            <select class="form-select" id="health-conditions">
+                            <select class="form-select" id="health-conditions" aria-label="Pre-existing conditions">
                                 <option value="1">None</option>
                                 <option value="1.3">Asthma</option>
                                 <option value="1.5">COPD</option>
@@ -8291,11 +8291,11 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                     <div class="grid-3">
                         <div class="form-group">
                             <label class="form-label">Current AQI</label>
-                            <input type="number" class="form-input" id="safe-aqi" value="285" min="0" max="999">
+                            <input type="number" class="form-input" id="safe-aqi" aria-label="Current AQI" value="285" min="0" max="999">
                         </div>
                         <div class="form-group">
                             <label class="form-label">Activity Level</label>
-                            <select class="form-select" id="safe-activity">
+                            <select class="form-select" id="safe-activity" aria-label="Activity level">
                                 <option value="1">Light (walking)</option>
                                 <option value="2" selected>Moderate (cycling)</option>
                                 <option value="3">Heavy (running)</option>
@@ -8303,7 +8303,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                         </div>
                         <div class="form-group">
                             <label class="form-label">Health Status</label>
-                            <select class="form-select" id="safe-health">
+                            <select class="form-select" id="safe-health" aria-label="Health status">
                                 <option value="1" selected>Healthy Adult</option>
                                 <option value="1.5">Sensitive</option>
                                 <option value="2">High Risk</option>
@@ -8625,7 +8625,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                         <div class="card-body">
                             <div class="form-group">
                                 <label class="form-label">Age</label>
-                                <input type="number" class="form-input" id="advisory-age" value="30" min="1" max="100">
+                                <input type="number" class="form-input" id="advisory-age" aria-label="Age" value="30" min="1" max="100">
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Health Conditions</label>
@@ -8640,13 +8640,13 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                             <div class="form-group">
                                 <label class="form-label">Hours Outdoors Daily</label>
                                 <div class="slider-group">
-                                    <input type="range" id="advisory-hours" min="0" max="12" value="3" oninput="document.getElementById('advisory-hours-val').textContent=this.value">
+                                    <input type="range" id="advisory-hours" aria-label="Hours outdoors daily" min="0" max="12" value="3" oninput="document.getElementById('advisory-hours-val').textContent=this.value">
                                     <span class="slider-value" id="advisory-hours-val">3</span>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <label class="form-label">City</label>
-                                <select class="form-select" id="advisory-city">
+                                <select class="form-select" id="advisory-city" aria-label="City">
                                     <optgroup label="Metros">
                                         <option value="delhi" selected>Delhi</option>
                                         <option value="mumbai">Mumbai</option>
@@ -9286,11 +9286,11 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
 
             <div style="margin-bottom:1.25rem;">
                 <label style="display:flex; justify-content:space-between; font-size:0.8125rem; font-weight:600; color:var(--text-2); margin-bottom:0.4rem;"><span>Built-up area (concrete, roads, roofs)</span><span id="uh-builtup-val" style="color:#B91C1C;">45%</span></label>
-                <input id="uh-builtup" type="range" min="0" max="100" value="45" step="1" style="width:100%; accent-color:#DC2626;" oninput="window.updateHeatEstimate&amp;&amp;window.updateHeatEstimate()">
+                <input id="uh-builtup" aria-label="Built-up area percentage" type="range" min="0" max="100" value="45" step="1" style="width:100%; accent-color:#DC2626;" oninput="window.updateHeatEstimate&amp;&amp;window.updateHeatEstimate()">
             </div>
             <div style="margin-bottom:1.5rem;">
                 <label style="display:flex; justify-content:space-between; font-size:0.8125rem; font-weight:600; color:var(--text-2); margin-bottom:0.4rem;"><span>Tree &amp; green cover</span><span id="uh-tree-val" style="color:#15803D;">5%</span></label>
-                <input id="uh-tree" type="range" min="0" max="100" value="5" step="1" style="width:100%; accent-color:#16A34A;" oninput="window.updateHeatEstimate&amp;&amp;window.updateHeatEstimate()">
+                <input id="uh-tree" aria-label="Tree and green cover percentage" type="range" min="0" max="100" value="5" step="1" style="width:100%; accent-color:#16A34A;" oninput="window.updateHeatEstimate&amp;&amp;window.updateHeatEstimate()">
             </div>
 
             <div id="uh-result" style="text-align:center; border-radius:10px; padding:1.25rem; background:var(--warm-white);">
@@ -9313,7 +9313,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
         </div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Pick any Indian city. The orange line is ozone hour by hour today; the red dashed line is the air temperature. Both climb through the morning and peak together in the afternoon &mdash; ground-level ozone is literally cooked by the day's heat and sunlight, then fades overnight. This pattern shows up in city after city, not just Delhi.">Pick any Indian city. The orange line is ozone, hour by hour today; the red dashed line is air temperature. Both climb through the morning and <strong>peak together in the afternoon</strong> &mdash; ground-level ozone is literally cooked by the day&rsquo;s heat and sunlight, then fades overnight. The same shape appears city after city, nationwide.</p>
-            <div style="position:relative; height:340px; width:100%;"><canvas id="uhOzoneHourChart"></canvas></div>
+            <div style="position:relative; height:340px; width:100%;"><canvas id="uhOzoneHourChart" role="img" aria-label="Line chart of today's hourly surface ozone and 2-metre air temperature for the selected city, showing both climbing through the morning and peaking together in the afternoon."></canvas></div>
             <div id="uh-chart-status" style="text-align:center; font-size:0.8125rem; color:var(--text-3); margin-top:0.6rem;"><span class="pulse"></span> Loading today&rsquo;s hourly readings&hellip;</div>
             <p style="font-size: 0.75rem; color: var(--text-3); margin:0.75rem 0 0;"><em>Hourly surface ozone (CAMS) and 2&thinsp;m air temperature for today, from the free <a href="https://open-meteo.com/" target="_blank" rel="noopener" style="color:var(--accent);">Open-Meteo</a> API. The afternoon ozone peak riding on the temperature peak is the &lsquo;climate penalty&rsquo;<sup>3</sup> at the scale of a single day. Ozone here is a modelled hourly estimate, not a ground-station reading.</em></p>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.67",
+  "version": "26.6.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.67",
+      "version": "26.6.68",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.67",
+  "version": "26.6.68",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -92,6 +92,11 @@ body {
 }
 a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
 a:hover { color: var(--accent-hover); }
+/* WCAG 1.4.1 (link-in-text-block): inline links inside prose must be
+   distinguishable by more than colour, so underline links within paragraphs,
+   list items and definitions. Button/nav/card link classes (.btn, .footer-link,
+   etc.) have higher specificity and keep their own no-underline styling. */
+p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
 
 .container { max-width: var(--max-w); margin: 0 auto; padding: 0 24px; }
 @media (min-width: 768px) { .container { padding: 0 40px; } }


### PR DESCRIPTION
## What (part 1 of #4 accessibility)

Evidence-driven WCAG 2.1 AA fixes, each **verified with axe-core** against the rendered panels (same engine `accessibility.yml` runs):

| Violation | Severity | Count | Fix |
|---|---|---|---|
| `label` + `select-name` | critical | 12 | `aria-label` on health-calculator & urban-heat inputs/selects/ranges with unassociated `<label>` text |
| `link-in-text-block` | serious | 12 | `p a, li a, dd a { text-decoration: underline }` (WCAG 1.4.1) |
| chart alt-text | — | 1 | `role="img"` + `aria-label` on the last unlabeled `<canvas>` (`#uhOzoneHourChart`) |

After these, axe reports **zero** `label` / `select-name` / `link-in-text-block` / chart-labelling violations across the audited panels (dashboard, health, accountability, about, urban-heat, resources).

Two findings from the audit worth recording:
- **Heading-order is *not* an axe violation** in the rendered DOM — the raw "120 h4" count was a linear-scan artefact, not a real skipped-level problem, so no risky heading retag was done.
- The button/nav/card link classes keep their no-underline styling via higher CSS specificity — verified 9/9 prose links underlined, 0 buttons affected.

## Remaining

`color-contrast` (serious, ~210 nodes — mostly `.badge` variants, `.grap-stage`, and inline-coloured text) is design-sensitive and needs **theme-aware** colours + screenshot verification in light & dark. Tracked for a dedicated follow-up PR; #4 stays open until that lands.

## Verification

axe-core (WCAG 2.1 A/AA) run in headless Chromium against the rendered panels, before and after — the three targeted violation classes drop to zero with no new violations introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_