### PR TITLE
Panel-switch fade on navigation (v26.6.80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.80] - 2026-07-16
+
+### UX — panel-switch fade
+
+Navigating to a section now eases the new panel in (fade + slight rise) instead of a hard swap. Because `loadPanel` injects a fresh `.panel` node into `#panel-container` on every switch, the entrance is pure CSS — no JS — and it's disabled under `prefers-reduced-motion`.
+
+Verified in Chromium on both an inline-template panel and a lazy-loaded fragment panel: the panel is mid-fade right after the switch and settles to full opacity with its content intact; zero page errors.
+
 ## [v26.6.79] - 2026-07-16
 
 ### UX — role grid fills evenly + classy motion

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.79"
+version: "26.6.80"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260679-v79';
+const CACHE_NAME = 'ask-janvayu-20260680-v80';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.79",
+  "version": "26.6.80",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -1901,6 +1901,17 @@ html.reveal-on [data-reveal].is-in { opacity: 1; transform: none; }
     .hero-headline, .hero-sub, .hero-data, .hero-live-alert, .hero-live-toggle { animation: none; }
     html.reveal-on [data-reveal] { opacity: 1 !important; transform: none !important; transition: none !important; }
 }
+
+/* Panel-switch fade: each navigation injects a fresh .panel node into
+   #panel-container, so this entrance animation replays on every switch —
+   no JS needed. Disabled for reduced motion. */
+#panel-container .panel {
+    animation: panelFadeIn 0.34s cubic-bezier(.22,1,.36,1) both;
+}
+@keyframes panelFadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) {
+    #panel-container .panel { animation: none; }
+}
 .role-card-icon {
     font-size: 2rem; margin-bottom: 0.5rem; display: block;
     line-height: 1; color: var(--accent);

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260679';
+const CACHE_VERSION = 'janvayu-20260680';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Navigating to a section now eases the new panel in (fade + slight rise) instead of a hard swap — the next step in the "classy motion" pass.

Because `loadPanel` injects a fresh `.panel` node into `#panel-container` on every switch, the entrance is **pure CSS scoped to `#panel-container .panel`** — no JS change — and it's disabled under `prefers-reduced-motion`.

## Verification (Chromium)
Tested on both an inline-template panel (`health`) and a lazy-loaded fragment panel (`resources`):
- Panel is **mid-fade** right after the switch (opacity 0.5 / 0) …
- … and **settles to full opacity with its content intact**.
- Zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_