### PR TITLE
Fix: restore multilingual UI (setLanguage crash) + panel i18n (v26.6.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.71] - 2026-07-15
+
+### Fix — restore the multilingual UI (setLanguage crash) + panel i18n (#1)
+
+**Critical bug fix:** `setLanguage()` referenced `document.getElementById('langBtnLabel')`, but the language switcher is an icon-only button with no such element — so the function threw on its second line **before applying any translations**. The entire 5-language feature (Hindi, Tamil, Marathi, Bengali) was silently dead: clicking a language did nothing. Guarded the missing element, which restores the whole system — verified live that nav, hero and dropdowns now translate (e.g. "Reading List" → "पठन सूची").
+
+**Panel i18n wiring:** panels load lazily, after `setLanguage()` has run, so their markup wasn't being translated on open. `loadPanelInits()` now re-applies the active language to each freshly-injected panel.
+
+**About panel translated (staged template):** scaffolded the About panel's descriptive prose (heading, intro, mission, data-sources & partners headings) with `data-i18n` keys and added full **en/hi/ta/mr/bn** translations to the `I18N` dictionary — a proven, low-risk template. Health/legal/policy panels are deliberately left for a reviewed translation pass (auto-translating public health guidance without review would be irresponsible).
+
+Verified end-to-end with headless Chromium: switching to each of the four Indian languages and opening About renders the panel fully translated, and switching back to English restores it — no page errors.
+
 ## [v26.6.70] - 2026-07-15
 
 ### Data — rankings backend expanded 27 → 88 cities (#2)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.70"
+version: "26.6.71"

--- a/index.html
+++ b/index.html
@@ -1521,6 +1521,14 @@
 
     const I18N = {
         en: {
+            about_heading: 'About JanVayu',
+            about_intro: 'JanVayu (<span lang="hi">जनवायु</span> &mdash; &ldquo;People&rsquo;s Air&rdquo;) is a non-partisan, citizen-led platform documenting India&rsquo;s air quality crisis &mdash; its live data, its human toll, its policies, and its public memory. It brings together real-time AQI across <strong>115+ cities</strong>, a ward-level atlas, a live forecast and farm-fire tracker, health and economic-impact research, policy and accountability tracking, RTI tools, the <a href="/ask/">Ask JanVayu</a> AI assistant, and a multilingual wall of citizen testimony &mdash; every figure sourced and open. It is not a campaign; it is a public record, built for the <strong>#AQIForJanHit</strong> effort.',
+            about_mission_h: 'Our Mission',
+            about_mission_p1: 'JanVayu exists because clean air is not a privilege, it is a fundamental right. We bridge the gap between government promises and actual air quality outcomes through independent verification, citizen empowerment, and data-driven accountability.',
+            about_mission_p2: 'This platform is part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> &mdash; the broader <strong>#AQIForJanHit</strong> campaign. We use real-time monitoring data, peer-reviewed research, RTI responses, and independent analysis to provide the accountability that India&rsquo;s air quality crisis demands.',
+            about_datasources_h: 'Data Sources',
+            about_partners_h: 'Janhit Partners',
+            about_partners_intro: 'The organisations and initiatives JanVayu works alongside in the <strong>#AQIForJanHit</strong> effort for clean air as a public good.',
             hero_title: "India's air is killing <em>1.72 million people</em> every year",
             hero_sub: "JanVayu is India's independent, citizen-led air quality platform. We track live pollution data, measure health impacts, follow the money, and hold governments accountable. Because clean air is not a privilege, it is a right.",
             tagline: "Citizen Air Quality Platform",
@@ -1555,6 +1563,14 @@
             lang_note: ""
         },
         hi: {
+            about_heading: 'जनवायु के बारे में',
+            about_intro: 'जनवायु (<span lang="hi">जनवायु</span> &mdash; &ldquo;लोगों की हवा&rdquo;) एक गैर-पक्षपाती, नागरिक-नेतृत्व वाला मंच है जो भारत के वायु गुणवत्ता संकट का दस्तावेज़ीकरण करता है &mdash; इसका लाइव डेटा, इसकी मानवीय क्षति, इसकी नीतियाँ और इसकी सार्वजनिक स्मृति। यह <strong>115+ शहरों</strong> का रीयल-टाइम एक्यूआई, वार्ड-स्तरीय एटलस, लाइव पूर्वानुमान और खेत-आग ट्रैकर, स्वास्थ्य और आर्थिक-प्रभाव शोध, नीति और जवाबदेही ट्रैकिंग, आरटीआई उपकरण, <a href="/ask/">Ask JanVayu</a> एआई सहायक, और नागरिक गवाही की बहुभाषी दीवार को एक साथ लाता है &mdash; हर आँकड़ा स्रोत-सहित और खुला। यह कोई अभियान नहीं है; यह एक सार्वजनिक अभिलेख है, जो <strong>#AQIForJanHit</strong> प्रयास के लिए बनाया गया है।',
+            about_mission_h: 'हमारा उद्देश्य',
+            about_mission_p1: 'जनवायु इसलिए है क्योंकि स्वच्छ हवा कोई सुविधा नहीं, बल्कि एक मौलिक अधिकार है। हम स्वतंत्र सत्यापन, नागरिक सशक्तिकरण और डेटा-आधारित जवाबदेही के माध्यम से सरकारी वादों और वास्तविक वायु गुणवत्ता परिणामों के बीच की खाई को पाटते हैं।',
+            about_mission_p2: 'यह मंच <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> का हिस्सा है &mdash; व्यापक <strong>#AQIForJanHit</strong> अभियान। हम रीयल-टाइम निगरानी डेटा, सहकर्मी-समीक्षित शोध, आरटीआई जवाब और स्वतंत्र विश्लेषण का उपयोग करके वह जवाबदेही प्रदान करते हैं जिसकी भारत के वायु गुणवत्ता संकट को आवश्यकता है।',
+            about_datasources_h: 'डेटा स्रोत',
+            about_partners_h: 'जनहित सहयोगी',
+            about_partners_intro: 'स्वच्छ हवा को सार्वजनिक हित बनाने के <strong>#AQIForJanHit</strong> प्रयास में जनवायु जिन संगठनों और पहलों के साथ मिलकर काम करता है।',
             hero_title: "भारत की हवा हर साल <em>20 लाख लोगों</em> की जान ले रही है",
             hero_sub: "जनवायु भारत का स्वतंत्र, नागरिक-संचालित वायु गुणवत्ता मंच है। हम प्रदूषण के आंकड़े, स्वास्थ्य प्रभाव, बजट का हिसाब और सरकारी जवाबदेही पर नज़र रखते हैं। क्योंकि स्वच्छ हवा विशेषाधिकार नहीं, अधिकार है।",
             tagline: "नागरिक वायु गुणवत्ता मंच",
@@ -1584,6 +1600,14 @@
             lang_note: "विस्तृत विश्लेषण अंग्रेज़ी में उपलब्ध है। हिन्दी अनुवाद चरणबद्ध रूप से जोड़ा जा रहा है।"
         },
         ta: {
+            about_heading: 'ஜன்வாயு பற்றி',
+            about_intro: 'ஜன்வாயு (<span lang="hi">जनवायु</span> &mdash; &ldquo;மக்களின் காற்று&rdquo;) என்பது இந்தியாவின் காற்று தர நெருக்கடியை ஆவணப்படுத்தும் ஒரு கட்சி சாராத, குடிமக்கள் தலைமையிலான தளம் &mdash; அதன் நேரடி தரவு, அதன் மனித இழப்பு, அதன் கொள்கைகள் மற்றும் அதன் பொது நினைவு. இது <strong>115+ நகரங்களில்</strong> நிகழ்நேர AQI, வார்டு அளவிலான அட்லஸ், நேரடி முன்னறிவிப்பு மற்றும் வயல்-தீ கண்காணிப்பு, சுகாதார மற்றும் பொருளாதார-தாக்க ஆராய்ச்சி, கொள்கை மற்றும் பொறுப்புக்கூறல் கண்காணிப்பு, RTI கருவிகள், <a href="/ask/">Ask JanVayu</a> AI உதவியாளர், மற்றும் குடிமக்கள் சாட்சியத்தின் பன்மொழி சுவர் ஆகியவற்றை ஒன்றிணைக்கிறது &mdash; ஒவ்வொரு புள்ளிவிவரமும் ஆதாரத்துடன், திறந்தது. இது ஒரு பிரச்சாரம் அல்ல; இது <strong>#AQIForJanHit</strong> முயற்சிக்காக உருவாக்கப்பட்ட ஒரு பொது பதிவு.',
+            about_mission_h: 'எங்கள் நோக்கம்',
+            about_mission_p1: 'தூய்மையான காற்று ஒரு சலுகை அல்ல, அது ஒரு அடிப்படை உரிமை என்பதால் ஜன்வாயு உள்ளது. சுயாதீன சரிபார்ப்பு, குடிமக்கள் அதிகாரமளித்தல் மற்றும் தரவு சார்ந்த பொறுப்புக்கூறல் மூலம் அரசாங்க வாக்குறுதிகளுக்கும் உண்மையான காற்று தர விளைவுகளுக்கும் இடையிலான இடைவெளியை நாங்கள் இணைக்கிறோம்.',
+            about_mission_p2: 'இந்த தளம் <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> இன் ஒரு பகுதி &mdash; பரந்த <strong>#AQIForJanHit</strong> பிரச்சாரம். நிகழ்நேர கண்காணிப்பு தரவு, சக மதிப்பாய்வு ஆராய்ச்சி, RTI பதில்கள் மற்றும் சுயாதீன பகுப்பாய்வைப் பயன்படுத்தி இந்தியாவின் காற்று தர நெருக்கடி கோரும் பொறுப்புக்கூறலை நாங்கள் வழங்குகிறோம்.',
+            about_datasources_h: 'தரவு ஆதாரங்கள்',
+            about_partners_h: 'ஜன்ஹித் பங்காளர்கள்',
+            about_partners_intro: 'தூய்மையான காற்றை பொது நலனாக்கும் <strong>#AQIForJanHit</strong> முயற்சியில் ஜன்வாயு இணைந்து செயல்படும் அமைப்புகள் மற்றும் முயற்சிகள்.',
             hero_title: "இந்தியாவின் காற்று ஆண்டுதோறும் <em>20 லட்சம் பேரைக்</em> கொல்கிறது",
             hero_sub: "ஜன்வாயு இந்தியாவின் சுயாதீன, குடிமக்கள் வழிநடத்தும் காற்றுத் தர தளமாகும். நாங்கள் மாசு தரவுகள், சுகாதார பாதிப்புகள், பட்ஜெட் கணக்கு மற்றும் அரசின் பொறுப்புணர்வை கண்காணிக்கிறோம். ஏனெனில் சுத்தமான காற்று சலுகை அல்ல, அது உரிமை.",
             tagline: "குடிமக்கள் காற்றுத் தர தளம்",
@@ -1613,6 +1637,14 @@
             lang_note: "விரிவான பகுப்பாய்வு ஆங்கிலத்தில் உள்ளது. தமிழ் மொழிபெயர்ப்பு படிப்படியாக சேர்க்கப்படுகிறது."
         },
         mr: {
+            about_heading: 'जनवायु विषयी',
+            about_intro: 'जनवायु (<span lang="hi">जनवायु</span> &mdash; &ldquo;लोकांची हवा&rdquo;) हे भारताच्या हवा गुणवत्ता संकटाचे दस्तऐवजीकरण करणारे एक निष्पक्ष, नागरिक-नेतृत्वाखालील व्यासपीठ आहे &mdash; त्याचा थेट डेटा, त्याची मानवी हानी, त्याची धोरणे आणि त्याची सार्वजनिक स्मृती. हे <strong>115+ शहरांतील</strong> रिअल-टाइम AQI, वॉर्ड-स्तरीय नकाशा, थेट अंदाज आणि शेत-आग ट्रॅकर, आरोग्य आणि आर्थिक-परिणाम संशोधन, धोरण आणि उत्तरदायित्व ट्रॅकिंग, आरटीआय साधने, <a href="/ask/">Ask JanVayu</a> AI सहाय्यक, आणि नागरिक साक्षीची बहुभाषिक भिंत एकत्र आणते &mdash; प्रत्येक आकडा स्रोतासह आणि खुला. ही मोहीम नाही; हे <strong>#AQIForJanHit</strong> प्रयत्नासाठी तयार केलेले सार्वजनिक अभिलेख आहे.',
+            about_mission_h: 'आमचे ध्येय',
+            about_mission_p1: 'जनवायु अस्तित्वात आहे कारण स्वच्छ हवा ही सवलत नाही, तो मूलभूत अधिकार आहे. स्वतंत्र पडताळणी, नागरिक सक्षमीकरण आणि डेटा-आधारित उत्तरदायित्वाद्वारे आम्ही सरकारी आश्वासने आणि प्रत्यक्ष हवा गुणवत्ता परिणाम यांच्यातील दरी भरून काढतो.',
+            about_mission_p2: 'हे व्यासपीठ <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> चा भाग आहे &mdash; व्यापक <strong>#AQIForJanHit</strong> मोहीम. रिअल-टाइम निरीक्षण डेटा, समवयस्क-पुनरावलोकित संशोधन, आरटीआय उत्तरे आणि स्वतंत्र विश्लेषण वापरून आम्ही भारताच्या हवा गुणवत्ता संकटाला आवश्यक असलेले उत्तरदायित्व प्रदान करतो.',
+            about_datasources_h: 'डेटा स्रोत',
+            about_partners_h: 'जनहित भागीदार',
+            about_partners_intro: 'स्वच्छ हवा हा सार्वजनिक हिताचा विषय बनवण्याच्या <strong>#AQIForJanHit</strong> प्रयत्नात जनवायु ज्या संस्था आणि उपक्रमांसोबत काम करते.',
             hero_title: "भारतातील हवा दरवर्षी <em>20 लाख लोकांचा</em> बळी घेत आहे",
             hero_sub: "जनवायू हे भारताचे स्वतंत्र, नागरिक-संचालित हवा गुणवत्ता व्यासपीठ आहे. आम्ही प्रदूषणाचे आकडे, आरोग्यावरील परिणाम, बजेटचा मागोवा आणि सरकारी जबाबदारी यांवर लक्ष ठेवतो. कारण स्वच्छ हवा ही सवलत नाही, ती हक्क आहे.",
             tagline: "नागरिक हवा गुणवत्ता व्यासपीठ",
@@ -1642,6 +1674,14 @@
             lang_note: "तपशीलवार विश्लेषण इंग्रजीत उपलब्ध आहे. मराठी भाषांतर टप्प्याटप्प्याने जोडले जात आहे."
         },
         bn: {
+            about_heading: 'জনবায়ু সম্পর্কে',
+            about_intro: 'জনবায়ু (<span lang="hi">जनवायु</span> &mdash; &ldquo;জনগণের বাতাস&rdquo;) হল একটি নিরপেক্ষ, নাগরিক-নেতৃত্বাধীন প্ল্যাটফর্ম যা ভারতের বায়ুর মানের সংকট নথিভুক্ত করে &mdash; এর সরাসরি তথ্য, এর মানবিক ক্ষতি, এর নীতি এবং এর জনস্মৃতি। এটি <strong>115+ শহরে</strong> রিয়েল-টাইম AQI, ওয়ার্ড-স্তরের অ্যাটলাস, সরাসরি পূর্বাভাস ও খেত-আগুন ট্র্যাকার, স্বাস্থ্য ও অর্থনৈতিক-প্রভাব গবেষণা, নীতি ও জবাবদিহিতা ট্র্যাকিং, আরটিআই সরঞ্জাম, <a href="/ask/">Ask JanVayu</a> AI সহকারী, এবং নাগরিক সাক্ষ্যের একটি বহুভাষিক দেয়াল একত্র করে &mdash; প্রতিটি পরিসংখ্যান উৎসসহ ও উন্মুক্ত। এটি কোনো অভিযান নয়; এটি একটি জনসাধারণের নথি, <strong>#AQIForJanHit</strong> প্রয়াসের জন্য নির্মিত।',
+            about_mission_h: 'আমাদের লক্ষ্য',
+            about_mission_p1: 'জনবায়ু বিদ্যমান কারণ পরিষ্কার বাতাস কোনো সুবিধা নয়, এটি একটি মৌলিক অধিকার। স্বাধীন যাচাই, নাগরিক ক্ষমতায়ন এবং তথ্য-নির্ভর জবাবদিহিতার মাধ্যমে আমরা সরকারি প্রতিশ্রুতি ও প্রকৃত বায়ুর মানের ফলাফলের মধ্যে ব্যবধান দূর করি।',
+            about_mission_p2: 'এই প্ল্যাটফর্মটি <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong>-এর অংশ &mdash; বৃহত্তর <strong>#AQIForJanHit</strong> অভিযান। রিয়েল-টাইম পর্যবেক্ষণ তথ্য, সমকক্ষ-পর্যালোচিত গবেষণা, আরটিআই উত্তর এবং স্বাধীন বিশ্লেষণ ব্যবহার করে আমরা ভারতের বায়ুর মানের সংকট যে জবাবদিহিতা দাবি করে তা প্রদান করি।',
+            about_datasources_h: 'তথ্য উৎস',
+            about_partners_h: 'জনহিত অংশীদার',
+            about_partners_intro: 'পরিষ্কার বাতাসকে জনস্বার্থে পরিণত করার <strong>#AQIForJanHit</strong> প্রচেষ্টায় জনবায়ু যেসব সংস্থা ও উদ্যোগের সঙ্গে কাজ করে।',
             hero_title: "ভারতের বায়ু প্রতি বছর <em>২০ লক্ষ মানুষের</em> প্রাণ কেড়ে নিচ্ছে",
             hero_sub: "জনবায়ু ভারতের স্বাধীন, নাগরিক-পরিচালিত বায়ু মান প্ল্যাটফর্ম। আমরা দূষণের তথ্য, স্বাস্থ্যের প্রভাব, বাজেটের হিসাব এবং সরকারি জবাবদিহিতা পর্যবেক্ষণ করি। কারণ বিশুদ্ধ বাতাস বিশেষাধিকার নয়, এটি অধিকার।",
             tagline: "নাগরিক বায়ু মান প্ল্যাটফর্ম",
@@ -1691,9 +1731,12 @@
         const t = I18N[lang];
         if (!t) return;
 
-        // Update button label
+        // Update button label (the language switcher is an icon-only button, so
+        // this label element is optional — guard against its absence, otherwise
+        // setLanguage() throws here and NO translations are ever applied).
         const labels = { en: 'EN', hi: 'हि', ta: 'த', mr: 'म', bn: 'ব' };
-        document.getElementById('langBtnLabel').textContent = labels[lang] || lang.toUpperCase();
+        const langBtnLabel = document.getElementById('langBtnLabel');
+        if (langBtnLabel) langBtnLabel.textContent = labels[lang] || lang.toUpperCase();
 
         // Update active state
         document.querySelectorAll('.lang-option').forEach(o => o.classList.remove('active'));
@@ -2350,6 +2393,14 @@
         }
     }
     function loadPanelInits(panelId) {
+            // Re-apply the active language to the freshly-injected panel markup:
+            // panels load lazily, after setLanguage() has already run, so any
+            // data-i18n elements inside them need translating on open.
+            try {
+                if (typeof currentLang !== 'undefined' && currentLang !== 'en' && typeof window.setLanguage === 'function') {
+                    window.setLanguage(currentLang);
+                }
+            } catch (e) { /* i18n re-apply is best-effort */ }
             // Re-init charts/map after DOM update
             setTimeout(() => {
                 try { initAllCharts(); } catch(e) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.70",
+  "version": "26.6.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.70",
+      "version": "26.6.71",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.70",
+  "version": "26.6.71",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/about.html
+++ b/panels/about.html
@@ -1,22 +1,22 @@
 
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span>About JanVayu</h2>
-        <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="JanVayu (जनवायु, ‘People’s Air’) is a free, citizen-run website — not a government or party site. We bring India’s air pollution into one place: live air quality for 115+ cities, ward maps, health and cost information, what leaders have promised, and the voices of the people who breathe it. Clean air is a right, so we track it and hold leaders to account.">JanVayu (<span lang="hi">जनवायु</span> &mdash; &ldquo;People&rsquo;s Air&rdquo;) is a non-partisan, citizen-led platform documenting India&rsquo;s air quality crisis &mdash; its live data, its human toll, its policies, and its public memory. It brings together real-time AQI across <strong>115+ cities</strong>, a ward-level atlas, a live forecast and farm-fire tracker, health and economic-impact research, policy and accountability tracking, RTI tools, the <a href="/ask/">Ask JanVayu</a> AI assistant, and a multilingual wall of citizen testimony &mdash; every figure sourced and open. It is not a campaign; it is a public record, built for the <strong>#AQIForJanHit</strong> effort.</p>
+        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-info" style="color: var(--accent); margin-right: 0.4rem;"></span><span data-i18n="about_heading">About JanVayu</span></h2>
+        <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-i18n="about_intro" data-simple="JanVayu (जनवायु, ‘People’s Air’) is a free, citizen-run website — not a government or party site. We bring India’s air pollution into one place: live air quality for 115+ cities, ward maps, health and cost information, what leaders have promised, and the voices of the people who breathe it. Clean air is a right, so we track it and hold leaders to account.">JanVayu (<span lang="hi">जनवायु</span> &mdash; &ldquo;People&rsquo;s Air&rdquo;) is a non-partisan, citizen-led platform documenting India&rsquo;s air quality crisis &mdash; its live data, its human toll, its policies, and its public memory. It brings together real-time AQI across <strong>115+ cities</strong>, a ward-level atlas, a live forecast and farm-fire tracker, health and economic-impact research, policy and accountability tracking, RTI tools, the <a href="/ask/">Ask JanVayu</a> AI assistant, and a multilingual wall of citizen testimony &mdash; every figure sourced and open. It is not a campaign; it is a public record, built for the <strong>#AQIForJanHit</strong> effort.</p>
     </div>
     <div class="card mb-2">
         <div class="card-body">
             <div class="grid-2">
                 <div>
-                    <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem;">Our Mission</h3>
-                    <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2);">
+                    <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem;" data-i18n="about_mission_h">Our Mission</h3>
+                    <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2);" data-i18n="about_mission_p1">
                         JanVayu exists because clean air is not a privilege, it is a fundamental right. We bridge the gap between government promises and actual air quality outcomes through independent verification, citizen empowerment, and data-driven accountability.
                     </p>
-                    <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-top: 1rem;">
+                    <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-top: 1rem;" data-i18n="about_mission_p2">
                         This platform is part of <strong>AirQuality for Janhit by MMSF Fellows, AIPC</strong> &mdash; the broader <strong>#AQIForJanHit</strong> campaign. We use real-time monitoring data, peer-reviewed research, RTI responses, and independent analysis to provide the accountability that India's air quality crisis demands.
                     </p>
                 </div>
                 <div>
-                    <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem;">Data Sources</h3>
+                    <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem;" data-i18n="about_datasources_h">Data Sources</h3>
                     <div class="info-box" style="border-left: 3px solid var(--green-700);">
                         <ul style="font-size: 0.9375rem; line-height: 2;">
                             <li><strong>WAQI API</strong> (aqicn.org) for real-time AQI</li>
@@ -39,8 +39,8 @@
     <!-- ── JANHIT PARTNERS ── -->
     <div class="card mb-2" id="partners">
         <div class="card-body">
-            <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 0.5rem;"><span class="si si-user" style="color: var(--accent); margin-right: 0.4rem;"></span>Janhit Partners</h3>
-            <p style="font-size: 0.9375rem; line-height: 1.7; color: var(--text-2); margin-bottom: 1.25rem; max-width: 48rem;" data-simple="The people and groups JanVayu works with on clean air for the public good.">The organisations and initiatives JanVayu works alongside in the <strong>#AQIForJanHit</strong> effort for clean air as a public good.</p>
+            <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 0.5rem;"><span class="si si-user" style="color: var(--accent); margin-right: 0.4rem;"></span><span data-i18n="about_partners_h">Janhit Partners</span></h3>
+            <p style="font-size: 0.9375rem; line-height: 1.7; color: var(--text-2); margin-bottom: 1.25rem; max-width: 48rem;" data-i18n="about_partners_intro" data-simple="The people and groups JanVayu works with on clean air for the public good.">The organisations and initiatives JanVayu works alongside in the <strong>#AQIForJanHit</strong> effort for clean air as a public good.</p>
             <div class="grid-2" style="gap: 1rem;">
 
                 <a href="https://profcongress.in/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #1B6B4A;">


### PR DESCRIPTION
## What (#1 — i18n)

### 🔴 Critical bug fix — the whole multilingual feature was dead

`setLanguage()` referenced `document.getElementById('langBtnLabel')`, but the language switcher (`#langBtn`) is an **icon-only** button — there is no `langBtnLabel` element anywhere. So the function threw a `TypeError` on its second line, **before** the `data-i18n` translation loop ever ran. The result: clicking Hindi / Tamil / Marathi / Bengali did **nothing** — the entire 5-language system was silently broken.

Guarded the missing element (`const el = getElementById(...); if (el) …`). Verified live that nav, hero and dropdowns now translate — e.g. **"Reading List" → "पठन सूची"**.

### Panel i18n wiring

Panels load lazily (after `setLanguage()` has already run), so their markup wasn't translated on open. `loadPanelInits()` now re-applies the active language to each freshly-injected panel.

### About panel translated — the staged template

Per the agreed **scaffold + staged** approach: added `data-i18n` keys to the About panel's descriptive prose (heading, intro, mission, data-sources & partners headings) and full **en/hi/ta/mr/bn** translations in the `I18N` dictionary. This is the low-risk proof template. Health/legal/policy panels are **deliberately left** for a reviewed translation pass — auto-translating public health guidance without human review would be irresponsible.

## Verification

Headless Chromium, end-to-end:
- `setLanguage('hi'|'ta'|'mr'|'bn')` no longer throws; the document-wide `data-i18n` loop runs
- Opening the lazy **About** panel renders it fully translated in each language (heading, mission, intro all confirmed)
- Switching back to English restores it — **no page errors**
- Nav confirmed translating independently (`nav_resources`: Reading List → पठन सूची)

## Remaining on #1 (kept open)

Translating the remaining panels' long-form health/legal/policy prose — a larger, review-sensitive content effort now unblocked by the working `setLanguage` + the panel-i18n wiring + the proven About template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_