### PR TITLE
Docs: July platform write-up across blog, wiki, README, history (v26.6.72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.72] - 2026-07-15
+
+### Docs — July platform-quality write-up across blog, wiki, README & in-app history
+
+Documentation and history refresh for the v26.6.58–71 work (multilingual fix, accessibility sweep, rankings expansion, streamlining, backend dedup):
+
+- **Blog:** new post *"A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site"* (`blog/posts/2026-07-15-multilingual-accessibility-lighter.md`), registered in the blog sidebar and the README "Latest" table (also backfilled the 14 Jul entry).
+- **In-app Version History** (About panel) brought current through v26.6.71 with entries for the multilingual fix, rankings 27→88, the accessibility sweep, the shared CORS helper, and the sub-1 MB `index.html`.
+- **Docs wiki:** added *Phase 5.17* to `docs/wiki/Roadmap.md` and a current *What's New* entry to `docs/wiki/Home.md`.
+- **README:** refreshed the "Recently shipped" callout to v26.6.71.
+- **Roadmap issue #34** updated to check off completed Q2 items; closed the resolved issues (#1, #2, #3, #4, #5, #33, #74, #167, #183) with evidence and split the dark-theme contrast work into #213.
+
 ## [v26.6.71] - 2026-07-15
 
 ### Fix — restore the multilingual UI (setLanguage crash) + panel i18n (#1)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-15"
-version: "26.6.71"
+version: "26.6.72"

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ JanVayu integrates **160+ verified public data sources**, including:
 
 Full phased roadmap: **[docs/wiki/Roadmap.md](docs/wiki/Roadmap.md)** · tracked on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues).
 
-**Recently shipped (v26.6.25):** the **Ward-Level Atlas** — every municipal ward across **10 major cities**, with four switchable layers (live PM2.5, satellite heat, green cover, built-up), ward search / locate-me, and a per-ward correlation view, plus an Urban Heat Island panel.
+**Recently shipped (v26.6.71):** the **5-language switcher works again** (a crash had silently disabled Hindi/Tamil/Marathi/Bengali across the UI), a **WCAG 2.1 AA accessibility sweep** (axe-verified form labels, prose-link underlines, chart alt-text, theme-aware badge contrast), **live rankings expanded 27 → 88 cities**, and a **42%-lighter first load** (`index.html` ~1.59 MB → ~0.92 MB by lazy-loading 12 heavy panels). Earlier in July: 5-day forecast, farm-fire tracker, OpenAQ hyperlocal data, and a CORS-open Open Data API.
 
 **Next up:**
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -10,6 +10,8 @@ Data, research, policy accountability, and what the numbers mean for 1.4 billion
 
 | Date | Post | Topic |
 |------|------|-------|
+| 15 Jul 2026 | [A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site](posts/2026-07-15-multilingual-accessibility-lighter.md) | Platform |
+| 14 Jul 2026 | [What Shipped This Week: Forecasts, Fire Maps, and Pollution Beyond the Lungs](posts/2026-07-14-forecast-fire-and-beyond-the-lungs.md) | Product |
 | 8 Jul 2026 | [The Pollution You Can't See Being Emitted: Up to 42% of India's PM2.5 Is Made in the Sky](posts/2026-07-08-secondary-pm25.md) | Data |
 | 2 Jul 2026 | [The Citation That Didn't Exist: How We Found "Krishna et al." Was Really Jaganathan](posts/2026-07-02-citation-integrity.md) | Research |
 | 25 Jun 2026 | [Ask JanVayu Can Now Answer About Your Ward](posts/2026-06-25-ask-janvayu-knows-your-ward.md) | Product |

--- a/blog/_sidebar.md
+++ b/blog/_sidebar.md
@@ -3,6 +3,7 @@
 - [**JanVayu Blog**](README.md)
 
 - **July 2026**
+  - [What Shipped This Week: A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site](posts/2026-07-15-multilingual-accessibility-lighter.md)
   - [What Shipped This Week: Forecasts, Fire Maps, and Pollution Beyond the Lungs](posts/2026-07-14-forecast-fire-and-beyond-the-lungs.md)
   - [The Pollution You Can't See Being Emitted: Up to 42% of India's PM2.5 Is Made in the Sky](posts/2026-07-08-secondary-pm25.md)
   - [The Citation That Didn't Exist: How We Found "Krishna et al." Was Really Jaganathan](posts/2026-07-02-citation-integrity.md)

--- a/blog/posts/2026-07-15-multilingual-accessibility-lighter.md
+++ b/blog/posts/2026-07-15-multilingual-accessibility-lighter.md
@@ -1,0 +1,46 @@
+# What Shipped This Week: A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site
+
+**Published:** 15 July 2026 | **Author:** Team JanVayu | **Reading time:** 5 min
+
+---
+
+This week's releases (v26.6.58 to v26.6.71) were less about new panels and more about the plumbing: making what already exists work properly, load faster, and reach more people. Here is what changed and why it matters.
+
+## The language switcher was broken — now it works
+
+JanVayu has carried a five-language interface (English, Hindi, Tamil, Marathi, Bengali) for months. It turns out almost none of it was reaching users.
+
+The function that applies translations, `setLanguage()`, tried to update a small text label next to the language button on its very first step. But that button is icon-only — a globe — and the label element it was looking for did not exist. So the function threw an error and stopped **before it translated anything**. Clicking Hindi, Tamil, Marathi or Bengali did nothing at all.
+
+It was a one-line guard to fix, and the effect is night and day: the navigation, hero banner, and dropdown menus now translate the moment you switch languages. "Reading List" becomes "पठन सूची". All the translation work that had been sitting dormant is finally visible.
+
+We also wired translation into the panels that now load on demand (see below), so a panel you open *after* switching language still comes up translated. And we translated the **About** panel end-to-end into all five languages as a template for the rest. We are deliberately *not* auto-translating the health and legal panels without review — a mistranslated health instruction is worse than an English one — so those will follow through a checked translation pass.
+
+## An accessibility sweep, measured with the same tool the CI uses
+
+We ran [axe-core](https://github.com/dequelabs/axe-core) (the WCAG 2.1 AA engine our accessibility CI already runs) against the live panels and fixed what it actually flagged, rather than guessing:
+
+- **Form controls** in the health calculator and urban-heat estimator had visible labels that were not programmatically linked — a screen reader announced them as unlabelled. All twelve now carry proper accessible names.
+- **Inline links inside paragraphs** were distinguished only by colour, which fails for colour-blind readers. They are now underlined; buttons and nav links are unaffected.
+- The one remaining **chart without a text description** got one.
+- **Status badges** were the biggest colour-contrast offender by far. They are now theme-aware — darker text on the pale light-theme tint, brighter text in dark mode — and pass the 4.5:1 ratio in both. That alone cleared about half of all contrast findings.
+
+A dark-theme contrast pass is [tracked separately](https://github.com/JanVayu/JanVayu/issues/213); it needs design review, not bulk edits.
+
+## The rankings now cover 88 cities
+
+The live [City Rankings](https://www.janvayu.in/#rankings) were computed from a hardcoded list of 27 cities, even though the dashboard itself covers around 117. We expanded the rankings backend to **88 cities** — the core set plus state capitals and NCAP non-attainment cities — so the national picture is no longer a metro-only view. Cities without a nearby live station simply drop out; nothing is faked.
+
+## The site is 42% lighter
+
+The whole platform is a single HTML file, and it had grown to about 1.59 MB. Over a series of passes we moved the heaviest panels' markup — Citizen Voices, Resources, Legal, About, and eight more — into external fragments that load only when you open them and are cached afterwards. The Learning Games engine and the citizen-testimony data moved out to cacheable external files too, and the map stylesheet no longer blocks the first paint.
+
+The result: `index.html` dropped from ~1.59 MB to about **0.92 MB** — a 42% cut in what your browser downloads and parses on the very first visit, which matters most on the slower mobile connections common across India.
+
+## Under the hood
+
+We also consolidated the copy-pasted CORS handling across the Netlify serverless functions into a single shared helper, so there is one place to change how the API responds — a maintenance win with no user-visible change.
+
+---
+
+*Every figure on JanVayu is sourced and open. Found something off? The code is on [GitHub](https://github.com/JanVayu/JanVayu) and every panel links its sources.*

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -31,6 +31,15 @@ Welcome to the JanVayu technical wiki — the comprehensive documentation for In
 
 ### What's New (v26.6.x)
 
+**v26.6.58–71 — Multilingual fix, accessibility & a 42%-lighter site (15 Jul 2026)**
+- Fixed a crash that had silently disabled the entire 5-language switcher — Hindi, Tamil, Marathi and Bengali now actually apply across the UI. Lazy panels translate on open; the About panel is fully translated as a template.
+- Accessibility sweep (WCAG 2.1 AA, axe-verified): form-control labels, underlined prose links, chart alt-text, and theme-aware badge contrast.
+- Live rankings expanded 27 → 88 cities. Backend CORS handling consolidated into a shared helper.
+- `index.html` shrank from ~1.59 MB to ~0.92 MB by lazy-loading 12 heavy panels and externalising the Games engine and testimony data.
+
+**v26.6.43–47 — Forecast, Fire Tracker, Beyond the Lungs, Open Data API (14 Jul 2026)**
+- 5-day PM2.5 forecast (Open-Meteo/CAMS), NASA-FIRMS farm-fire tracker, OpenAQ hyperlocal data, whole-body health section, and a CORS-open public Open Data API at `/api`.
+
 **v26.6.23 — 7 new panels, shareable AQI cards, 12 roles, nav audit (27 May 2026)**
 - 4 new panels: Understanding AQI (pollutant breakdown + CPCB vs EPA scales), Shareable AQI Cards (canvas PNG for Instagram/WhatsApp), Exposure Diary (16-activity weighted exposure with cigarette equivalence), enhanced Migration Comparison (side-by-side live AQI + life-years verdict).
 - 3 more panels: Data Source Selector (CPCB/WAQI/IQAir/Sensor.Community education + Source Impact Simulator), City Policy Tracker (8-city NCAP dashboard), enhanced Legal Framework (8-region court rulings + citizen recourse guide).

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -4,6 +4,17 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 
 ---
 
+## Phase 5.17: Multilingual fix, accessibility & a lighter site (✅ Completed — v26.6.58–71)
+
+A mid-July 2026 platform-quality drop — mostly plumbing, and one significant bug fix.
+
+- [x] **Multilingual UI restored** — `setLanguage()` was throwing on a missing button-label element *before* applying any translations, so the entire 5-language switcher (Hindi, Tamil, Marathi, Bengali) was silently dead. Guarded it; nav/hero/menus now translate. Lazy panels re-apply the active language on open, and the About panel is fully translated in all five languages as a template. (#1, #212)
+- [x] **Accessibility sweep (WCAG 2.1 AA)** — audited with axe-core against the live panels: 12 form controls labelled, inline prose links underlined (WCAG 1.4.1), the last chart labelled, and status-badge colours made theme-aware to meet 4.5:1 in both themes. Dark-theme contrast pass tracked in #213. (#4, #209, #210)
+- [x] **Rankings backend 27 → 88 cities** — the live rankings now reflect a national set (core cities + state capitals + NCAP cities) rather than a metro subset. (#2, #211)
+- [x] **`index.html` ~1.59 MB → ~0.92 MB (~42%)** — 12 heavy panels moved to external fragments loaded on demand and cached; Games engine + testimonies data externalised; Leaflet CSS off the critical path. (#3)
+- [x] **Backend CORS/HTTP helper** — the preflight/CORS boilerplate copy-pasted across serverless functions consolidated into one shared module. (#208)
+- [x] **Housekeeping** — closed stale/duplicate issues (#5 CI/CD, #33 mobile, #167 blobs-v10, #183 link audit) after verifying each was already satisfied.
+
 ## Phase 5.16: Forecast, Fire Tracker, Health-Complete & Open Data (✅ Completed — v26.6.43–47)
 
 A July 2026 feature drop that shipped several long-standing Phase 9 and Phase 10 items (see those phases below, now ticked).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.71",
+  "version": "26.6.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.71",
+      "version": "26.6.72",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.71",
+  "version": "26.6.72",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/about.html
+++ b/panels/about.html
@@ -179,6 +179,36 @@
             <div style="font-family: var(--mono); font-size: 0.8rem; line-height: 1.9; color: var(--text-2);">
 
                 <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.71 &mdash; 15 July 2026</div>
+                    <strong>Fix: the multilingual UI works again</strong><br>
+                    &bull; <code>setLanguage()</code> was throwing on a missing button-label element <em>before</em> applying any translations &mdash; so the whole 5-language switcher (Hindi, Tamil, Marathi, Bengali) was silently dead. Guarded it: nav, hero and menus now translate. Lazy panels also re-apply the active language on open, and the About panel is fully translated in all five languages as a template.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.70 &mdash; 15 July 2026</div>
+                    <strong>City rankings expanded 27 &rarr; 88 cities</strong><br>
+                    &bull; The live rankings backend ranked only 27 hardcoded cities; it now covers 88 &mdash; the core set plus state capitals and NCAP non-attainment cities &mdash; so the national picture is no longer metro-only. Stationless cities simply drop out.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.68&ndash;69 &mdash; 15 July 2026</div>
+                    <strong>Accessibility sweep (WCAG 2.1 AA)</strong><br>
+                    &bull; Audited with axe-core against the live panels: labelled 12 form controls, underlined inline prose links (colour-blind support), labelled the last chart, and made status-badge colours theme-aware to meet contrast in both light and dark mode. A dark-theme contrast pass is tracked separately.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.67 &mdash; 15 July 2026</div>
+                    <strong>Backend: shared CORS/HTTP helper</strong><br>
+                    &bull; The CORS and preflight handling copy-pasted across the serverless functions is now a single shared module &mdash; one place to change how the API responds, no user-visible change.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
+                    <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.64&ndash;66 &mdash; 15 July 2026</div>
+                    <strong>Performance: index.html now under 1 MB</strong><br>
+                    &bull; The Resources, Legal, About and eight more content panels moved into external fragments that load on demand and cache after first open. Combined with the earlier passes, <code>index.html</code> dropped from ~1.59 MB to ~0.92 MB (~42%) &mdash; a big win for first load on slow mobile connections.
+                </div>
+
+                <div style="margin-bottom: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border-light);">
                     <div style="font-weight: 700; color: var(--accent); margin-bottom: 0.25rem;">v26.6.63 &mdash; 15 July 2026</div>
                     <strong>Performance: Voices panel lazy-loaded</strong><br>
                     &bull; The Citizen Voices panel (~107 KB of curated cards + live feed) now loads its markup from an external <code>/panels/voices.html</code> fragment only when you open it, via a small generic lazy-panel mechanism. It's off the initial parse and cached after first open. All cards, filters and the live feed verified working.


### PR DESCRIPTION
## What

Documentation, blog, and history refresh covering the v26.6.58–71 platform-quality work (multilingual fix, accessibility sweep, rankings expansion, streamlining, backend dedup):

- **Blog** — new post *"A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site"* (`blog/posts/2026-07-15-multilingual-accessibility-lighter.md`), registered in `blog/_sidebar.md` and the README "Latest" table (also backfilled the missing 14 Jul entry).
- **In-app Version History** (About panel) brought current through v26.6.71 — entries for the multilingual fix, rankings 27→88, the accessibility sweep, the shared CORS helper, and the sub-1 MB `index.html`.
- **Docs wiki** — added *Phase 5.17* to `docs/wiki/Roadmap.md` and a current *What's New* entry to `docs/wiki/Home.md`.
- **README** — refreshed the "Recently shipped" callout to v26.6.71.

## Also (issue housekeeping, done via API)

- Updated the **Roadmap issue #34** to check off completed Q2 items.
- Closed the resolved issues with evidence: **#1** (i18n), **#2** (cities), **#3** (performance), **#4** (accessibility), **#5** (CI/CD), **#33** (mobile), **#74** (ship log), **#167** (blobs v10), **#183** (link audit).
- Split the remaining **dark-theme colour-contrast** work into a focused new issue, **#213**.
- Left **#45** (Agent-Reach social pipeline) open — it's blocked on repo secrets, not on code.

## Verification

Headless Chromium: the About panel renders with the new Version History entries (v26.6.64–71), the partners grid intact, and the `data-i18n` keys live — no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zTHWpdP9MixByJ9fhuxMR)_