### PR TITLE
"How JanVayu works" system diagram (v26.6.83) — conference pass 3/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.83] - 2026-07-16
+
+### Design — "How JanVayu works" system diagram (conference-ready pass 3/4)
+
+Added a signature visual anchor to the dashboard: a three-stage flow that shows JanVayu as infrastructure, not a hobby project.
+
+- **Live data sources** (CPCB CAAQMS, WAQI, OpenAQ · Sensor.Community, NASA FIRMS, Open-Meteo · CAMS) → **JanVayu engine** (verify · compute · contextualize) → **Citizen tools** (live AQI, Ask JanVayu, forecast, fire tracker, RTI, alerts, open API).
+- Built as responsive, theme-aware HTML/CSS in JanVayu's own palette and Fraunces headline — the engine stage emphasised in green, connectors between stages, stacking vertically on mobile. Doubles as a slide for the talk.
+
+Verified in Chromium desktop + mobile: three stages, connectors, thirteen nodes; engine nodes vertically centred; zero page errors.
+
 ## [v26.6.82] - 2026-07-16
 
 ### Design — colour discipline on the dashboard (conference-ready pass 2/4)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.82"
+version: "26.6.83"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260682-v82';
+const CACHE_NAME = 'ask-janvayu-20260683-v83';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -970,6 +970,47 @@
                     </div>
                 </div>
 
+                <!-- How JanVayu works — system diagram -->
+                <section class="how-flow mt-3" aria-labelledby="how-flow-title">
+                    <div class="how-flow-head">
+                        <h2 id="how-flow-title" class="how-flow-title">How JanVayu works</h2>
+                        <p class="how-flow-sub">Independent monitoring, verified and turned into something people can act on &mdash; from raw sensors to accountability.</p>
+                    </div>
+                    <div class="how-flow-grid">
+                        <div class="how-stage">
+                            <div class="how-stage-label">Live data sources</div>
+                            <ul class="how-nodes">
+                                <li>CPCB CAAQMS <span>official government monitors</span></li>
+                                <li>WAQI <span>real-time AQI feed</span></li>
+                                <li>OpenAQ &middot; Sensor.Community <span>low-cost sensors</span></li>
+                                <li>NASA FIRMS <span>satellite farm-fire detections</span></li>
+                                <li>Open-Meteo &middot; CAMS <span>forecast &amp; weather</span></li>
+                            </ul>
+                        </div>
+                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
+                        <div class="how-stage how-engine">
+                            <div class="how-stage-label">JanVayu engine</div>
+                            <ul class="how-nodes">
+                                <li>Verify <span>freshness &amp; cross-source checks</span></li>
+                                <li>Compute <span>health &amp; exposure models</span></li>
+                                <li>Contextualize <span>AQI bands &middot; WHO limits &middot; NCAP</span></li>
+                            </ul>
+                        </div>
+                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
+                        <div class="how-stage">
+                            <div class="how-stage-label">Citizen tools</div>
+                            <ul class="how-nodes">
+                                <li>Live AQI <span>117 cities + ward atlas</span></li>
+                                <li>Ask JanVayu <span>AI air-quality assistant</span></li>
+                                <li>Forecast &middot; Farm-fire tracker</li>
+                                <li>RTI Assistant <span>government accountability</span></li>
+                                <li>Alerts &middot; Open Data API</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <p class="how-flow-foot">Every figure sourced and open &middot; no ads &middot; no login &middot; free forever.</p>
+                </section>
+
                 <!-- City Rankings + Charts -->
                 <div class="grid-3 mt-3">
                     <div class="card">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.82",
+  "version": "26.6.83",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -1920,6 +1920,63 @@ html.reveal-on [data-reveal].is-in { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) {
     #panel-container .panel { animation: none; }
 }
+
+/* ══ "How JanVayu works" system diagram ══════════════════════════════════ */
+.how-flow {
+    padding: 1.75rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+}
+.how-flow-head { text-align: center; margin-bottom: 1.5rem; }
+.how-flow-title {
+    font-family: var(--serif); font-weight: 700;
+    font-size: clamp(1.3rem, 3vw, 1.7rem);
+    letter-spacing: -0.01em; margin: 0 0 0.4rem; color: var(--ink);
+}
+.how-flow-sub {
+    color: var(--text-2); font-size: 0.92rem; line-height: 1.5;
+    max-width: 44rem; margin: 0 auto; text-wrap: balance;
+}
+.how-flow-grid { display: flex; align-items: stretch; gap: 0.75rem; }
+.how-stage {
+    flex: 1; min-width: 0;
+    display: flex; flex-direction: column;
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: 12px; padding: 1rem 0.85rem;
+}
+.how-engine {
+    border-color: var(--accent);
+    background: rgba(22,163,74,0.05);
+}
+.how-stage-label {
+    font-size: 0.66rem; font-weight: 700; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--accent);
+    text-align: center; margin-bottom: 0.8rem;
+}
+.how-nodes { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; flex: 1; justify-content: center; }
+.how-nodes li {
+    font-size: 0.82rem; font-weight: 600; color: var(--ink);
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 8px; padding: 0.5rem 0.65rem; line-height: 1.3;
+}
+.how-engine .how-nodes li { border-color: rgba(22,163,74,0.28); }
+.how-nodes li span {
+    display: block; font-weight: 400; font-size: 0.7rem;
+    color: var(--text-3); margin-top: 2px;
+}
+.how-arrow {
+    align-self: center; flex: none;
+    color: var(--accent); font-size: 1.5rem; font-weight: 700; line-height: 1;
+}
+.how-flow-foot {
+    text-align: center; color: var(--text-3);
+    font-size: 0.78rem; margin: 1.25rem 0 0; letter-spacing: 0.01em;
+}
+@media (max-width: 720px) {
+    .how-flow-grid { flex-direction: column; }
+    .how-arrow { transform: rotate(90deg); margin: 0.1rem 0; }
+}
 .role-card-icon {
     font-size: 2rem; margin-bottom: 0.5rem; display: block;
     line-height: 1; color: var(--accent);

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260682';
+const CACHE_VERSION = 'janvayu-20260683';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Step 3 of 4 — the missing **visual anchor**. A "How JanVayu works" system diagram on the dashboard that frames the platform as *infrastructure*, not a hobby project (the thing that most read as "enthusiast").

Three-stage flow:
- **Live data sources** — CPCB CAAQMS, WAQI, OpenAQ · Sensor.Community, NASA FIRMS, Open-Meteo · CAMS
- **→ JanVayu engine** — Verify (freshness & cross-source) · Compute (health & exposure models) · Contextualize (AQI bands · WHO limits · NCAP)
- **→ Citizen tools** — Live AQI (117 cities + wards), Ask JanVayu, forecast, fire tracker, RTI Assistant, alerts, Open Data API

Built as responsive, theme-aware HTML/CSS in JanVayu's own palette with the new Fraunces headline — engine stage emphasised in green, connectors between stages, stacks vertically on mobile. **Doubles as a slide for the talk.**

## Verification (Chromium)
- Desktop: three stages, two connectors, thirteen nodes; engine nodes vertically centred.
- Mobile: stacks vertically with the connectors rotated downward.
- Zero page errors.

## Pass status
1/4 typography ✅ · 2/4 colour ✅ · **3/4 diagram (this)** · 4/4 spacing & detail polish next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_