### PR TITLE
Colour discipline on the dashboard (v26.6.82) — conference pass 2/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.82] - 2026-07-16
+
+### Design — colour discipline on the dashboard (conference-ready pass 2/4)
+
+The dashboard's hero stats used four competing hues (red deaths, amber cost, purple annual-PM2.5, band-coloured worst-city), which read as decorative rather than meaningful. Tightened to a system:
+
+- **Deaths** stay red — the deliberate alarm, and JanVayu's thesis.
+- **Annual cost** and **Delhi annual PM2.5** are now neutral ink (they were arbitrarily amber and purple).
+- The **live worst-city** figure keeps its AQI-band colour (that one is genuinely a real-time severity signal).
+
+So colour on the primary surface now means something: alarm-red for the human toll, band-colour for live severity, ink for everything else. Everything else on the dashboard (AQI bands, GRAP strip, severity badges) was already semantic and is untouched. The deeper content panels still use per-category colour-coding — a larger, separate sweep.
+
 ## [v26.6.81] - 2026-07-16
 
 ### Design — Fraunces headline typeface (conference-ready pass 1/4)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.81"
+version: "26.6.82"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260681-v81';
+const CACHE_NAME = 'ask-janvayu-20260682-v82';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -907,12 +907,12 @@
                             <div class="hero-stat-note">State of Global Air 2025</div>
                         </div>
                         <div class="hero-stat">
-                            <div class="hero-stat-value warning" data-stat="economic_cost">$260B</div>
+                            <div class="hero-stat-value" data-stat="economic_cost">$260B</div>
                             <div class="hero-stat-label">Annual Cost (India)</div>
                             <div class="hero-stat-note" data-stat="economic_pct_gdp">9.5% GDP (Lancet)</div>
                         </div>
                         <div class="hero-stat">
-                            <div class="hero-stat-value" style="color: var(--purple);" data-stat="delhi_annual_pm25">96</div>
+                            <div class="hero-stat-value" data-stat="delhi_annual_pm25">96</div>
                             <div class="hero-stat-label">Delhi Annual PM2.5</div>
                             <div class="hero-stat-note">19x WHO (2025 avg)</div>
                         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.81",
+  "version": "26.6.82",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260681';
+const CACHE_VERSION = 'janvayu-20260682';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Step 2 of 4. The dashboard hero stats used **four competing hues** (red deaths, amber cost, purple annual-PM2.5, band worst-city) that read as decorative rather than meaningful — a classic "assembled, not designed" tell. Tightened to a system:

- **Deaths** stay red — the deliberate alarm and JanVayu's thesis.
- **Annual cost** and **Delhi annual PM2.5** → neutral ink (they were arbitrarily amber and purple).
- **Live worst-city** keeps its AQI-band colour — that one *is* a genuine real-time severity signal.

Now colour on the primary surface means something: alarm-red for the human toll, band-colour for live severity, ink for context. Everything else on the dashboard (AQI bands, GRAP strip, severity badges) was already semantic and is untouched.

## Scope note (honest)
The dashboard's *only* non-semantic colours were those two stats. The ~100 decorative per-category hues (pregnancy/children/elderly colour-coding, etc.) live in the **deep content panels** — a larger, lower-visibility sweep I've left out of this PR. Happy to do it as a follow-up if you want it before the conference; it's less demo-critical and riskier to touch en masse.

## Verification (Chromium)
Hero stat colours now compute as red / ink / ink / band; zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_