### PR TITLE
Fix: badge colour-contrast, theme-aware, WCAG 1.4.3 (v26.6.69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.69] - 2026-07-15
+
+### Accessibility — badge colour-contrast (WCAG 1.4.3, #4 part 2)
+
+Fixed the single largest colour-contrast offender — status badges — which alone accounted for ~106 of the ~210 light-theme `color-contrast` violations axe reported:
+
+- **`.badge-*` variant classes** made theme-aware: darker text (`#166534`/`#92400E`/`#991B1B`/`#1E40AF`) on the pale tint in light theme, brighter text on a stronger tint in dark theme (dark-on-dark would otherwise fail).
+- **Inline solid-background badges** (source-category chips with white text — Transport, Agricultural, Dust, Waste, etc.) had their backgrounds darkened to the next accessible shade (`#22C55E`→`#15803D`, `#3B82F6`→`#1D4ED8`, `#EF4444`→`#B91C1C`, `#F97316`→`#C2410C`, `#7C3AED`→`#6D28D9`), preserving the colour-coding while meeting 4.5:1 with white text. Only the `background+color:white` pairing was changed, so other uses of those hues are untouched.
+
+Verified with axe-core in **both light and dark themes**: badge contrast violations drop to **zero**, and light-theme total falls from ~210 to ~67. The remaining contrast findings (inline-styled prose colours, the deliberately-dimmed `.grap-stage` indicators, the WCAG-exempt multilingual logotype, and the dark theme's broader systemic gaps) are tracked on #4 as a dedicated design-system pass.
+
 ## [v26.6.68] - 2026-07-15
 
 ### Accessibility — critical form labels, prose-link underlines, chart alt-text (#4)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.68"
+version: "26.6.69"

--- a/index.html
+++ b/index.html
@@ -10906,9 +10906,9 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
                     <thead><tr><th>Stage</th><th>AQI Range</th><th>School Action</th><th>Other Measures</th></tr></thead>
                     <tbody>
                         <tr><td><span class="badge" style="background: #EAB308; color: black;">I</span></td><td>201-300</td><td>No closures, outdoor activity restricted</td><td>Water sprinkling, dust control</td></tr>
-                        <tr><td><span class="badge" style="background: #F97316; color: white;">II</span></td><td>301-400</td><td>No outdoor sports/activities</td><td>Ban on diesel generators, coal/biomass</td></tr>
-                        <tr><td><span class="badge" style="background: #EF4444; color: white;">III</span></td><td>401-450</td><td>Primary schools closed (up to Class 5)</td><td>Ban on construction, BS-III petrol vehicles</td></tr>
-                        <tr><td><span class="badge" style="background: #7C3AED; color: white;">IV</span></td><td>450+</td><td>All schools closed, online classes mandatory</td><td>Truck ban, 50% WFH for offices</td></tr>
+                        <tr><td><span class="badge" style="background: #C2410C; color: white;">II</span></td><td>301-400</td><td>No outdoor sports/activities</td><td>Ban on diesel generators, coal/biomass</td></tr>
+                        <tr><td><span class="badge" style="background: #B91C1C; color: white;">III</span></td><td>401-450</td><td>Primary schools closed (up to Class 5)</td><td>Ban on construction, BS-III petrol vehicles</td></tr>
+                        <tr><td><span class="badge" style="background: #6D28D9; color: white;">IV</span></td><td>450+</td><td>All schools closed, online classes mandatory</td><td>Truck ban, 50% WFH for offices</td></tr>
                     </tbody>
                 </table>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.68",
+  "version": "26.6.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.68",
+      "version": "26.6.69",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.68",
+  "version": "26.6.69",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/accountability.html
+++ b/panels/accountability.html
@@ -169,7 +169,7 @@
                     <span class="card-title" style="color: #7C3AED;">
                          CAG Audit &mdash; Monitoring Station Failures
                     </span>
-                    <span class="badge" style="background: #7C3AED; color: white; margin-left: 0.5rem;">CAG · April 2025</span>
+                    <span class="badge" style="background: #6D28D9; color: white; margin-left: 0.5rem;">CAG · April 2025</span>
                 </div>
                 <div class="card-body">
                     <div class="grid-3" style="gap: 1rem;">
@@ -250,28 +250,28 @@
                                 <!-- TRANSPORT -->
                                 <tr style="background: rgba(22,128,60,0.05);">
                                     <td><strong>BS-VI Fuel Standards</strong></td>
-                                    <td><span class="badge" style="background: #3B82F6; color: white;">Transport</span></td>
+                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td>2020</td>
                                     <td><span class="badge badge-success">E4</span></td>
                                     <td>Operational nationwide. CPCB shows 15-25% SO₂ reduction in monitoring stations.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Delhi Metro Expansion (Phase 4)</strong></td>
-                                    <td><span class="badge" style="background: #3B82F6; color: white;">Transport</span></td>
+                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td>2019</td>
                                     <td><span class="badge badge-warning">E3</span></td>
                                     <td>65km operational, 45km under construction. Ridership impact on emissions unquantified.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Electric Bus Fleet (1000 buses)</strong></td>
-                                    <td><span class="badge" style="background: #3B82F6; color: white;">Transport</span></td>
+                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td>2021</td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">E2</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
                                     <td>~400 deployed (RTI 2025). Target repeatedly missed. Charging infra incomplete.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Odd-Even Scheme</strong></td>
-                                    <td><span class="badge" style="background: #3B82F6; color: white;">Transport</span></td>
+                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td>2016</td>
                                     <td><span class="badge badge-danger">E1</span></td>
                                     <td>IIT study: 2-4% reduction only. Exemptions undermine effectiveness. Seasonal deployment.</td>
@@ -280,14 +280,14 @@
                                 <!-- INDUSTRIAL -->
                                 <tr style="background: rgba(124,58,237,0.05);">
                                     <td><strong>Brick Kiln Zigzag Technology</strong></td>
-                                    <td><span class="badge" style="background: #7C3AED; color: white;">Industrial</span></td>
+                                    <td><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
                                     <td>2019</td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">E2</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
                                     <td>30% compliance (CPCB 2024). Enforcement weak. Seasonal operation continues.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Industrial Emission Standards (FGD)</strong></td>
-                                    <td><span class="badge" style="background: #7C3AED; color: white;">Industrial</span></td>
+                                    <td><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
                                     <td>2015</td>
                                     <td><span class="badge badge-warning">E3</span></td>
                                     <td>Multiple deadline extensions. ~35% thermal plants compliant (CEA 2024).</td>
@@ -296,14 +296,14 @@
                                 <!-- AGRICULTURAL -->
                                 <tr style="background: rgba(34,197,94,0.05);">
                                     <td><strong>Stubble Management Subsidies</strong></td>
-                                    <td><span class="badge" style="background: #22C55E; color: white;">Agricultural</span></td>
+                                    <td><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
                                     <td>2018</td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">E2</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
                                     <td>₹3,062 Cr allocated (2018-24). NASA FIRMS shows 30% fewer fires in 2024 vs 2021 peak.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>PUSA Bio-Decomposer</strong></td>
-                                    <td><span class="badge" style="background: #22C55E; color: white;">Agricultural</span></td>
+                                    <td><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
                                     <td>2020</td>
                                     <td><span class="badge badge-warning">E3</span></td>
                                     <td>Free distribution in Delhi. Efficacy disputed. Adoption rate low outside Delhi.</td>
@@ -312,30 +312,30 @@
                                 <!-- DUST CONTROL -->
                                 <tr style="background: rgba(249,115,22,0.05);">
                                     <td><strong>Mechanical Road Sweeping</strong></td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">Dust</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
                                     <td>2019</td>
                                     <td><span class="badge badge-warning">E3</span></td>
                                     <td>64% of NCAP funds spent on dust control (CSE). Impact on PM2.5 not quantified.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Smog Towers</strong></td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">Dust</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
                                     <td>2021</td>
                                     <td><span class="badge badge-danger">E1</span></td>
                                     <td>₹20 Cr spent. IIT-Bombay: "Negligible impact beyond 50m radius." Photo-op policy.</td>
                                 </tr>
                                 <tr>
                                     <td><strong>Construction Site Dust Screens</strong></td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">Dust</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
                                     <td>2017</td>
-                                    <td><span class="badge" style="background: #F97316; color: white;">E2</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
                                     <td>NGT mandate. ~40% compliance (DPCC inspections). No impact measurement.</td>
                                 </tr>
 
                                 <!-- WASTE -->
                                 <tr style="background: rgba(239,68,68,0.05);">
                                     <td><strong>Waste Burning Ban Enforcement</strong></td>
-                                    <td><span class="badge" style="background: #EF4444; color: white;">Waste</span></td>
+                                    <td><span class="badge" style="background: #B91C1C; color: white;">Waste</span></td>
                                     <td>2015</td>
                                     <td><span class="badge badge-danger">E1</span></td>
                                     <td>Open burning continues. Fines rarely collected. Landfill fires persist at Ghazipur, Bhalswa.</td>

--- a/panels/legal.html
+++ b/panels/legal.html
@@ -98,7 +98,7 @@
                                     <td>Water sprinkling; dust control; PUC checks</td>
                                 </tr>
                                 <tr style="background: rgba(249,115,22,0.05);">
-                                    <td><span class="badge" style="background: #F97316; color: white;">II</span></td>
+                                    <td><span class="badge" style="background: #C2410C; color: white;">II</span></td>
                                     <td>301-400</td>
                                     <td>Enhanced parking fees; increased public transport</td>
                                 </tr>
@@ -426,7 +426,7 @@
                     <!-- Step 1: RTI -->
                     <div class="info-box mb-2" style="border-left: 4px solid #22C55E; padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <span style="background: #22C55E; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 1</span>
+                            <span style="background: #15803D; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 1</span>
                             <h4 style="font-size: 0.9375rem; color: #166534; margin: 0;">File an RTI &mdash; Free, 30-day response guaranteed</h4>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Send a letter asking for information. It's free for BPL families, ₹10 for others. The government MUST reply within 30 days.">The simplest and most powerful tool. Any citizen can demand pollution data, budget utilisation details, or enforcement records.</p>
@@ -453,7 +453,7 @@
                     <!-- Step 2: CPCB Complaint -->
                     <div class="info-box mb-2" style="border-left: 4px solid #3B82F6; padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <span style="background: #3B82F6; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 2</span>
+                            <span style="background: #1D4ED8; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 2</span>
                             <h4 style="font-size: 0.9375rem; color: #1E40AF; margin: 0;">File a Complaint with CPCB</h4>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="If you see a factory polluting, waste being burned, or construction dust everywhere, you can complain to CPCB online. Include photos if you can.">Report specific violations &mdash; illegal burning, industrial emissions, construction dust &mdash; directly to CPCB online.</p>
@@ -500,7 +500,7 @@ Yours faithfully,
                     <!-- Step 4: Approach NGT -->
                     <div class="info-box mb-2" style="border-left: 4px solid #7C3AED; padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <span style="background: #7C3AED; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 4</span>
+                            <span style="background: #6D28D9; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 4</span>
                             <h4 style="font-size: 0.9375rem; color: #5B21B6; margin: 0;">Approach the National Green Tribunal (NGT)</h4>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Any person can go to the NGT &mdash; India's special environment court. No lawyer needed. It costs just 1,000 rupees (free if you're BPL).">The NGT is a dedicated environmental court. Any individual can file an application &mdash; no lawyer is needed for individual applications.</p>
@@ -520,7 +520,7 @@ Yours faithfully,
                     <!-- Step 5: PIL -->
                     <div class="info-box" style="border-left: 4px solid #EF4444; padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <span style="background: #EF4444; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 5</span>
+                            <span style="background: #B91C1C; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 5</span>
                             <h4 style="font-size: 0.9375rem; color: #991B1B; margin: 0;">File a PIL (Public Interest Litigation)</h4>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="If the problem is big and affects your whole community, you can file a Public Interest Litigation in the High Court or Supreme Court. Any citizen can file one.">For systemic failures affecting a community. Filed in the High Court or Supreme Court. Any citizen can file &mdash; no special locus standi required.</p>

--- a/panels/resources.html
+++ b/panels/resources.html
@@ -142,7 +142,7 @@
             <div class="card mb-2" data-resource-category="featured health source data policy justice">
                 <div class="card-header">
                     <span class="card-title" style="color: #7C3AED;">Peer-Reviewed Research
-                        <span class="badge" style="background: #7C3AED; color: white; margin-left: 0.5rem;">24 studies</span>
+                        <span class="badge" style="background: #6D28D9; color: white; margin-left: 0.5rem;">24 studies</span>
                     </span>
                 </div>
                 <div class="card-body">
@@ -582,7 +582,7 @@
                         </div>
                         <div class="resource-card" data-keywords="janvayu presentation platform tour janhit campaign slides">
                             <a href="https://www.janvayu.in" target="_blank">
-                                <div class="resource-type">Presentation <span class="badge" style="background: #7C3AED; color: white;">PPTX</span></div>
+                                <div class="resource-type">Presentation <span class="badge" style="background: #6D28D9; color: white;">PPTX</span></div>
                                 <div class="resource-title">JanVayu Platform Tour — Janhit Campaign</div>
                                 <div class="resource-desc">Complete presentation deck for advocacy and outreach.</div>
                             </a>

--- a/panels/voices.html
+++ b/panels/voices.html
@@ -1085,7 +1085,7 @@
             <div class="card mt-2">
                 <div class="card-header">
                     <span class="card-title" style="color: #7C3AED;"> Expert Voices & Advocates</span>
-                    <span class="badge" style="background: #7C3AED; color: white; margin-left: 0.5rem;">v19.0</span>
+                    <span class="badge" style="background: #6D28D9; color: white; margin-left: 0.5rem;">v19.0</span>
                 </div>
                 <div class="card-body">
                     <div class="grid-2">

--- a/styles.css
+++ b/styles.css
@@ -1093,10 +1093,16 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     display: inline-block; padding: 2px 8px; border-radius: 4px;
     font-size: 0.65rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
 }
-.badge-success { background: rgba(22,163,74,0.1); color: #16A34A; }
-.badge-warning { background: rgba(245,158,11,0.1); color: #D97706; }
-.badge-danger { background: rgba(192,57,43,0.1); color: var(--red); }
-.badge-info { background: rgba(37,99,235,0.1); color: var(--blue); }
+/* Badge text darkened to meet WCAG AA 4.5:1 against the pale tint background
+   in light theme; brightened for dark theme (dark-on-dark would fail). */
+.badge-success { background: rgba(22,163,74,0.12); color: #166534; }
+.badge-warning { background: rgba(245,158,11,0.12); color: #92400E; }
+.badge-danger { background: rgba(192,57,43,0.12); color: #991B1B; }
+.badge-info { background: rgba(37,99,235,0.12); color: #1E40AF; }
+[data-theme="dark"] .badge-success { background: rgba(22,163,74,0.18); color: #6EE7B7; }
+[data-theme="dark"] .badge-warning { background: rgba(245,158,11,0.18); color: #FCD34D; }
+[data-theme="dark"] .badge-danger { background: rgba(220,80,60,0.20); color: #FCA5A5; }
+[data-theme="dark"] .badge-info { background: rgba(59,130,246,0.20); color: #93C5FD; }
 
 /* ── Forms ──────────────────────────────── */
 .form-group { margin-bottom: 14px; }


### PR DESCRIPTION
## What (part 2 of #4 accessibility)

Fixes the single largest `color-contrast` offender — status badges — which alone accounted for **~106 of ~210** light-theme violations axe reported.

- **`.badge-*` variant classes** made theme-aware: darker text (`#166534`/`#92400E`/`#991B1B`/`#1E40AF`) on the pale tint in light theme; brighter text on a stronger tint in dark theme (dark-on-dark would otherwise fail).
- **Inline solid-background badges** (source-category chips with white text) darkened to the next accessible shade — `#22C55E`→`#15803D`, `#3B82F6`→`#1D4ED8`, `#EF4444`→`#B91C1C`, `#F97316`→`#C2410C`, `#7C3AED`→`#6D28D9` — preserving the colour-coding while meeting 4.5:1. Only the `background + color:white` pairing was changed, so other uses of those hues are untouched.

## Verification

axe-core (WCAG 2.1 A/AA) run in headless Chromium in **both light and dark themes**:
- **Badge** contrast violations → **zero** in both themes
- Light-theme total `color-contrast` nodes fall **~210 → ~67**

## Remaining (tracked on #4)

The rest of the contrast landscape is a design-sensitive, design-system-level effort and is **not** in this PR:
- Inline-styled prose colours (light: ~39 nodes)
- `.grap-stage` indicators — low contrast is from **deliberate opacity-dimming** of inactive GRAP stages (design-intent)
- The multilingual `.logo-script` wordmark — WCAG **logotype exception** applies
- The **dark theme's broader systemic gaps** (~500 nodes across many components + inline colours) — needs human design/brand review, not blind bulk edits

#4 stays open for that dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_