### PR TITLE
Role grid fills evenly + classy entrance motion (v26.6.79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.79] - 2026-07-16
+
+### UX — role grid fills evenly + classy motion
+
+- **Role selector no longer leaves awkward gaps.** Twelve roles in a 5-column `auto-fill` grid rendered as 5 + 5 + 2, leaving three empty slots. Pinned the columns to divisors of 12 — **4 (desktop) / 3 (tablet) / 2 (mobile)** — so every row is full at every breakpoint. Cards now animate in with a soft staggered "tile" entrance and a lift-on-hover.
+- **Gentle entrance + scroll-reveal.** The hero headline, subhead and live-data card fade up on load; dashboard cards ease into view as they scroll in. Implemented as progressive enhancement (a `.reveal-on` class is only added by JS, with a failsafe that reveals any straggler) and fully disabled under `prefers-reduced-motion`, so content can never end up hidden.
+
+Verified in Chromium: role grid renders 4×3 with zero trailing gap; after scroll + failsafe, 0 of the dashboard cards remain hidden; zero page errors; 12/12 calculator unit tests pass.
+
 ## [v26.6.78] - 2026-07-16
 
 ### UX — visual decluttering (lead with data)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.78"
+version: "26.6.79"

--- a/app.js
+++ b/app.js
@@ -13,6 +13,29 @@
     }
     window.toggleHeroAlert = toggleHeroAlert;
 
+    // ── Classy motion: reveal dashboard cards as they scroll into view ──
+    // Scoped to the always-visible dashboard section (never a hidden panel),
+    // progressive-enhancement only, with a failsafe so nothing stays hidden.
+    (function classyReveal() {
+        try {
+            if (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+            if (!('IntersectionObserver' in window)) return;
+            const run = () => {
+                const dash = document.getElementById('section-dashboard');
+                if (!dash) return;
+                document.documentElement.classList.add('reveal-on');
+                const io = new IntersectionObserver((entries) => {
+                    entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('is-in'); io.unobserve(e.target); } });
+                }, { threshold: 0.06, rootMargin: '0px 0px -6% 0px' });
+                dash.querySelectorAll('.card').forEach(el => { el.setAttribute('data-reveal', ''); io.observe(el); });
+                // Failsafe: never leave content hidden if the observer misfires.
+                setTimeout(() => dash.querySelectorAll('[data-reveal]:not(.is-in)').forEach(el => el.classList.add('is-in')), 2600);
+            };
+            if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', run);
+            else run();
+        } catch (e) { /* motion is optional — never block the app */ }
+    })();
+
     // ── Configuration ──
     const WAQI_TOKEN = '1f64cc8563a165dc5a6ce48f7eeb9ba0221b63f3';
     const DEMO_DATA = {

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260678-v78';
+const CACHE_NAME = 'ask-janvayu-20260679-v79';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.78",
+  "version": "26.6.79",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -1835,20 +1835,72 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
 
 .role-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    /* 12 roles: pin to divisors of 12 (4 / 3 / 2) so every row is full and
+       there are never awkward trailing empty slots. */
+    grid-template-columns: repeat(4, 1fr);
     gap: 12px; margin-bottom: 2rem;
 }
 .role-card {
     background: var(--bg-card); border: 1px solid var(--border);
     border-radius: var(--radius-lg); padding: 1.25rem 1rem;
-    cursor: pointer; transition: all 0.2s ease;
+    cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
     text-align: center; position: relative;
+    /* Soft staggered "tile" entrance when the overlay opens. */
+    animation: roleTileIn 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 .role-card:hover {
     border-color: var(--accent); box-shadow: var(--shadow-md);
-    transform: translateY(-2px);
+    transform: translateY(-3px);
+    background: rgba(22,163,74,0.06);
 }
-.role-card:active { transform: translateY(0); }
+.role-card:hover .role-card-icon { transform: scale(1.08); }
+.role-card:active { transform: translateY(-1px); }
+.role-card-icon { transition: transform 0.18s ease; }
+@keyframes roleTileIn {
+    from { opacity: 0; transform: translateY(12px) scale(0.96); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+.role-card:nth-child(1)  { animation-delay: 0.02s; }
+.role-card:nth-child(2)  { animation-delay: 0.06s; }
+.role-card:nth-child(3)  { animation-delay: 0.10s; }
+.role-card:nth-child(4)  { animation-delay: 0.14s; }
+.role-card:nth-child(5)  { animation-delay: 0.18s; }
+.role-card:nth-child(6)  { animation-delay: 0.22s; }
+.role-card:nth-child(7)  { animation-delay: 0.26s; }
+.role-card:nth-child(8)  { animation-delay: 0.30s; }
+.role-card:nth-child(9)  { animation-delay: 0.34s; }
+.role-card:nth-child(10) { animation-delay: 0.38s; }
+.role-card:nth-child(11) { animation-delay: 0.42s; }
+.role-card:nth-child(12) { animation-delay: 0.46s; }
+@media (prefers-reduced-motion: reduce) {
+    .role-card { animation: none; }
+    .role-card:hover { transform: none; }
+    .role-card:hover .role-card-icon { transform: none; }
+}
+
+/* ══ Classy motion ═══════════════════════════════════════════════════════
+   Gentle entrance + scroll-reveal. Progressive enhancement: elements are
+   only hidden once JS adds .reveal-on to <html>, a failsafe reveals any
+   stragglers, and everything is disabled for prefers-reduced-motion — so
+   content can never end up permanently hidden. */
+.hero-headline { animation: heroRise 0.7s cubic-bezier(.22,1,.36,1) both; }
+.hero-sub      { animation: heroRise 0.7s cubic-bezier(.22,1,.36,1) 0.08s both; }
+.hero-data     { animation: heroRise 0.8s cubic-bezier(.22,1,.36,1) 0.10s both; }
+.hero-live-alert  { animation: heroRise 0.7s cubic-bezier(.22,1,.36,1) 0.16s both; }
+.hero-live-toggle { animation: heroRise 0.7s cubic-bezier(.22,1,.36,1) 0.20s both; }
+@keyframes heroRise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+
+html.reveal-on [data-reveal] {
+    opacity: 0; transform: translateY(22px);
+    transition: opacity 0.7s ease, transform 0.75s cubic-bezier(.22,1,.36,1);
+    will-change: opacity, transform;
+}
+html.reveal-on [data-reveal].is-in { opacity: 1; transform: none; }
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-headline, .hero-sub, .hero-data, .hero-live-alert, .hero-live-toggle { animation: none; }
+    html.reveal-on [data-reveal] { opacity: 1 !important; transform: none !important; transition: none !important; }
+}
 .role-card-icon {
     font-size: 2rem; margin-bottom: 0.5rem; display: block;
     line-height: 1; color: var(--accent);
@@ -2200,6 +2252,11 @@ body.simple-language .section-intro [data-simple]::after {
 }
 .panel-action-box .action-btn:hover {
     background: var(--accent-hover);
+}
+
+/* Tablet: 3 columns (12 → 4 full rows), still no trailing gaps. */
+@media (max-width: 820px) {
+    .role-grid { grid-template-columns: repeat(3, 1fr); }
 }
 
 @media (max-width: 640px) {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260678';
+const CACHE_VERSION = 'janvayu-20260679';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Fixes the awkward role-selector gaps and adds a first, restrained layer of "classy" motion.

### Role grid — no more awkward empty slots
Twelve roles in a 5-column `auto-fill` grid rendered as **5 + 5 + 2**, leaving three empty slots. Pinned the columns to divisors of 12 — **4 (desktop) / 3 (tablet) / 2 (mobile)** — so every row is full at every breakpoint. Cards get a soft staggered "tile" entrance and a lift-on-hover.

### Classy motion (first pass)
- Hero headline, subhead and live-data card **fade up on load**.
- Dashboard cards **ease into view as they scroll in**.
- Implemented as **progressive enhancement**: the reveal is only armed once JS adds `.reveal-on` to `<html>`, a failsafe reveals any straggler after a moment, and everything is disabled under `prefers-reduced-motion` — so content can **never** end up hidden.

## Verification (Chromium)
- Role grid renders **4×3 with zero trailing gap**.
- After scrolling the whole dashboard + past the failsafe, **0 of the dashboard cards remain hidden**.
- Zero page errors; `node --check` clean; **12/12** calculator unit tests pass.

Deliberately restrained — real classiness is subtle motion, not flashy text effects. Easy to extend (panel-switch fades, link underlines, typography) or dial back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_