### PR TITLE
Conference polish: full colour discipline + hero gap fix + diagram moved up (v26.6.84–85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.84] - 2026-07-16
+
+### Design — colour discipline across all content panels (conference-ready)
+
+Extended the dashboard colour discipline to the ~20 interior panels, which used a different saturated hue per category (pregnancy pink, children amber, mental-health purple, etc.) — the clearest "assembled by an enthusiast" tell.
+
+- **82** decorative heading colours (blue/amber/purple/pink/sky) neutralised to ink; brand-green and semantic-red headings kept.
+- **248** hardcoded-hex card rails unified to the brand accent (green) instead of cycling hues.
+- **45** blue/sky/pink text colours (never AQI-semantic) neutralised to ink; **6** dashboard "Did You Know" stat numbers flattened to ink.
+- AQI-band amber/purple on actual readings preserved — colour now means something (AQI severity), not decoration.
+
+Verified in Chromium across dashboard + interior panels: de-rainbowed, headings ink, rails uniform green, zero page errors; 12/12 unit tests pass.
+
 ## [v26.6.83] - 2026-07-16
 
 ### Design — "How JanVayu works" system diagram (conference-ready pass 3/4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.85] - 2026-07-16
+
+### Design — hero gap fix, diagram moved up, larger card text
+
+- **Fixed the large gap under the nav.** The hero grid was `align-items: center`, which vertically centred the short headline column against the tall live-data column and pushed the headline ~150px down. Switched to `align-items: start` so the Fraunces headline sits directly under the nav (gap now just the intended 56px hero padding).
+- **Moved the "How JanVayu works" diagram up** to immediately after the hero, so the platform's shape reads before the detailed cards.
+- Bumped `.card-body` text 0.9rem → 0.95rem for readability (matters when projected).
+
 ## [v26.6.84] - 2026-07-16
 
 ### Design — colour discipline across all content panels (conference-ready)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.83"
+version: "26.6.84"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.84"
+version: "26.6.85"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260684-v84';
+const CACHE_NAME = 'ask-janvayu-20260685-v85';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260683-v83';
+const CACHE_NAME = 'ask-janvayu-20260684-v84';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -928,6 +928,47 @@
                 </div>
 
                 <!-- Personal Impact (cigarette equivalence, disease risk, solutions) -->
+                <!-- How JanVayu works — system diagram -->
+                <section class="how-flow mt-3" aria-labelledby="how-flow-title">
+                    <div class="how-flow-head">
+                        <h2 id="how-flow-title" class="how-flow-title">How JanVayu works</h2>
+                        <p class="how-flow-sub">Independent monitoring, verified and turned into something people can act on &mdash; from raw sensors to accountability.</p>
+                    </div>
+                    <div class="how-flow-grid">
+                        <div class="how-stage">
+                            <div class="how-stage-label">Live data sources</div>
+                            <ul class="how-nodes">
+                                <li>CPCB CAAQMS <span>official government monitors</span></li>
+                                <li>WAQI <span>real-time AQI feed</span></li>
+                                <li>OpenAQ &middot; Sensor.Community <span>low-cost sensors</span></li>
+                                <li>NASA FIRMS <span>satellite farm-fire detections</span></li>
+                                <li>Open-Meteo &middot; CAMS <span>forecast &amp; weather</span></li>
+                            </ul>
+                        </div>
+                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
+                        <div class="how-stage how-engine">
+                            <div class="how-stage-label">JanVayu engine</div>
+                            <ul class="how-nodes">
+                                <li>Verify <span>freshness &amp; cross-source checks</span></li>
+                                <li>Compute <span>health &amp; exposure models</span></li>
+                                <li>Contextualize <span>AQI bands &middot; WHO limits &middot; NCAP</span></li>
+                            </ul>
+                        </div>
+                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
+                        <div class="how-stage">
+                            <div class="how-stage-label">Citizen tools</div>
+                            <ul class="how-nodes">
+                                <li>Live AQI <span>117 cities + ward atlas</span></li>
+                                <li>Ask JanVayu <span>AI air-quality assistant</span></li>
+                                <li>Forecast &middot; Farm-fire tracker</li>
+                                <li>RTI Assistant <span>government accountability</span></li>
+                                <li>Alerts &middot; Open Data API</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <p class="how-flow-foot">Every figure sourced and open &middot; no ads &middot; no login &middot; free forever.</p>
+                </section>
+
                 <div class="grid-3 mt-3" id="personal-impact-row">
                     <div class="card">
                         <div class="card-header">
@@ -970,46 +1011,6 @@
                     </div>
                 </div>
 
-                <!-- How JanVayu works — system diagram -->
-                <section class="how-flow mt-3" aria-labelledby="how-flow-title">
-                    <div class="how-flow-head">
-                        <h2 id="how-flow-title" class="how-flow-title">How JanVayu works</h2>
-                        <p class="how-flow-sub">Independent monitoring, verified and turned into something people can act on &mdash; from raw sensors to accountability.</p>
-                    </div>
-                    <div class="how-flow-grid">
-                        <div class="how-stage">
-                            <div class="how-stage-label">Live data sources</div>
-                            <ul class="how-nodes">
-                                <li>CPCB CAAQMS <span>official government monitors</span></li>
-                                <li>WAQI <span>real-time AQI feed</span></li>
-                                <li>OpenAQ &middot; Sensor.Community <span>low-cost sensors</span></li>
-                                <li>NASA FIRMS <span>satellite farm-fire detections</span></li>
-                                <li>Open-Meteo &middot; CAMS <span>forecast &amp; weather</span></li>
-                            </ul>
-                        </div>
-                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
-                        <div class="how-stage how-engine">
-                            <div class="how-stage-label">JanVayu engine</div>
-                            <ul class="how-nodes">
-                                <li>Verify <span>freshness &amp; cross-source checks</span></li>
-                                <li>Compute <span>health &amp; exposure models</span></li>
-                                <li>Contextualize <span>AQI bands &middot; WHO limits &middot; NCAP</span></li>
-                            </ul>
-                        </div>
-                        <div class="how-arrow" aria-hidden="true">&rarr;</div>
-                        <div class="how-stage">
-                            <div class="how-stage-label">Citizen tools</div>
-                            <ul class="how-nodes">
-                                <li>Live AQI <span>117 cities + ward atlas</span></li>
-                                <li>Ask JanVayu <span>AI air-quality assistant</span></li>
-                                <li>Forecast &middot; Farm-fire tracker</li>
-                                <li>RTI Assistant <span>government accountability</span></li>
-                                <li>Alerts &middot; Open Data API</li>
-                            </ul>
-                        </div>
-                    </div>
-                    <p class="how-flow-foot">Every figure sourced and open &middot; no ads &middot; no login &middot; free forever.</p>
-                </section>
 
                 <!-- City Rankings + Charts -->
                 <div class="grid-3 mt-3">

--- a/index.html
+++ b/index.html
@@ -1137,7 +1137,7 @@
                         <div><h4 data-i18n="ql_economic_title">Economic Impact</h4><p data-i18n="ql_economic_desc">Productivity loss</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('aqi-explainer')">
-                        <div class="quick-link-icon" style="background: #EFF6FF; color: var(--blue);"><span class="si si-info" style="width:20px;height:20px;"></span></div>
+                        <div class="quick-link-icon" style="background: #EFF6FF; color: var(--ink);"><span class="si si-info" style="width:20px;height:20px;"></span></div>
                         <div><h4>What is AQI?</h4><p>The number explained — all 6 pollutants, two scales, what they hide</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('source-selector')">
@@ -1165,7 +1165,7 @@
                 </div>
                 <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('go-outside')">
-                        <div class="quick-link-icon" style="background: #EFF6FF; color: var(--blue);"><span class="si si-flare" style="width:20px;height:20px;"></span></div>
+                        <div class="quick-link-icon" style="background: #EFF6FF; color: var(--ink);"><span class="si si-flare" style="width:20px;height:20px;"></span></div>
                         <div><h4 data-i18n="ql_outside_t">Go Outside?</h4><p data-i18n="ql_outside_d">Real-time advice</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('social-feed')">
@@ -1220,44 +1220,44 @@
                 <span style="font-size: 0.7rem; color: var(--text-3);">Six sourced India-specific facts &middot; figures are the most recent published values from each source (Lancet Countdown 2025, IQAir 2025, AQLI 2025, CSE 2026, Jaganathan et al. 2024)</span>
             </div>
             <div class="grid-3" style="gap: 12px;">
-                <div class="card" style="border-left: 3px solid #1B6B4A;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--green-700); line-height: 1;" data-stat="deaths_annual">1.72M</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;" data-stat="deaths_annual">1.72M</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_deaths_title">Indian PM2.5 deaths a year</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;" data-stat="global_share_deaths">Lancet Countdown 2025. Up from 1.5M last cycle &mdash; ~70% of the global PM2.5 mortality burden is India.</div>
                     </div>
                 </div>
-                <div class="card" style="border-left: 3px solid #B91C1C;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--red); line-height: 1;" data-stat="most_polluted_city">112.5 µg/m&sup3;</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;" data-stat="most_polluted_city">112.5 µg/m&sup3;</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_loni_title">Loni, India &mdash; the world&rsquo;s most polluted city</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;">IQAir World Air Quality Report 2025 (covering 2024 data; the most recent annual). Loni in Ghaziabad district, UP, dethroned Byrnihat. The annual average is 22&times; the WHO guideline.</div>
                     </div>
                 </div>
-                <div class="card" style="border-left: 3px solid #2563EB;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--blue); line-height: 1;" data-stat="life_expectancy_loss">3.5 yrs</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;" data-stat="life_expectancy_loss">3.5 yrs</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_le_title">Life expectancy lost on average</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;">AQLI 2025 (UChicago EPIC). Indo-Gangetic Plain residents lose 7-8 years &mdash; the highest in any region globally.</div>
                     </div>
                 </div>
-                <div class="card" style="border-left: 3px solid #F59E0B;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--amber); line-height: 1;">64%</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;">64%</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_ncap_title">of NCAP funds spent on dust suppression</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;">CSE 2026 NCAP review. Mostly mechanical sweeping &amp; water-spraying &mdash; not the combustion sources that drive most PM2.5.</div>
                     </div>
                 </div>
-                <div class="card" style="border-left: 3px solid #7C3AED;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--purple); line-height: 1;">8&times;</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;">8&times;</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_naaqs_title">India&rsquo;s NAAQS vs WHO guideline</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;">India NAAQS = 40 µg/m&sup3; annual PM2.5; WHO 2021 guideline = 5. Indian standard last revised in 2009.</div>
                     </div>
                 </div>
-                <div class="card" style="border-left: 3px solid #16A34A;">
+                <div class="card" style="border-left: 3px solid var(--accent);">
                     <div class="card-body" style="font-size: 0.85rem; line-height: 1.5;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--green-600); line-height: 1;">8.6%</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--ink); line-height: 1;">8.6%</div>
                         <div style="font-weight: 600; margin: 4px 0 4px;" data-i18n="dyk_doseresp_title">Mortality rise per +10 µg/m&sup3; PM2.5</div>
                         <div style="color: var(--text-2); font-size: 0.8rem;">Jaganathan et al. 2024, <em>Lancet Planetary Health</em>. India&rsquo;s first nationwide causal estimate &mdash; a difference-in-differences design across 655 districts.</div>
                     </div>
@@ -1715,8 +1715,8 @@
                 <div class="card-header"><span class="card-title"> Vulnerable Groups — Special Risks</span></div>
                 <div class="card-body">
                     <div class="grid-3">
-                        <div class="info-box" style="border-left: 3px solid #EC4899;">
-                            <h4 style="color: var(--pink);"> Pregnancy & Fetal Development</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Pregnancy & Fetal Development</h4>
                             <p data-simple="Pollution passes from mother to unborn baby through the placenta. It can cause low birth weight, premature birth, and even affect the baby&rsquo;s brain development before they are born.">Air pollution crosses the placenta. Effects on unborn children:</p>
                             <ul>
                                 <li><strong>Low birth weight:</strong> 15-20% higher risk at high PM2.5</li>
@@ -1729,8 +1729,8 @@
                             <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Sources: Lancet Planetary Health 2022, ICMR studies</div>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="color: var(--amber);"> Children (0-14 years)</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Children (0-14 years)</h4>
                             <p>Children are not small adults — they're uniquely vulnerable:</p>
                             <ul>
                                 <li><strong>Breathe 50% more air</strong> per kg body weight</li>
@@ -1742,8 +1742,8 @@
                             <p style="margin-top: 0.5rem; font-size: 0.875rem;"><strong>Impact:</strong> Delhi children have 40% reduced lung capacity vs. clean air cities (CPCB study).</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                            <h4 style="color: var(--purple);"> Mental Health Impact</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Mental Health Impact</h4>
                             <p data-simple="Pollution does not just hurt your lungs &mdash; it harms your brain too. It increases depression, anxiety, and memory loss. In children, it can lower IQ and cause behavior problems.">Air pollution affects the brain, not just lungs:</p>
                             <ul>
                                 <li><strong>Depression:</strong> 10% higher risk at high PM2.5</li>
@@ -1758,7 +1758,7 @@
                     </div>
 
                     <div class="grid-2 mt-2">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--red);"> Elderly (65+)</h4>
                             <ul>
                                 <li>Weakened immune response</li>
@@ -1767,8 +1767,8 @@
                                 <li>Higher hospitalization rates</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);"> Outdoor Workers</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Outdoor Workers</h4>
                             <ul>
                                 <li>Traffic police, delivery workers, construction</li>
                                 <li>8-12 hours daily exposure</li>
@@ -1809,8 +1809,8 @@
                             </div>
 
                             <!-- LANCET 10-CITY STUDY -->
-                            <div class="info-box" style="border-left: 4px solid #2563EB; background: rgba(37,99,235,0.03);">
-                                <h4 style="color: var(--blue); margin-bottom: 0.5rem;"> Lancet 10-City Causal Study (Dec 2024)</h4>
+                            <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(37,99,235,0.03);">
+                                <h4 style="margin-bottom: 0.5rem"> Lancet 10-City Causal Study (Dec 2024)</h4>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>33,000 deaths</strong> directly attributable to PM2.5 across 10 Indian cities</li>
                                     <li><strong>7.2% of daily deaths</strong> in Delhi linked to PM2.5 above WHO guideline</li>
@@ -1822,8 +1822,8 @@
 
                         <div>
                             <!-- HEAT-POLLUTION INTERACTION -->
-                            <div class="info-box mb-2" style="border-left: 4px solid #F59E0B; background: rgba(245,158,11,0.03);">
-                                <h4 style="color: var(--amber); margin-bottom: 0.5rem;"> Heat-Pollution Interaction (Karolinska, 2024)</h4>
+                            <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
+                                <h4 style="margin-bottom: 0.5rem"> Heat-Pollution Interaction (Karolinska, 2024)</h4>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>4.6% mortality increase</strong> on days with both high heat AND high PM2.5</li>
                                     <li><strong>Synergistic effect:</strong> Combined risk > sum of individual risks</li>
@@ -1833,8 +1833,8 @@
                             </div>
 
                             <!-- DEMENTIA & COGNITIVE -->
-                            <div class="info-box mb-2" style="border-left: 4px solid #7C3AED; background: rgba(124,58,237,0.03);">
-                                <h4 style="color: var(--purple); margin-bottom: 0.5rem;"> PM2.5 and Dementia (SoGA 2025 — New Finding)</h4>
+                            <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
+                                <h4 style="margin-bottom: 0.5rem"> PM2.5 and Dementia (SoGA 2025 — New Finding)</h4>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>54,000 dementia deaths</strong> attributed to PM2.5 in India (first-ever estimate)</li>
                                     <li><strong>Mechanism:</strong> Ultrafine particles cross blood-brain barrier, cause neuroinflammation</li>
@@ -1844,7 +1844,7 @@
                             </div>
 
                             <!-- SOURCE APPORTIONMENT -->
-                            <div class="info-box" style="border-left: 4px solid #16803C; background: rgba(22,128,60,0.03);">
+                            <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(22,128,60,0.03);">
                                 <h4 style="color: var(--green-700); margin-bottom: 0.5rem;"> Source Apportionment Update (EGUsphere, 2025)</h4>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>Industrial emissions:</strong> Now largest domestic source at 18% (previously underestimated)</li>
@@ -1870,8 +1870,8 @@
 
                     <div class="grid-2">
                         <!-- HOUSEHOLD AIR POLLUTION -->
-                        <div class="info-box" style="border-left: 4px solid #EC4899; background: rgba(236,72,153,0.03);">
-                            <h4 style="color: var(--pink); margin-bottom: 0.75rem;"> Household Air Pollution — The Invisible Epidemic</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(236,72,153,0.03);">
+                            <h4 style="margin-bottom: 0.75rem"> Household Air Pollution — The Invisible Epidemic</h4>
                             <p style="font-size: 0.875rem; margin-bottom: 0.75rem;">
                                 <strong>481,700 deaths/year in India</strong> from household air pollution (HAP) — nearly 30% of India's air pollution deaths. Yet NCAP focuses almost exclusively on ambient air.
                             </p>
@@ -1889,8 +1889,8 @@
                         </div>
 
                         <!-- OCCUPATIONAL EXPOSURE -->
-                        <div class="info-box" style="border-left: 4px solid #F59E0B; background: rgba(245,158,11,0.03);">
-                            <h4 style="color: var(--amber); margin-bottom: 0.75rem;"> Occupational Exposure — Unprotected Workers</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
+                            <h4 style="margin-bottom: 0.75rem"> Occupational Exposure — Unprotected Workers</h4>
                             <p style="font-size: 0.875rem; margin-bottom: 0.75rem;">
                                 <strong>93% of India's workforce is informal</strong> — with no occupational health standards for ambient air exposure. The formal sector gets WFH; workers breathe poison.
                             </p>
@@ -1911,8 +1911,8 @@
 
                     <div class="grid-2 mt-2">
                         <!-- SPATIAL INJUSTICE -->
-                        <div class="info-box" style="border-left: 4px solid #7C3AED; background: rgba(124,58,237,0.03);">
-                            <h4 style="color: var(--purple); margin-bottom: 0.75rem;"> Spatial Injustice — Where You Live Matters</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
+                            <h4 style="margin-bottom: 0.75rem"> Spatial Injustice — Where You Live Matters</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Industrial proximity:</strong> Low-income housing systematically located near factories, refineries, power plants</li>
                                 <li><strong>Highway adjacency:</strong> Slums built along arterial roads; PM2.5 50% higher within 100m of highways</li>
@@ -1926,8 +1926,8 @@
                         </div>
 
                         <!-- CASTE & CLASS -->
-                        <div class="info-box" style="border-left: 4px solid #0EA5E9; background: rgba(14,165,233,0.03);">
-                            <h4 style="color: var(--sky); margin-bottom: 0.75rem;"> Caste, Class & Environmental Racism</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(14,165,233,0.03);">
+                            <h4 style="margin-bottom: 0.75rem"> Caste, Class & Environmental Racism</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Manual scavenging:</strong> Still practiced despite ban; sewer deaths from toxic gases; predominantly Dalit</li>
                                 <li><strong>Sanitation workers:</strong> Burn waste, clear drains; no protective gear; municipality neglect</li>
@@ -1943,7 +1943,7 @@
 
                     <div class="grid-2 mt-2">
                         <!-- ADAPTATION INEQUALITY -->
-                        <div class="info-box" style="border-left: 4px solid #16803C; background: rgba(22,128,60,0.03);">
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(22,128,60,0.03);">
                             <h4 style="color: var(--green-700); margin-bottom: 0.75rem;"> Adaptation Inequality — Protection is a Privilege</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Air purifiers:</strong> ₹10,000-50,000 + electricity cost; inaccessible to 70%+ households</li>
@@ -1956,7 +1956,7 @@
                         </div>
 
                         <!-- POLICY CRITIQUE -->
-                        <div class="info-box" style="border-left: 4px solid #EF4444; background: rgba(239,68,68,0.03);">
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.03);">
                             <h4 style="color: var(--red); margin-bottom: 0.75rem;"> Policy Blind Spots — Who's Not at the Table?</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>NCAP:</strong> Focuses on ambient PM10/PM2.5; HAP not integrated; no equity metrics</li>
@@ -1992,7 +1992,7 @@
                                 <div style="font-size: 0.8125rem; color: var(--text-3);">No air quality protections</div>
                             </div>
                             <div style="text-align: center; padding: 0.75rem; background: var(--bg-card); border-radius: 8px;">
-                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--sky);">3-5×</div>
+                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--ink);">3-5×</div>
                                 <div style="font-size: 0.8125rem; color: var(--text-2);">Higher exposure</div>
                                 <div style="font-size: 0.8125rem; color: var(--text-3);">Street vendors vs residents</div>
                             </div>
@@ -2108,7 +2108,7 @@
 <template id="tmpl-policy">
 
             <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-clipboard-check" style="color: var(--blue); margin-right: 0.4rem;"></span>Policy Effectiveness Tracker</h2>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-clipboard-check" style="color: var(--ink); margin-right: 0.4rem;"></span>Policy Effectiveness Tracker</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="Which government actions actually cleaned the air, and which ones were a waste of money? Here&rsquo;s the evidence.">Evaluating major air quality interventions by actual PM2.5 impact, evidence quality, and cost-effectiveness.</p>
             </div>
 
@@ -2161,7 +2161,7 @@
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">Evidence-based recommendations for more effective air quality management. These are citizen suggestions for policymakers.</p>
                     
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--red);"> 72-Hour Persistence Rule for GRAP</h4>
                             <p><strong>Problem:</strong> GRAP stages are currently relaxed as soon as AQI dips below threshold, even briefly. This "yo-yo" effect leads to:</p>
                             <ul>
@@ -2174,8 +2174,8 @@
                             <p style="font-size: 0.875rem; color: var(--text-3); margin-top: 0.5rem;"><em>Rationale: Weather patterns typically cycle over 3-5 days. 72-hour persistence ensures improvement is sustained, not a temporary dip.</em></p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="color: var(--amber);"> Anticipatory Activation</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Anticipatory Activation</h4>
                             <p><strong>Problem:</strong> GRAP is reactive — activated only after AQI crosses threshold. By then, damage is done.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2186,8 +2186,8 @@
                             <p style="font-size: 0.875rem; color: var(--text-3); margin-top: 0.5rem;"><em>Example: If weather + fire data predicts AQI 400+ in 48 hours, activate Stage III immediately.</em></p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);"> Automatic School Closures</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Automatic School Closures</h4>
                             <p><strong>Problem:</strong> Schools remain open even during AQI 400-500. Children are most vulnerable.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2199,7 +2199,7 @@
                             <p style="font-size: 0.875rem; color: var(--text-3); margin-top: 0.5rem;"><em>Legal basis: Right to Life (Article 21) includes right to clean air.</em></p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-700);"> Stubble — Fix the Economics</h4>
                             <p><strong>Problem:</strong> Burning is rational for farmers. Bans without alternatives don't work.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
@@ -2212,8 +2212,8 @@
                             <p style="font-size: 0.875rem; color: var(--text-3); margin-top: 0.5rem;"><em>Evidence: Punjab fires down 50%+ in districts with effective cash transfer programs.</em></p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                            <h4 style="color: var(--purple);"> Year-Round Industrial Standards</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Year-Round Industrial Standards</h4>
                             <p><strong>Problem:</strong> Industrial restrictions only during GRAP. Pollution is year-round problem.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2224,8 +2224,8 @@
                             </ul>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #EC4899;">
-                            <h4 style="color: var(--pink);"> Congestion Pricing (Not Odd-Even)</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Congestion Pricing (Not Odd-Even)</h4>
                             <p><strong>Problem:</strong> Odd-even has minimal impact (2-4% reduction) with high compliance cost.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2262,7 +2262,7 @@
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">Other cities faced similar crises and fixed them. Delhi can too.</p>
                     
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4> Beijing, China</h4>
                             <p><strong>Problem:</strong> 2013 "Airpocalypse" — PM2.5 over 500 for weeks. Called "unlivable."</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
@@ -2276,7 +2276,7 @@
                             <p style="margin-top: 0.5rem; color: var(--green-600);"><strong>Result:</strong> PM2.5 down 50% in 6 years (2013-2019)</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4> London, UK</h4>
                             <p><strong>Problem:</strong> 1952 Great Smog killed 12,000. Chronic pollution through 1990s.</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
@@ -2290,7 +2290,7 @@
                             <p style="margin-top: 0.5rem; color: var(--green-600);"><strong>Result:</strong> NO2 down 44% since 2016. Congestion down 15%.</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4> Los Angeles, USA</h4>
                             <p><strong>Problem:</strong> 1970s smog so bad children couldn't play outside. "Smog capital."</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
@@ -2304,7 +2304,7 @@
                             <p style="margin-top: 0.5rem; color: var(--green-600);"><strong>Result:</strong> Ozone down 70%, PM2.5 down 50% since 1980.</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4> Surat, India</h4>
                             <p><strong>Problem:</strong> 1994 plague outbreak linked to poor sanitation and air quality.</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
@@ -2333,7 +2333,7 @@
 <template id="tmpl-compare">
 
             <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-globe" style="color: var(--blue); margin-right: 0.4rem;"></span>Live City Comparison</h2>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-globe" style="color: var(--ink); margin-right: 0.4rem;"></span>Live City Comparison</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="See how dirty the air is in different Indian cities, and compare with cities in other countries. The numbers update every 10 minutes.">Compare air quality across Indian cities and with international benchmarks. Data refreshes every 10 minutes from WAQI API.</p>
             </div>
 
@@ -2561,17 +2561,17 @@
                 <div class="card-header"><span class="card-title"> What COVID Lockdown Proved</span></div>
                 <div class="card-body">
                     <div class="grid-3">
-                        <div class="stat-card" style="border-left: 3px solid #22C55E;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="color: var(--green-600);">-52%</div>
                             <div class="stat-label">PM2.5 Reduction</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Apr 2020 vs Apr 2019</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #3B82F6;">
-                            <div class="stat-value" style="color: var(--blue);">-60%</div>
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
+                            <div class="stat-value" style="color: var(--ink);">-60%</div>
                             <div class="stat-label">NO2 Reduction</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Vehicular pollution proxy</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #7C3AED;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="color: var(--purple);">Himalayas</div>
                             <div class="stat-label">Visible from Punjab</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">First time in 30+ years</div>
@@ -2595,25 +2595,25 @@
     </div>
 
     <!-- ═══ Section 4: How heat and air pollution are connected ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #6366F1;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">How heat and air pollution are connected</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1.25rem;" data-simple="Heat and dirty air are not two separate problems sitting side by side. They share the same chemistry, the same weather, the same causes and the same victims. Here is how they feed each other.">Heat and dirty air are not two separate problems sitting side by side &mdash; they share chemistry, weather, causes and victims. Here is how they feed each other, which is why this sits inside an air quality archive.</p>
 
             <div class="grid-2" style="gap:1rem; margin-bottom:1rem;">
-                <div class="info-box" style="background: rgba(234,88,12,0.06); border-left: 3px solid #EA580C;">
+                <div class="info-box" style="background: rgba(234,88,12,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:#C2410C;">Heat cooks ozone</h4>
                     <p data-simple="Ground-level ozone is not emitted by anything &mdash; it is formed when vehicle and factory gases react in sunlight, and that reaction runs faster as the air gets hotter. A 50&deg;C street makes more ozone than a 35&deg;C one from the same traffic.">Ground-level ozone isn&rsquo;t emitted &mdash; it&rsquo;s formed when NOx and VOCs react in sunlight, and the reaction runs <strong>faster as temperature rises</strong>. A 50&deg;C street makes more ozone than a 35&deg;C one from the same traffic.<sup>3,4</sup></p>
                 </div>
-                <div class="info-box" style="background: rgba(100,116,139,0.06); border-left: 3px solid #64748B;">
+                <div class="info-box" style="background: rgba(100,116,139,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:#475569;">Hot days are still days</h4>
                     <p data-simple="Heatwaves usually arrive with stagnant, high-pressure weather. The same still air that traps heat also fails to blow away smoke, dust and exhaust &mdash; so pollution piles up instead of dispersing.">Heatwaves ride in on stagnant high-pressure systems. The same still air that won&rsquo;t carry heat away <strong>won&rsquo;t disperse smoke, dust and exhaust either</strong> &mdash; so pollution accumulates.<sup>4</sup></p>
                 </div>
-                <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid #DC2626;">
+                <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:var(--red);">The cooling spiral</h4>
                     <p data-simple="Hotter colonies run more air conditioners. That pulls more electricity from a coal-heavy grid, releasing more PM2.5 and SO2 &mdash; and every AC dumps its waste heat onto the street, making it hotter still. Heat makes pollution makes heat.">Hotter colonies run more ACs &rarr; more power from a coal-heavy grid &rarr; more PM2.5 and SO2 &mdash; and every AC dumps waste heat onto the street. <strong>Heat makes pollution makes heat.</strong><sup>7</sup></p>
                 </div>
-                <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid #15803D;">
+                <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:var(--green-700);">One canopy, two jobs</h4>
                     <p data-simple="Tree cover lowers the temperature and also traps particle pollution on its leaves. Removing the green takes away both the shade and the filter at the same time.">Tree cover lowers temperature <em>and</em> deposits particulate matter on its leaves. Strip the green and you remove <strong>the shade and the filter at once</strong> &mdash; which is why &lsquo;trees cool more than concrete heats&rsquo; is also an air-quality statement.<sup>8</sup></p>
                 </div>
@@ -2626,7 +2626,7 @@
     </div>
 
     <!-- ═══ Section 1: The Delhi heat map ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #DC2626;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">The worked example: Delhi, neighbourhood by neighbourhood</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1.25rem;" data-simple="A thermal map of Delhi found surface temperatures ranging from 34&deg;C in green Mehrauli to 52&deg;C in built-up Mubarakpur on the same day. Greener areas were cooler; concrete-heavy areas were hotter.">A thermal survey of Delhi captured surface temperatures on a single day. The greenest pockets &mdash; the Ridge, Mehrauli, the wooded south &mdash; stayed near <strong>34&ndash;35&deg;C</strong>. The densest, most built-up colonies of the north and west crossed <strong>50&deg;C</strong>. Same sun, same hour &mdash; up to 18&deg;C apart.</p>
@@ -2648,16 +2648,16 @@
     </div>
 
     <!-- ═══ Section 2: The science ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #15803D;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">The science behind the divide</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="A study by Artha Global looked at 2,368 homes across all 70 assembly seats of Delhi. It found a clear, measurable link between how a neighbourhood is built and how hot it actually feels.">A white paper by <strong>Artha Global</strong> studied <strong>2,368 households</strong> across all <strong>70 assembly constituencies</strong> of Delhi and found a precise, measurable relationship between urban form and experienced heat.</p>
             <div class="grid-2" style="gap:1rem; margin-bottom:1rem;">
-                <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid #DC2626;">
+                <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:var(--red);">Concrete heats</h4>
                     <p data-simple="When the built-up area of a neighbourhood rises from 25% to 55%, the temperature people actually feel goes up by 0.6&deg;C.">Increasing built-up area from <strong>25% to 55%</strong> raises experienced temperature by <strong>+0.6&deg;C</strong>.</p>
                 </div>
-                <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid #15803D;">
+                <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid var(--accent);">
                     <h4 style="color:var(--green-700);">Trees cool</h4>
                     <p data-simple="When tree cover rises from just 3% to 11%, the heat people feel drops by a full 1&deg;C.">Increasing tree cover from just <strong>3% to 11%</strong> lowers experienced heat by <strong>&minus;1&deg;C</strong>.</p>
                 </div>
@@ -2670,7 +2670,7 @@
     </div>
 
     <!-- ═══ Section 3: Interactive estimator ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #EA580C;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">Estimate your neighbourhood&rsquo;s heat</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1.25rem;" data-simple="Move the sliders to match your area &mdash; how much is built-up (concrete) and how much has tree cover. See how much hotter or cooler it runs compared with a typical Delhi neighbourhood, using the white paper's own numbers.">Move the sliders to match your locality and see how much hotter or cooler it runs versus a typical Delhi neighbourhood &mdash; using the Artha Global coefficients (+0.02&deg;C per 1% built-up, &minus;0.125&deg;C per 1% tree cover).</p>
@@ -2694,7 +2694,7 @@
     </div>
 
     <!-- ═══ Section 5: Live evidence chart ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #EA580C;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header" style="display:flex; justify-content:space-between; align-items:center; gap:0.75rem; flex-wrap:wrap;">
             <span class="card-title">Live evidence: ozone tracks the day&rsquo;s heat</span>
             <div style="display:flex; align-items:center; gap:0.5rem;">
@@ -2711,7 +2711,7 @@
     </div>
 
     <!-- ═══ Section 6: Sources &amp; further reading ═══ -->
-    <div class="card mb-3" id="uh-sources" style="border-left: 4px solid #64748B;">
+    <div class="card mb-3" id="uh-sources" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">Sources &amp; further reading</span></div>
         <div class="card-body">
             <ol style="margin:0; padding-left:1.25rem; color:var(--text-2); font-size:0.8125rem; line-height:1.7;">
@@ -2754,7 +2754,7 @@
                         <span style="font-size: 0.65rem; color: var(--text-3);">External facilitator &middot; fee set by facilitator</span>
                     </div>
                     <div class="card-body" style="flex: 1; display: flex; flex-direction: column;">
-                        <div style="border-left: 3px solid #7C3AED; padding: 4px 0 4px 12px; margin-bottom: 14px;">
+                        <div style="border-left: 3px solid var(--accent); padding: 4px 0 4px 12px; margin-bottom: 14px;">
                             <strong style="display: block; font-size: 0.95rem;">Air Quality Jeopardy and more</strong>
                             <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Dr. Sarath Guttikunda of <a href="https://urbanemissions.info/" target="_blank" rel="noopener">UrbanEmissions.Info</a> runs interactive sessions on air quality science, sources, and policy &mdash; including a Jeopardy-format game tested with school and adult cohorts. Choose Class 9+ students, college, or adult learners. <strong>Pricing and scheduling are set directly by Dr. Guttikunda</strong>; we relay your request and he'll respond with terms. <em>If you'd like a self-paced taste of the format first, try the <a href="#games" onclick="showPanel('games'); return false;">Learning Games</a> panel.</em></p>
                         </div>
@@ -2830,7 +2830,7 @@
                         <span style="font-size: 0.65rem; color: var(--text-3);">JanVayu team</span>
                     </div>
                     <div class="card-body" style="flex: 1; display: flex; flex-direction: column;">
-                        <div style="border-left: 3px solid #1B6B4A; padding: 4px 0 4px 12px; margin-bottom: 14px;">
+                        <div style="border-left: 3px solid var(--accent); padding: 4px 0 4px 12px; margin-bottom: 14px;">
                             <strong style="display: block; font-size: 0.95rem;">Hands-on session</strong>
                             <p style="font-size: 0.85rem; color: var(--text-2); margin: 4px 0 0; line-height: 1.55;">Live walkthrough of the dashboard. Set AQI alerts for your city, file an RTI in one sitting, read the NCAP scorecard, and find the right purifier for your room. Free, online, English/Hindi. Up to 25 participants.</p>
                         </div>
@@ -3017,7 +3017,7 @@
         </div>
 
         <div class="card card-accent-blue">
-            <div class="card-header"><span class="card-title"><span class="si si-sm si-shield" style="color: var(--blue);"></span> Who Is Most Affected</span></div>
+            <div class="card-header"><span class="card-title"><span class="si si-sm si-shield" style="color: var(--ink);"></span> Who Is Most Affected</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;"><strong>Women using solid fuel:</strong> 60% of India's rural women still cook with firewood, dung, or crop residue. Average cooking time: 3-4 hours daily. Exposure levels during cooking sessions can exceed 500 µg/m³ PM2.5.</p>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;"><strong>Home-based workers:</strong> SEWA estimates 40% of non-agricultural women workers are home-based, in sewing, food production, or handicrafts. Aluminium sheet roofs trap heat 8-10°C above ambient, worsening pollutant concentration.</p>
@@ -3039,7 +3039,7 @@
     </div>
 
     <div class="card mt-2 card-accent-blue">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-shield" style="color: var(--blue);"></span> Choosing a low-cost indoor sensor</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-shield" style="color: var(--ink);"></span> Choosing a low-cost indoor sensor</span></div>
         <div class="card-body">
             <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="If you want to measure the air inside your own home, a cheap sensor can help &mdash; but only some are accurate. Here is what to look for so you don&rsquo;t waste money on a gadget that guesses.">Cheap PM sensors put indoor monitoring within reach &mdash; but accuracy varies widely. A 2026 IIT (ISM) Dhanbad evaluation benchmarked affordable PM2.5/PM10 sensors under Indian indoor conditions; use its findings to buy wisely rather than trust the marketing.</p>
             <div class="grid-3" style="gap: 1rem;">
@@ -3122,7 +3122,7 @@
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--red);">169K</div><div class="stat-label">Under-5 deaths from air pollution in India (IHME GBD 2021)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--purple);">30%+</div><div class="stat-label">Pneumonia deaths in under-5s linked to indoor air (ICMR)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--amber);">68</div><div class="stat-label">School closure days in Delhi (pollution, 2023-2026 cumulative)</div></div>
-        <div class="stat-strip-item"><div class="number-callout" style="color: var(--blue);">2.6x</div><div class="stat-label">Asthma rate in children near highways vs. clean areas</div></div>
+        <div class="stat-strip-item"><div class="number-callout" style="color: var(--ink);">2.6x</div><div class="stat-label">Asthma rate in children near highways vs. clean areas</div></div>
     </div>
 
     <div class="grid-2" style="gap: 1.25rem;">
@@ -3130,7 +3130,7 @@
             <div class="card-header"><span class="card-title">School Closures Tracker</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Delhi had to close schools many times during winter 2025-26 because the air was too dirty. When pollution gets really bad (AQI above 400), all primary schools must close. But many students in government schools don&rsquo;t have laptops or internet for online classes, so they simply miss out on learning. The next pollution-season closures start October-November 2026.">Delhi schools shifted to online mode multiple times during Winter 2025-26 (the most recent pollution season). Under GRAP Stage III/IV, all primary schools close when AQI exceeds 400. Students in government schools often lack devices for online learning, widening the education equity gap. The next closure window opens with the post-monsoon pollution season &mdash; typically late October 2026.</p>
-                <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid #EF4444;">
+                <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
                     <h4>Winter 2025-26 closures (most recent pollution season)</h4>
                     <p>Nov 4-8, Nov 14-18, Nov 22-26, Dec 2-5, Jan 6-10, Jan 16-20. <strong>Total: ~30 days</strong> across Winter 2025-26. An estimated 4+ million school-age children affected in Delhi-NCR alone. Learning loss is cumulative and disproportionately harms first-generation learners.</p>
                 </div>
@@ -3164,19 +3164,19 @@
 <!-- ═══════════════════════════════════════════════ -->
 <template id="tmpl-gender">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-heart" style="color: var(--pink); margin-right: 0.4rem;"></span>Women's Health &amp; Air Quality</h2>
+        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-heart" style="color: var(--ink); margin-right: 0.4rem;"></span>Women's Health &amp; Air Quality</h2>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="Women and girls are hurt more by India's air pollution. They cook with dirty fuels, work in polluted places, and face higher health risks during pregnancy. But we barely track the problem because most air monitors are not where women spend their time.">Women and girls bear a disproportionate burden of India&rsquo;s air pollution crisis. From indoor cooking smoke to occupational exposure, from maternal health risks to the near-total absence of gender-disaggregated monitoring, the intersection of gender and air quality is one of India&rsquo;s most under-examined public health failures.</p>
     </div>
 
     <div class="stat-strip" style="margin-bottom: 2rem;">
-        <div class="stat-strip-item"><div class="number-callout" style="color: var(--pink);">~70%</div><div class="stat-label">Rural Indian women still cook with solid fuels (NFHS-5, 2019-21)</div></div>
+        <div class="stat-strip-item"><div class="number-callout" style="color: var(--ink);">~70%</div><div class="stat-label">Rural Indian women still cook with solid fuels (NFHS-5, 2019-21)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--purple);">3&ndash;5%</div><div class="stat-label">Increase in preterm birth risk per +10 &micro;g/m&sup3; PM2.5 (Lancet Planetary Health 2023)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--red);">~500K</div><div class="stat-label">Indian women die annually from household air pollution (GBD 2021)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--amber);">60%</div><div class="stat-label">Of global HAP deaths are women (Lancet Countdown 2025)</div></div>
     </div>
 
     <div class="grid-3" style="gap: 1.25rem; margin-bottom: 1.25rem;">
-        <div class="card" style="border-left: 4px solid #EC4899;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title">Indoor Cooking Exposure</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2);" data-simple="About 70% of rural Indian women still cook with wood, dung, or crop waste. They stand near the chulha for 3 to 5 hours every day, breathing in pollution levels 20 to 40 times higher than what the WHO says is safe.">Approximately 70% of rural Indian women still cook with solid fuels &mdash; wood, dung cake, and crop residue (NFHS-5, 2019-21). Women spend 3&ndash;5 hours per day near the chulha, inhaling PM2.5 concentrations 20&ndash;40&times; the WHO annual guideline of 5 &micro;g/m&sup3;.</p>
@@ -3204,7 +3204,7 @@
             <div class="card-header"><span class="card-title">The Indoor Cooking Crisis</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Cooking with wood, dung, and crop waste exposes women to pollution levels 10 to 40 times higher than outdoor air. The government's Ujjwala scheme gave out 10 crore LPG connections, but many women can't afford refills. They use only about 3.5 cylinders per year instead of the 6-7 needed. Many go back to using firewood because LPG is too expensive.">Solid fuel cooking &mdash; wood, dung, and crop residue &mdash; exposes women to PM2.5 concentrations 10&ndash;40&times; ambient levels. The Pradhan Mantri Ujjwala Yojana (PMUY) distributed over 10 Cr LPG connections since 2016, but sustained use remains a challenge. Refill rates have dropped to approximately 3.5 cylinders per year in many states, far below the 6&ndash;7 cylinders needed for a full cooking fuel transition. Cost remains the primary barrier: many beneficiaries revert to biomass fuels when subsidies are delayed or insufficient.</p>
-                <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid #D97706;">
+                <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid var(--accent);">
                     <h4>Ujjwala: Connection vs. Transition</h4>
                     <p>A 2024 CEEW evaluation found that only 38% of Ujjwala beneficiaries use LPG as their primary cooking fuel. The remaining 62% practice fuel stacking &mdash; using LPG for quick meals and biomass for roti-making and extended cooking. The scheme succeeded in access but has not yet achieved a clean cooking transition.</p>
                 </div>
@@ -3216,7 +3216,7 @@
             <div class="card-header"><span class="card-title">Occupational Exposure</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Women who work in construction, brick kilns, street vending, and farming breathe dirty air all day without protection. About 30% of construction workers are women, but they are rarely given N95 masks or any safety gear.">Women in construction, brick kilns, street vending, and agriculture face sustained outdoor PM2.5 exposure without respiratory protection. Female construction workers comprise approximately 30% of the workforce but are rarely provided N95 masks or occupational health screening. Brick kiln workers &mdash; many of them women from migrant families &mdash; are exposed to PM levels of 500&ndash;1,000 &micro;g/m&sup3; during firing cycles.</p>
-                <div class="info-box" style="background: rgba(59,130,246,0.06); border-left: 3px solid #3B82F6;">
+                <div class="info-box" style="background: rgba(59,130,246,0.06); border-left: 3px solid var(--accent);">
                     <h4>The Informal Sector Gap</h4>
                     <p>India&rsquo;s Factories Act and Building &amp; Other Construction Workers Act mandate protective equipment, but enforcement in the informal sector &mdash; where most women work &mdash; is nearly non-existent. No national data exists on occupational respiratory disease among female informal workers.</p>
                 </div>
@@ -3237,7 +3237,7 @@
             <div class="card-header"><span class="card-title">The Gender Data Gap</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Most air quality sensors are placed in commercial and industrial areas, not in homes and kitchens where women spend most of their time. India has zero official indoor air monitoring stations. Health studies rarely separate data by gender, so we don't fully know how much worse pollution is for women.">Most air quality monitoring stations (CAAQMS) are sited in commercial, industrial, and traffic zones &mdash; not in residential areas where women spend the majority of their time. CPCB&rsquo;s monitoring network includes zero indoor monitoring stations. Health impact studies rarely disaggregate outcomes by gender, making it impossible to precisely quantify the differential burden on women.</p>
-                <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid #EF4444;">
+                <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
                     <h4>CAG Audit Finding (April 2025)</h4>
                     <p>The Comptroller and Auditor General&rsquo;s April 2025 audit of India&rsquo;s air quality monitoring infrastructure found that station siting criteria systematically excluded residential and peri-urban areas. The audit recommended gender-sensitive monitoring protocols and indoor air quality stations in at least 50 cities by 2028.</p>
                 </div>
@@ -3246,7 +3246,7 @@
         </div>
     </div>
 
-    <div class="card mt-2" style="border-left: 4px solid #10B981;">
+    <div class="card mt-2" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">What Needs to Change</span></div>
         <div class="card-body">
             <div class="grid-3" style="gap: 1rem;">
@@ -3284,7 +3284,7 @@
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--red);">30%</div><div class="stat-label">Industrial contribution to NCR PM2.5 (TERI-ARAI)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--amber);">1,700+</div><div class="stat-label">Industries in Delhi-NCR operating without consent (DPCC est.)</div></div>
         <div class="stat-strip-item"><div class="number-callout" style="color: var(--purple);">50mg</div><div class="stat-label">CAQM PM emission limit for NCR industries (2024)</div></div>
-        <div class="stat-strip-item"><div class="number-callout" style="color: var(--blue);">11</div><div class="stat-label">Coal power plants within 300km of Delhi</div></div>
+        <div class="stat-strip-item"><div class="number-callout" style="color: var(--ink);">11</div><div class="stat-label">Coal power plants within 300km of Delhi</div></div>
     </div>
 
     <div class="grid-2" style="gap: 1.25rem;">
@@ -3511,7 +3511,7 @@
             <div class="stat-strip" style="margin-bottom: 1.5rem;">
                 <div class="stat-strip-item"><div class="number-callout" style="color: var(--red);">40%</div><div class="stat-label">Target PM10 reduction (vs. 2017 baseline)</div></div>
                 <div class="stat-strip-item"><div class="number-callout" style="color: var(--amber);">23/100</div><div class="stat-label">Cities that met target (CREA Jan 2026, 100 cities with sufficient data)</div></div>
-                <div class="stat-strip-item"><div class="number-callout" style="color: var(--blue);">68%</div><div class="stat-label">NCAP funds spent on road dust control</div></div>
+                <div class="stat-strip-item"><div class="number-callout" style="color: var(--ink);">68%</div><div class="stat-label">NCAP funds spent on road dust control</div></div>
                 <div class="stat-strip-item"><div class="number-callout" style="color: var(--purple);">&lt;1%</div><div class="stat-label">Spent on industrial emission control</div></div>
             </div>
             <p style="font-size: 0.875rem; color: var(--text-2);">NCAP's 31 March 2026 deadline for 40% PM10 reduction across 131 non-attainment cities has elapsed with the programme far short of its target. Guttikunda et al.'s 2024 analysis (examining 2019&ndash;2023 data) documented "no change in the fraction of cities above 150 µg/m³" for PM10. The programme's spending priorities &mdash; overwhelmingly tilted toward road dust rather than transport, industry, or biomass &mdash; explain much of this underperformance. The CSE Five-Year Review (April 2026) found that 64% of NCAP funds went to dust suppression, not combustion sources. See the <a href="#resources" onclick="showPanel('resources'); return false;">Resources panel</a> for the CSE review.</p>
@@ -3522,19 +3522,19 @@
         <div class="card card-accent-amber">
             <div class="card-header"><span class="card-title">Promise vs. Reality: Key Interventions</span></div>
             <div class="card-body" style="font-size: 0.875rem; color: var(--text-2);">
-                <div class="info-box" style="border-left: 3px solid #EF4444; margin-bottom: 0.75rem;">
+                <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
                     <h4>Anti-Smog Guns (200 deployed, Rs 58 Cr)</h4>
                     <p><strong>Evidence:</strong> Reduce AQI by 5-10 points in immediate vicinity only. No measurable city-level impact. IIT Delhi study: "cosmetic measure."</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #D97706; margin-bottom: 0.75rem;">
+                <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
                     <h4>Road Mechanised Sweeping</h4>
                     <p><strong>Evidence:</strong> Mixed. Reduces resuspended road dust temporarily. 68% of NCAP budget goes here, but road dust is not the primary PM2.5 source (vehicles and biomass are).</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #22C55E; margin-bottom: 0.75rem;">
+                <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
                     <h4>E-bus Procurement</h4>
                     <p><strong>Evidence:</strong> Strong long-term impact. Delhi targets 6,000 buses by Dec 2026 (from 3,600). Each diesel bus replaced = ~25 tonnes CO2/year + significant PM reduction. But procurement pace is slow.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6;">
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
                     <h4>Cloud Seeding Experiments</h4>
                     <p><strong>Evidence:</strong> Delhi government conducted trials in late 2025 and early 2026; both claimed success. Independent assessment of both rounds: minimal rainfall produced, no measurable AQI impact. Scientific consensus (CEEW, IIT-Delhi DSS): not scalable as a pollution-control intervention &mdash; addresses symptoms after the fact, not sources.</p>
                 </div>
@@ -3813,7 +3813,7 @@
     <!-- ── SECTION 3: Public Feedback ── -->
     <div class="card mb-2">
         <div class="card-header">
-            <span class="card-title" style="color: var(--blue);">
+            <span class="card-title" style="color: var(--ink);">
                 <span class="si si-chat"></span>
                 Citizen Observations
             </span>
@@ -3857,33 +3857,33 @@
                 These are the questions that citizens, journalists, and ward councillors should be putting to their municipal corporations and state pollution control boards. Use these in RTI applications, public hearings, or media advocacy.
             </p>
             <div class="grid-2" style="gap: 1rem;">
-                <div class="info-box" style="border-left: 3px solid #EF4444;">
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
                     <h4 style="color: var(--red); font-size: 0.875rem;">On spending priorities</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;How much of the NCAP budget was spent on road dust suppression vs actual emission reduction (vehicles, industry, biomass)?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: 68% of NCAP funds nationally went to dust control. Vehicles (38%) and industry (18%) &mdash; the top PM2.5 sources &mdash; received &lt;1% combined.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #D97706;">
-                    <h4 style="color: var(--amber); font-size: 0.875rem;">On CAQM functioning</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">On CAQM functioning</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;How many CAQM meetings were held in the past 6 months? What was decided? Are minutes publicly available?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: CAQM is the apex body for NCR air quality. Meeting frequency and decisions should be public. File RTI under CAQM, MoEFCC.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                    <h4 style="color: var(--blue); font-size: 0.875rem;">On monitoring gaps</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">On monitoring gaps</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;Has your city&rsquo;s monitoring station count increased since NCAP started? Are all stations reporting data continuously?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: Many cities have 2-3 stations for millions of people. Data gaps (&gt;25% downtime) are common. Without measurement, there is no accountability.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                    <h4 style="color: var(--purple); font-size: 0.875rem;">On the funding cliff</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">On the funding cliff</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;What happened to the 15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) that expired 31 March 2026?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: This bucket was 87% of all NCAP city funding. 16th FC recommendations expected Oct 2026 for FY27 (Apr 2027) &mdash; leaving a potential 12-month gap with no new allocation.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #16803C;">
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
                     <h4 style="color: var(--green-700); font-size: 0.875rem;">On target accountability</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;NCAP targeted 40% PM10 reduction by March 2026. Only 23 of 100 cities met it. What is the revised plan?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: As of mid-May 2026, no revised NCAP programme has been announced. Guttikunda et al. (2024) found &ldquo;no change in the fraction of cities above 150 &micro;g/m&sup3;&rdquo; for PM10.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #EC4899;">
-                    <h4 style="color: var(--pink); font-size: 0.875rem;">On compliance enforcement</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">On compliance enforcement</h4>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;During the last GRAP Stage IV, how many construction sites were inspected? How many penalties were issued?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: Compliance monitoring during winter 2025-26 found 40% of construction sites continued operations during the ban. Enforcement is the weakest link.</p>
                 </div>
@@ -3902,7 +3902,7 @@
 <!-- ═══════════════════════════════════════════════ -->
 <template id="tmpl-migration">
     <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-bus" style="color: var(--blue); margin-right: 0.4rem;"></span>Migration &amp; Climate Displacement</h2>
+        <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-bus" style="color: var(--ink); margin-right: 0.4rem;"></span>Migration &amp; Climate Displacement</h2>
         <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="Many people are leaving Delhi because of bad air. IT workers and rich families move to cities with cleaner air. But daily wage workers, who breathe the worst air, cannot afford to leave. This is deeply unfair.">Air quality is becoming a driver of internal migration. Skilled professionals leave Delhi for Bangalore, Pune, Hyderabad. But informal workers who bear the worst exposure have no option to leave. This asymmetry defines the environmental justice crisis.</p>
     </div>
 
@@ -3977,7 +3977,7 @@
         <div class="card card-accent-blue">
             <div class="card-body" style="padding: 1.75rem;">
                 <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
-                    <span class="si si-lg si-clipboard" style="color: var(--blue);"></span>
+                    <span class="si si-lg si-clipboard" style="color: var(--ink);"></span>
                     <h3 style="font-size: 1rem; font-weight: 600;">RTI Template Pack</h3>
                 </div>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1.25rem;">Pre-formatted RTI applications for CPCB, DPCC, MoEFCC, and CAQM. Print-ready with filing instructions.</p>
@@ -4601,7 +4601,7 @@
         </div>
 
         <div>
-            <div class="card mb-2" style="border-left:4px solid #DC2626;">
+            <div class="card mb-2" style="border-left: 4px solid var(--accent);">
                 <div class="card-header"><span class="card-title">But&hellip;</span></div>
                 <div class="card-body" id="ward-stats">
                     <div style="color:var(--text-3); font-size:0.85rem;"><span class="pulse"></span> Loading live ward readings&hellip;</div>
@@ -4648,7 +4648,7 @@
                         <strong style="color: var(--purple);">Nov-Feb:</strong> Temperature inversion traps pollutants near ground level
                     </div>
                     <div style="padding: 0.5rem 0; border-bottom: 1px solid var(--border-light);">
-                        <strong style="color: var(--blue);">Year-round:</strong> Vehicular emissions (40% of Delhi pollution)
+                        <strong style="color: var(--ink);">Year-round:</strong> Vehicular emissions (40% of Delhi pollution)
                     </div>
                     <div style="padding: 0.5rem 0; border-bottom: 1px solid var(--border-light);">
                         <strong style="color: #6B7280;">Year-round:</strong> Construction dust, industrial emissions, waste burning
@@ -6114,7 +6114,7 @@ Citizens are fighting back. RWAs install community air purifiers. Parents demand
           </div>` },
         { id: 'obs-ncap', top: 504, bottom: 634, left: containerWidth - 200, right: containerWidth,
           html: `<div style="text-align:center;">
-            <div style="font-size:2rem;font-weight:700;color:var(--blue);font-family:var(--sans);">40%</div>
+            <div style="font-size:2rem;font-weight:700;color: var(--ink);font-family:var(--sans);">40%</div>
             <div style="font-size:0.72rem;color:var(--text-3);margin-top:4px;">NCAP 2026 target</div>
             <div style="font-size:0.65rem;color:var(--text-4);margin-top:4px;">PM2.5 reduction goal</div>
             <div style="width:100%;height:6px;background:var(--border);border-radius:3px;margin-top:8px;">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.84",
+  "version": "26.6.85",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.83",
+  "version": "26.6.84",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/about.html
+++ b/panels/about.html
@@ -43,7 +43,7 @@
             <p style="font-size: 0.9375rem; line-height: 1.7; color: var(--text-2); margin-bottom: 1.25rem; max-width: 48rem;" data-i18n="about_partners_intro" data-simple="The people and groups JanVayu works with on clean air for the public good.">The organisations and initiatives JanVayu works alongside in the <strong>#AQIForJanHit</strong> effort for clean air as a public good.</p>
             <div class="grid-2" style="gap: 1rem;">
 
-                <a href="https://profcongress.in/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #1B6B4A;">
+                <a href="https://profcongress.in/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #fff; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 6px;"><img src="/partners/aipc.png" alt="All India Professionals' Congress logo" loading="lazy" style="max-width: 100%; max-height: 100%; object-fit: contain;"></div>
                     <div>
                         <strong style="display: block; color: var(--ink);">All India Professionals' Congress (AIPC)</strong>
@@ -51,7 +51,7 @@
                     </div>
                 </a>
 
-                <a href="https://manmohansinghfellows.com/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #7C3AED;">
+                <a href="https://manmohansinghfellows.com/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #fff; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 3px;"><img src="/partners/mmsf.webp" alt="Dr. Manmohan Singh Fellows Programme logo" loading="lazy" style="max-width: 100%; max-height: 100%; object-fit: contain;"></div>
                     <div>
                         <strong style="display: block; color: var(--ink);">Dr. Manmohan Singh Fellows Programme</strong>
@@ -59,7 +59,7 @@
                     </div>
                 </a>
 
-                <a href="https://m.thewire.in/article/environment/citizen-groups-urge-caqm-to-take-year-round-action-on-delhi-air" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #2563EB;">
+                <a href="https://m.thewire.in/article/environment/citizen-groups-urge-caqm-to-take-year-round-action-on-delhi-air" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #2563EB; color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 1.05rem; flex-shrink: 0;">साँस</div>
                     <div>
                         <strong style="display: block; color: var(--ink);">Delhi SSANS &mdash; Swasth Saans Adhikar Nagrik Samiti</strong>
@@ -67,7 +67,7 @@
                     </div>
                 </a>
 
-                <a href="https://urbanemissions.info/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #EA580C;">
+                <a href="https://urbanemissions.info/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #fff; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 6px;"><img src="/partners/urbanemissions.webp" alt="UrbanEmissions.info logo" loading="lazy" style="max-width: 100%; max-height: 100%; object-fit: contain;"></div>
                     <div>
                         <strong style="display: block; color: var(--ink);">UrbanEmissions.info</strong>
@@ -75,7 +75,7 @@
                     </div>
                 </a>
 
-                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #0F766E;">
+                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #fff; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 6px;"><img src="/partners/terra.webp" alt="Terra.do logo" loading="lazy" style="max-width: 100%; max-height: 100%; object-fit: contain;"></div>
                     <div>
                         <strong style="display: block; color: var(--ink);">Terra.do</strong>
@@ -83,7 +83,7 @@
                     </div>
                 </a>
 
-                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid #0D9488;">
+                <a href="https://www.terra.do/" target="_blank" rel="noopener" class="info-box" style="display: flex; gap: 0.85rem; align-items: flex-start; text-decoration: none; border-left: 3px solid var(--accent);">
                     <div style="width: 64px; height: 48px; border-radius: 10px; background: #fff; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 8px;"><img src="/partners/terra-mark.svg" alt="Terra.do Studio (Terra.do mark)" loading="lazy" style="max-width: 100%; max-height: 100%; object-fit: contain;"></div>
                     <div>
                         <strong style="display: block; color: var(--ink);">Terra.do Studio</strong>
@@ -103,12 +103,12 @@
                     <h4 style="color: var(--green-700);">Scientific Accuracy</h4>
                     <p>PM2.5 primary reporting over AQI. WHO 2021 guideline alignment. GEMM model for health estimates. All claims sourced and verified.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                    <h4 style="color: var(--purple);">Environmental Justice</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4>Environmental Justice</h4>
                     <p>Air pollution disproportionately affects marginalized communities. Our analysis centers the burden on informal workers, women, Dalit communities, and the urban poor.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                    <h4 style="color: var(--blue);">Independent Verification</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4>Independent Verification</h4>
                     <p>Government self-reporting is insufficient. We correlate promises with measurable outcomes using RTI, satellite data, and academic research.</p>
                 </div>
             </div>
@@ -127,12 +127,12 @@
                     <h4 style="color: var(--green-700); font-size: 0.85rem;">More cities</h4>
                     <p style="font-size: 0.8rem;">Extend the atlas to tier-1 &amp; tier-2 cities as open ward boundaries are sourced.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #7C3AED; padding: 12px;">
-                    <h4 style="color: var(--purple); font-size: 0.85rem;">Time-aware heat</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 12px;">
+                    <h4 style="font-size: 0.85rem">Time-aware heat</h4>
                     <p style="font-size: 0.8rem;">Seasonal-median land-surface temperature instead of a single clear-sky scene, to reduce single-day noise.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6; padding: 12px;">
-                    <h4 style="color: var(--blue); font-size: 0.85rem;">Your ward, shareable</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 12px;">
+                    <h4 style="font-size: 0.85rem">Your ward, shareable</h4>
                     <p style="font-size: 0.8rem;">Per-ward share cards &mdash; "my ward vs the city" snapshots for the air, heat and green layers.</p>
                 </div>
             </div>
@@ -155,12 +155,12 @@
                     <h4 style="color: var(--accent); font-size: 0.85rem;">Research</h4>
                     <p style="font-size: 0.8rem;">Add papers to the Zotero library. Translate findings into platform-legible numbers. Fill city and state data gaps.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #7C3AED; padding: 12px;">
-                    <h4 style="color: var(--purple); font-size: 0.85rem;">Policy</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 12px;">
+                    <h4 style="font-size: 0.85rem">Policy</h4>
                     <p style="font-size: 0.8rem;">Track NCAP budgets, court orders, and government promises vs reality. Write policy briefs for the blog.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6; padding: 12px;">
-                    <h4 style="color: var(--blue); font-size: 0.85rem;">Technical</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 12px;">
+                    <h4 style="font-size: 0.85rem">Technical</h4>
                     <p style="font-size: 0.8rem;">Pull requests on GitHub. Mobile performance, WCAG accessibility, city expansion, AI features.</p>
                 </div>
             </div>

--- a/panels/accountability.html
+++ b/panels/accountability.html
@@ -60,7 +60,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="color: var(--amber); font-size: 0.875rem; margin-bottom: 0.75rem;"> Fund Misallocation</h4>
+                            <h4 style="font-size: 0.875rem; margin-bottom: 0.75rem"> Fund Misallocation</h4>
                             <div style="background: var(--bg); padding: 0.75rem; border-radius: 8px; font-size: 0.875rem;">
                                 <div style="display: flex; justify-content: space-between; margin-bottom: 0.5rem;">
                                     <span>Road dust control</span><strong style="color: var(--green-700);">68%</strong>
@@ -92,7 +92,7 @@
             </div>
 
             <!-- NEW: MARCH 2026 UPDATE -->
-            <div class="card mb-2" style="border-left: 4px solid #DC2626;">
+            <div class="card mb-2" style="border-left: 4px solid var(--accent);">
                 <div class="card-header">
                     <span class="card-title" style="color: var(--red);">
                         <span class="si si-fact-check"></span>
@@ -121,7 +121,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="color: var(--purple); font-size: 0.875rem; margin-bottom: 0.75rem;">GRAP & Monitoring Gaps</h4>
+                            <h4 style="font-size: 0.875rem; margin-bottom: 0.75rem">GRAP & Monitoring Gaps</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>GRAP triggers:</strong> Imposed 17 times since Jan 2025 — Stage III for 53 days, Stage IV for 15 days</li>
                                 <li><strong>Monitor discrepancy:</strong> Newslaundry found AQI 400+ at street level vs 249 at nearest CPCB station (Safdarjung, Mar 12)</li>
@@ -164,7 +164,7 @@
             </div>
 
             <!-- NEW: CAG AUDIT FINDINGS -->
-            <div class="card mb-2" style="border-left: 4px solid #7C3AED;">
+            <div class="card mb-2" style="border-left: 4px solid var(--accent);">
                 <div class="card-header">
                     <span class="card-title" style="color: var(--purple);">
                          CAG Audit &mdash; Monitoring Station Failures
@@ -194,7 +194,7 @@
             </div>
             <div class="card mb-2">
                 <div class="card-header">
-                    <span class="card-title" style="color: var(--blue);">
+                    <span class="card-title" style="color: var(--ink);">
                         <span class="si si-fact-check"></span>
                          Clean Air Mission Tracker — Independent Verification
                     </span>
@@ -209,7 +209,7 @@
 
                     <!-- EVIDENCE GRADING LEGEND -->
                     <div class="info-box mb-2">
-                        <h4 style="color: var(--blue); margin-bottom: 0.75rem;"> Evidence Grading Scale (E1-E5)</h4>
+                        <h4 style="margin-bottom: 0.75rem"> Evidence Grading Scale (E1-E5)</h4>
                         <div class="grid-5" style="gap: 0.5rem; font-size: 0.8125rem;">
                             <div style="padding: 0.5rem; background: rgba(27,107,74,0.08); border-radius: 6px; text-align: center;">
                                 <strong style="color: var(--green-700);">E1</strong><br>
@@ -346,20 +346,20 @@
 
                     <!-- FOUR I'S FRAMEWORK -->
                     <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--border);">
-                        <h4 style="color: var(--blue); margin-bottom: 0.75rem;"> World Bank "Four I's" Framework Assessment</h4>
+                        <h4 style="margin-bottom: 0.75rem"> World Bank "Four I's" Framework Assessment</h4>
                         <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">
                             The World Bank's December 2025 report identifies four pillars essential for clean air progress. We assess India's NCAP against this framework:
                         </p>
                         <div class="grid-4" style="gap: 0.75rem;">
-                            <div class="info-box" style="border-left: 3px solid #3B82F6; padding: 0.75rem;">
-                                <h5 style="color: var(--blue); font-size: 0.875rem;"> Information</h5>
+                            <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
+                                <h5 style="font-size: 0.875rem"> Information</h5>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Accessible, reliable data for planning and accountability"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> CPCB CAAQMS coverage expanding but gaps remain. Real-time source apportionment only in 50/130 cities. JanVayu fills citizen data gap.
                                 </div>
                                 <span class="badge badge-warning mt-1" style="font-size: 0.8125rem;">PARTIAL</span>
                             </div>
-                            <div class="info-box" style="border-left: 3px solid #22C55E; padding: 0.75rem;">
+                            <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
                                 <h5 style="color: var(--green-600); font-size: 0.875rem;"> Incentives</h5>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Encourage behavioral and investment shift"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
@@ -367,16 +367,16 @@
                                 </div>
                                 <span class="badge badge-warning mt-1" style="font-size: 0.8125rem;">WEAK</span>
                             </div>
-                            <div class="info-box" style="border-left: 3px solid #F59E0B; padding: 0.75rem;">
-                                <h5 style="color: var(--amber); font-size: 0.875rem;"> Institutions</h5>
+                            <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
+                                <h5 style="font-size: 0.875rem"> Institutions</h5>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Coordinate action, ensure compliance"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> CAQM created 2021 but limited enforcement. Inter-state coordination remains blame-game. NCAP city action plans inconsistent.
                                 </div>
                                 <span class="badge badge-danger mt-1" style="font-size: 0.8125rem;">WEAK</span>
                             </div>
-                            <div class="info-box" style="border-left: 3px solid #7C3AED; padding: 0.75rem;">
-                                <h5 style="color: var(--purple); font-size: 0.875rem;"> Infrastructure</h5>
+                            <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
+                                <h5 style="font-size: 0.875rem"> Infrastructure</h5>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Enable clean energy, transport, waste systems"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> Metro expansion ongoing. EV charging patchy. Waste management infrastructure decades behind need. Industrial modernization slow.
@@ -452,7 +452,7 @@
                 <div class="card-header"><span class="card-title"> Budget & Fund Utilization</span></div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--red);">NCAP Funds (2019-2025)</h4>
                             <ul>
                                 <li><strong>Allocated:</strong> ₹11,211 crore to 131 cities</li>
@@ -464,8 +464,8 @@
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Source: RTI Jan 2025, CREA Report April 2025, CSE Assessment</div>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);">State Budgets for Air Quality</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>State Budgets for Air Quality</h4>
                             <ul>
                                 <li><strong>Delhi (2024-25):</strong> ₹500 Cr (0.6% of budget)</li>
                                 <li><strong>Punjab stubble:</strong> ₹300 Cr (mostly unspent)</li>
@@ -483,7 +483,7 @@
                 <div class="card-header"><span class="card-title"> Who's Responsible? The Blame Game Decoded</span></div>
                 <div class="card-body">
                     <div class="grid-3">
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4>Delhi Government</h4>
                             <ul>
                                 <li>Local transport (buses, autos)</li>
@@ -495,7 +495,7 @@
                             <p style="font-size: 0.875rem; color: var(--text-2); margin-top: 0.5rem;">~35-40% of winter PM2.5</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4>Punjab/Haryana</h4>
                             <ul>
                                 <li>Stubble burning (Oct-Nov)</li>
@@ -506,7 +506,7 @@
                             <p style="font-size: 0.875rem; color: var(--text-2); margin-top: 0.5rem;">~25-35% during peak burning season</p>
                         </div>
 
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4>Central Government</h4>
                             <ul>
                                 <li>Vehicle emission standards</li>

--- a/panels/actions.html
+++ b/panels/actions.html
@@ -82,7 +82,7 @@
                 <div class="card-body">
                     <div class="grid-3">
                         <!-- ZERO COST -->
-                        <div class="info-box" style="border-left: 3px solid #22C55E;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-600);">₹0 — Zero Cost Actions</h4>
                             <p data-simple="Things you can do right now that cost nothing: wet mop your floors, seal window gaps with wet towels, don&rsquo;t burn incense on bad air days, and rinse your nose with salt water after going outside."></p>
                             <ul>
@@ -99,8 +99,8 @@
                         </div>
 
                         <!-- LOW COST -->
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);">₹500-2000 — Low Cost</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>₹500-2000 — Low Cost</h4>
                             <p data-simple="For a small budget: buy N95 masks (₹50-150), make a DIY air purifier with a box fan and filter for ₹1200, or get indoor plants like money plant and snake plant."></p>
                             <ul>
                                 <li><strong>N95/N99 masks</strong> — ₹50-150 each. Only N95+ blocks PM2.5. Cloth masks don't work.</li>
@@ -115,8 +115,8 @@
                         </div>
 
                         <!-- INVESTMENT -->
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                            <h4 style="color: var(--purple);">₹5000+ — Investment Solutions</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>₹5000+ — Investment Solutions</h4>
                             <p data-simple="If you can spend more: get a HEPA air purifier (₹8,000+), buy an air quality monitor (₹3,000+), upgrade your car&rsquo;s cabin filter, or get your windows professionally sealed."></p>
                             <ul>
                                 <li><strong>HEPA air purifier</strong> — ₹8,000-50,000. Get CADR rating for your room size. Run 24/7 during bad days.</li>
@@ -199,7 +199,7 @@
                                         <tr><td>Surgical mask</td><td>30-50%</td><td>₹5-10</td><td style="color: var(--amber);"> Better than nothing</td></tr>
                                         <tr><td>N95 (no valve)</td><td>95%</td><td>₹50-150</td><td style="color: var(--green-600);"> Recommended</td></tr>
                                         <tr><td>N99</td><td>99%</td><td>₹150-300</td><td style="color: var(--green-600);"> Best protection</td></tr>
-                                        <tr><td>N95 with valve</td><td>95% (inhale only)</td><td>₹100-200</td><td style="color: var(--blue);"> Easier breathing</td></tr>
+                                        <tr><td>N95 with valve</td><td>95% (inhale only)</td><td>₹100-200</td><td style="color: var(--ink);"> Easier breathing</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -227,8 +227,8 @@
                 <div class="card-header"><span class="card-title"> For Schools — Admin & Parents</span></div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);">What Schools Should Do</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>What Schools Should Do</h4>
                             <ul>
                                 <li><strong>AQI-based schedule</strong> — No outdoor PT/games when AQI >200</li>
                                 <li><strong>Indoor assembly</strong> — Shift morning assembly indoors during bad days</li>
@@ -240,7 +240,7 @@
                             </ul>
                             <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Reference: CPCB School Guidelines 2023</div>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #22C55E;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-600);">What Parents Can Demand (Legal Basis)</h4>
                             <ul>
                                 <li><strong>CAQM Direction 2024:</strong> Schools must suspend outdoor activities when AQI >400</li>
@@ -261,7 +261,7 @@
                 <div class="card-header"><span class="card-title"> For Hospitals & Clinics</span></div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--red);">Clinical Preparedness</h4>
                             <ul>
                                 <li><strong>Stock up:</strong> Nebulizers, bronchodilators, steroids for Nov-Dec surge</li>
@@ -272,8 +272,8 @@
                                 <li><strong>Oxygen readiness:</strong> Check O2 supply and concentrator availability</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                            <h4 style="color: var(--purple);">Infrastructure</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>Infrastructure</h4>
                             <ul>
                                 <li><strong>HEPA in ICU/NICU:</strong> Critical care units need filtered air</li>
                                 <li><strong>Positive pressure:</strong> OTs should have positive pressure ventilation</li>
@@ -292,8 +292,8 @@
                 <div class="card-header"><span class="card-title"> For RWAs & Housing Societies</span></div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="color: var(--amber);">Immediate Actions</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>Immediate Actions</h4>
                             <ul>
                                 <li><strong>Ban leaf burning:</strong> Compost pit instead. Fine violators.</li>
                                 <li><strong>No open waste burning:</strong> Report to MCD if staff burns</li>
@@ -304,7 +304,7 @@
                                 <li><strong>EV charging:</strong> Install points to encourage electric vehicles</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-700);">Legal Powers & Long-term</h4>
                             <ul>
                                 <li><strong>MC Act:</strong> RWAs can frame bylaws on burning, DG use</li>
@@ -325,7 +325,7 @@
                 <div class="card-header"><span class="card-title"> Rural vs  Urban — Context-Specific Actions</span></div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="info-box" style="border-left: 3px solid #22C55E;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-600);"> Rural Areas</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Main sources:</strong> Crop burning, biomass cooking, dust roads, brick kilns</p>
                             <ul>
@@ -343,8 +343,8 @@
                             </ul>
                             <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Subsidy: Contact District Agriculture Officer for Happy Seeder</div>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);"> Urban Areas</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4> Urban Areas</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Main sources:</strong> Vehicles, construction, industry, road dust, waste burning</p>
                             <ul>
                                 <li><strong>Transport:</strong>
@@ -372,7 +372,7 @@
                 <div class="card-header"><span class="card-title"> Beyond Your Home — Advocacy Actions</span></div>
                 <div class="card-body">
                     <div class="grid-3">
-                        <div class="info-box" style="border-left: 3px solid #EF4444;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--red);">Report Violations</h4>
                             <ul>
                                 <li><strong>Sameer App</strong> — CPCB app to report pollution sources</li>
@@ -382,8 +382,8 @@
                                 <li><strong>Traffic Police</strong> — Report visibly polluting vehicles</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue);">Demand Action</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4>Demand Action</h4>
                             <ul>
                                 <li><strong>File RTI</strong> — Templates in RTI tab</li>
                                 <li><strong>Write to MLA/MP</strong> — Elected representatives respond to volume</li>
@@ -392,7 +392,7 @@
                                 <li><strong>PIL support</strong> — Support existing public interest litigations</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #22C55E;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="color: var(--green-600);">Community Building</h4>
                             <ul>
                                 <li><strong>WhatsApp groups</strong> — Coordinate local clean air initiatives</li>
@@ -411,19 +411,19 @@
                 <div class="card-header"><span class="card-title"> Quick Reference — Emergency Numbers & Apps</span></div>
                 <div class="card-body">
                     <div class="grid-4">
-                        <div class="stat-card" style="border-left: 3px solid #EF4444;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1rem;">1800-111-6397</div>
                             <div class="stat-label">MCD Helpline (Delhi)</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #3B82F6;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1rem;">Sameer App</div>
                             <div class="stat-label">CPCB Complaint App</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #22C55E;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1rem;">Green Delhi</div>
                             <div class="stat-label">Delhi Govt App</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #7C3AED;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1rem;">112</div>
                             <div class="stat-label">Emergency (Medical)</div>
                         </div>

--- a/panels/aqi-explainer.html
+++ b/panels/aqi-explainer.html
@@ -5,11 +5,11 @@
     </div>
 
     <!-- ═══ Section 1: What is AQI? ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #6366F1;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">What is AQI?</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="AQI is like a report card for air. It checks up to 8 pollutants, gives each a score, and reports the worst score as the final AQI. The pollutant with the worst score is called the 'dominant pollutant'.">AQI is a <strong>composite index</strong>. Monitoring stations measure up to 8 pollutants (PM2.5, PM10, NO2, SO2, O3, CO, NH3, Pb). Each pollutant concentration is converted into a sub-index on a 0&ndash;500 scale using breakpoint tables. The <strong>final AQI = maximum of all sub-indices</strong>. The pollutant with the highest sub-index is called the <em>dominant pollutant</em>.</p>
-            <div class="info-box" style="background: rgba(99,102,241,0.06); border-left: 3px solid #6366F1; margin-bottom: 1rem;">
+            <div class="info-box" style="background: rgba(99,102,241,0.06); border-left: 3px solid var(--accent); margin-bottom: 1rem;">
                 <h4>Why this matters</h4>
                 <p data-simple="An AQI of 200 from PM2.5 and an AQI of 200 from NO2 need different responses. PM2.5 means wear a mask. NO2 means avoid traffic areas. Same number, different action.">An AQI of 200 could be driven by PM2.5 alone OR by NO2 alone &mdash; the health response should differ. PM2.5-driven AQI calls for N95 masks and air purifiers. NO2-driven AQI calls for avoiding traffic corridors and idling vehicles. <strong>Same number, different action.</strong></p>
             </div>
@@ -40,7 +40,7 @@
 
     <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.25rem;">
         <!-- PM2.5 Card -->
-        <div class="card" style="border-left: 4px solid #EF4444;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: var(--red);">PM2.5 &mdash; Fine Particulate Matter (&lt;2.5&micro;m)</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="PM2.5 particles are so tiny they get into your lungs and blood. They come from cars, cooking, burning waste, and factories. They kill 17.2 lakh Indians every year."><strong>What:</strong> Tiny particles less than 2.5 micrometres in diameter &mdash; small enough to penetrate deep into lungs and cross into the bloodstream.</p>
@@ -48,13 +48,13 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> The #1 air pollution killer &mdash; responsible for an estimated <strong>1.72 million Indian deaths per year</strong> (Lancet Countdown 2025). Causes heart disease, stroke, lung cancer, COPD, and reduced life expectancy.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(239,68,68,0.08); color: var(--red); font-weight: 600;">NAAQS: 40 &micro;g/m&sup3; annual</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 5 &micro;g/m&sup3; annual</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 5 &micro;g/m&sup3; annual</span>
                 </div>
             </div>
         </div>
 
         <!-- PM10 Card -->
-        <div class="card" style="border-left: 4px solid #D97706;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: #B45309;">PM10 &mdash; Coarse Particulate Matter (&lt;10&micro;m)</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="PM10 includes larger dust particles from roads, construction, and farming. They irritate your nose and lungs and make asthma worse. In dusty cities like Jaipur, PM10 often drives the AQI higher than PM2.5."><strong>What:</strong> Larger particles &mdash; dust, pollen, mould spores, construction debris &mdash; that settle in the upper airways.</p>
@@ -62,13 +62,13 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> Causes respiratory inflammation, aggravates asthma and bronchitis. Often <strong>dominates AQI in dust-prone cities</strong> across Rajasthan, Gujarat, and western UP &mdash; but gets less media attention than PM2.5.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(217,119,6,0.08); color: #B45309; font-weight: 600;">NAAQS: 60 &micro;g/m&sup3; annual</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 15 &micro;g/m&sup3; annual</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 15 &micro;g/m&sup3; annual</span>
                 </div>
             </div>
         </div>
 
         <!-- NO2 Card -->
-        <div class="card" style="border-left: 4px solid #7C3AED;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: var(--purple);">NO2 &mdash; Nitrogen Dioxide</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="NO2 is a reddish-brown gas that comes mostly from diesel vehicles and power plants. It inflames your airways and triggers asthma attacks. It also helps form ground-level ozone. NO2 is rising fast in big Indian cities."><strong>What:</strong> A reddish-brown gas produced by high-temperature combustion. Gives smoggy air its brownish tint.</p>
@@ -76,13 +76,13 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> Causes airway inflammation, increases frequency and severity of asthma attacks. A key <strong>precursor to ground-level ozone</strong>. NO2 is <strong>rising rapidly in Indian metro cities</strong> due to growing diesel vehicle fleets &mdash; a silent crisis.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(124,58,237,0.08); color: var(--purple); font-weight: 600;">NAAQS: 40 &micro;g/m&sup3; annual</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 10 &micro;g/m&sup3; annual</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 10 &micro;g/m&sup3; annual</span>
                 </div>
             </div>
         </div>
 
         <!-- SO2 Card -->
-        <div class="card" style="border-left: 4px solid #EAB308;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: #A16207;">SO2 &mdash; Sulfur Dioxide</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="SO2 is a sharp-smelling gas from coal power plants and oil refineries. It irritates your lungs, makes heart disease worse, and causes acid rain that damages buildings and crops."><strong>What:</strong> A pungent, irritating gas produced when sulfur-containing fuels are burned.</p>
@@ -90,13 +90,13 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> Causes acid rain, respiratory irritation, bronchoconstriction, and worsens cardiovascular disease. Even short-term spikes can trigger hospital admissions in people with asthma or heart conditions.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(234,179,8,0.08); color: #A16207; font-weight: 600;">NAAQS: 50 &micro;g/m&sup3; annual</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 40 &micro;g/m&sup3; (24hr)</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 40 &micro;g/m&sup3; (24hr)</span>
                 </div>
             </div>
         </div>
 
         <!-- O3 Card -->
-        <div class="card" style="border-left: 4px solid #22C55E;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: var(--green-700);">O3 &mdash; Ground-level Ozone</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="This is NOT the good ozone layer up in the sky. Ground-level ozone is a toxic gas formed when vehicle and factory pollution reacts with sunlight. It is worst on hot, sunny afternoons. It triggers asthma and damages crops. It is rising fast in Indian cities."><strong>What:</strong> NOT the protective ozone layer &mdash; this is <strong>toxic ozone at ground level</strong>, formed by photochemical reactions.</p>
@@ -104,13 +104,13 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> Triggers asthma attacks, reduces lung function, damages agricultural crops. <strong>Rising in Indian cities</strong> but barely discussed because India&rsquo;s pollution narrative focuses on winter PM2.5. O3 is the pollutant most people have never heard of.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(34,197,94,0.08); color: var(--green-700); font-weight: 600;">NAAQS: 100 &micro;g/m&sup3; (8hr)</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 60 &micro;g/m&sup3; (peak season)</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 60 &micro;g/m&sup3; (peak season)</span>
                 </div>
             </div>
         </div>
 
         <!-- CO Card -->
-        <div class="card" style="border-left: 4px solid #64748B;">
+        <div class="card" style="border-left: 4px solid var(--accent);">
             <div class="card-header"><span class="card-title" style="color: #475569;">CO &mdash; Carbon Monoxide</span></div>
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="CO is an invisible, odourless gas from incomplete burning of fuels. It stops your blood from carrying oxygen. It can kill you in enclosed spaces like rooms with a coal angithi. Outdoors, it comes mainly from vehicle exhaust."><strong>What:</strong> An odourless, colourless gas produced by incomplete combustion. Undetectable without instruments.</p>
@@ -118,36 +118,36 @@
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Why it matters:</strong> Binds to haemoglobin 200&times; more strongly than oxygen, reducing the blood&rsquo;s oxygen-carrying capacity. <strong>Fatal in enclosed spaces</strong> &mdash; every winter, families die from angithi CO poisoning in northern India.</p>
                 <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.75rem;">
                     <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(100,116,139,0.08); color: #475569; font-weight: 600;">NAAQS: 2 mg/m&sup3; (8hr)</span>
-                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--blue); font-weight: 600;">WHO: 4 mg/m&sup3; (24hr)</span>
+                    <span style="font-size: 0.75rem; padding: 0.25rem 0.5rem; border-radius: 4px; background: rgba(59,130,246,0.08); color: var(--ink); font-weight: 600;">WHO: 4 mg/m&sup3; (24hr)</span>
                 </div>
             </div>
         </div>
     </div>
 
     <!-- ═══ Section 3: Why PM2.5 Isn't the Whole Story ═══ -->
-    <div class="card mb-3" style="border-left: 4px solid #F59E0B;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">Why PM2.5 Isn&rsquo;t the Whole Story</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Most people think air pollution means PM2.5. But other pollutants cause serious harm too, and they need different solutions. Dust dominates in Rajasthan. NO2 is rising in big cities from diesel vehicles. Ozone surges in summer but nobody talks about it.">India&rsquo;s air pollution conversation is dominated by PM2.5 &mdash; understandably, since it is the deadliest. But focusing exclusively on one pollutant creates dangerous blind spots:</p>
             <div class="grid-2" style="gap: 1rem; margin-bottom: 1rem;">
-                <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid #D97706;">
+                <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid var(--accent);">
                     <h4>Different AQI, different response</h4>
                     <p data-simple="AQI 150 from PM2.5 means tiny particles in the air — wear a mask and use a purifier. AQI 150 from ozone means avoid being outdoors in the afternoon sun. Same AQI number, but different actions needed.">A city with AQI 150 from PM2.5 vs AQI 150 from O3 requires completely different responses. PM2.5 calls for masks and purifiers; O3 calls for staying indoors during peak sunlight hours. Masks do <strong>not</strong> filter ozone.</p>
                 </div>
-                <div class="info-box" style="background: rgba(234,179,8,0.06); border-left: 3px solid #EAB308;">
+                <div class="info-box" style="background: rgba(234,179,8,0.06); border-left: 3px solid var(--accent);">
                     <h4>PM10: the forgotten pollutant</h4>
                     <p data-simple="In cities like Jaipur, Jodhpur, and Ahmedabad, PM10 (dust) often makes the AQI worse than PM2.5. But media and policy focus almost entirely on PM2.5, so dust-driven pollution gets ignored.">PM10 dominates AQI in Rajasthan, Gujarat, and western India due to desert dust and road dust resuspension &mdash; but gets a fraction of the media coverage PM2.5 receives. Dust-driven AQI crises are real health events.</p>
                 </div>
-                <div class="info-box" style="background: rgba(124,58,237,0.06); border-left: 3px solid #7C3AED;">
+                <div class="info-box" style="background: rgba(124,58,237,0.06); border-left: 3px solid var(--accent);">
                     <h4>NO2: the silent crisis</h4>
                     <p data-simple="NO2 from diesel vehicles is rising fast in Delhi, Mumbai, Bengaluru, and Chennai. It inflames airways and helps create ozone. But because PM2.5 gets all the attention, NO2 rises unchecked.">NO2 is rising rapidly in metro cities due to growing diesel vehicle fleets. It is a direct health hazard <em>and</em> a precursor to ozone formation. The dual threat makes NO2 reduction one of the highest-impact interventions.</p>
                 </div>
-                <div class="info-box" style="background: rgba(34,197,94,0.06); border-left: 3px solid #22C55E;">
+                <div class="info-box" style="background: rgba(34,197,94,0.06); border-left: 3px solid var(--accent);">
                     <h4>O3: surging in summer</h4>
                     <p data-simple="Ozone pollution is worst in hot, sunny months — exactly when PM2.5 drops and people think the air is clean. In many Indian cities, ozone is rising year over year, but almost nobody talks about it.">Ozone is the pollutant most people have never heard of but is surging in Indian summers. It peaks precisely when PM2.5 drops &mdash; creating a false sense of &ldquo;clean air&rdquo; in months when ozone may be dangerously high.</p>
                 </div>
             </div>
-            <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid #EF4444;">
+            <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
                 <h4>India&rsquo;s NAAQS vs WHO guidelines</h4>
                 <p data-simple="India says PM2.5 up to 40 is safe for a year. WHO says anything above 5 is unsafe. That's an 8 times difference. What India calls 'Moderate' air, the WHO calls 'Unhealthy'. Always look at the actual pollution numbers, not just the AQI label.">India&rsquo;s National Ambient Air Quality Standard for PM2.5 is <strong>40 &micro;g/m&sup3;</strong> (annual average). The WHO 2021 guideline is <strong>5 &micro;g/m&sup3;</strong> &mdash; an <strong>8&times; gap</strong>. What CPCB labels &ldquo;Moderate&rdquo; would be classified &ldquo;Unhealthy&rdquo; by global standards. <strong>Always look at raw &micro;g/m&sup3; values, not just the AQI label.</strong></p>
             </div>
@@ -155,7 +155,7 @@
     </div>
 
     <!-- ═══ Section 4: CPCB vs US EPA AQI Scales ═══ -->
-    <div class="card" style="border-left: 4px solid #3B82F6;">
+    <div class="card" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">CPCB vs US EPA AQI Scales</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="India's CPCB and America's EPA use different scales to calculate AQI from the same PM2.5 number. CPCB is more lenient — it calls things 'Moderate' that the EPA would call 'Unhealthy'. This table shows the difference.">India&rsquo;s CPCB and the US EPA use different breakpoint tables to convert the same PM2.5 concentration into an AQI number. The CPCB scale is significantly more lenient &mdash; masking the true severity of exposure.</p>
@@ -202,7 +202,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid #EF4444; margin-top: 1rem;">
+            <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent); margin-top: 1rem;">
                 <h4>Key insight</h4>
                 <p data-simple="At 100 micrograms of PM2.5, CPCB still says 'Moderate' but the US EPA says 'Unhealthy'. CPCB's 'Moderate' range hides what the rest of the world considers dangerous. Don't trust the label — look at the actual PM2.5 number.">At 100 &micro;g/m&sup3; PM2.5, CPCB still says &ldquo;Moderate&rdquo; while the US EPA says &ldquo;Unhealthy.&rdquo; CPCB&rsquo;s &ldquo;Moderate&rdquo; category hides what the rest of the world classifies as dangerous air. <strong>Always look at the raw &micro;g/m&sup3; concentration, not just the AQI number or colour code.</strong></p>
             </div>

--- a/panels/budget.html
+++ b/panels/budget.html
@@ -21,7 +21,7 @@
             <!-- KEY STATS -->
             <div class="stat-strip mb-2">
                 <div class="stat-cell">
-                    <div class="stat-value" style="color: var(--blue);">₹13,415 Cr</div>
+                    <div class="stat-value" style="color: var(--ink);">₹13,415 Cr</div>
                     <div class="stat-label">NCAP Released (2019-26)</div>
                 </div>
                 <div class="stat-cell">
@@ -77,7 +77,7 @@
                 <!-- NCAP FUNDING -->
                 <div class="card">
                     <div class="card-header">
-                        <span class="card-title" style="color: var(--blue);">
+                        <span class="card-title" style="color: var(--ink);">
                             <span class="si si-target"></span>
                             NCAP Fund Flow (2019-2026)
                         </span>
@@ -206,7 +206,7 @@
                                 <div style="font-size: 0.875rem; color: var(--text-3);">Connections (Jul 2025)</div>
                             </div>
                             <div style="text-align: center; padding: 0.75rem; background: var(--bg); border-radius: 6px;">
-                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--blue);">₹12,000 Cr</div>
+                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--ink);">₹12,000 Cr</div>
                                 <div style="font-size: 0.875rem; color: var(--text-3);">2025-26 Subsidy</div>
                             </div>
                         </div>
@@ -247,7 +247,7 @@
                                 <li>Uttar Pradesh: ₹764 Cr (21%)</li>
                             </ul>
                         </div>
-                        <div style="padding: 0.75rem; background: rgba(22,128,60,0.1); border-radius: 6px; border-left: 3px solid #16803C;">
+                        <div style="padding: 0.75rem; background: rgba(22,128,60,0.1); border-radius: 6px; border-left: 3px solid var(--accent);">
                             <strong style="color: var(--green-700);">Success Story:</strong> Fire incidents dropped from 82,533 (2021) to 18,457 (2024). 3 lakh+ machines distributed.
                         </div>
                     </div>
@@ -310,7 +310,7 @@
                             <span style="color: var(--text-3);">Vehicles Supported</span>
                         </div>
                         <div style="padding: 0.5rem; background: var(--bg); border-radius: 4px; text-align: center;">
-                            <strong style="color: var(--blue);">72,300</strong><br>
+                            <strong style="color: var(--ink);">72,300</strong><br>
                             <span style="color: var(--text-3);">Chargers Planned</span>
                         </div>
                     </div>
@@ -359,7 +359,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="color: var(--amber); font-size: 0.875rem; margin-bottom: 0.5rem;">Hidden Funds</h4>
+                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">Hidden Funds</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Environmental Cess:</strong> ₹45.8 Cr collected over 8 years, &lt;1% spent on pollution control (RTI)</li>
                                 <li><strong>CAMPA Funds:</strong> ₹94,844 Cr collected, only ₹26,002 Cr utilized (2019-24)</li>

--- a/panels/citizen-action.html
+++ b/panels/citizen-action.html
@@ -39,7 +39,7 @@
                             <div class="stat-change">AQI 51-200</div>
                         </div>
                     </div>
-                    <div class="info-box" style="border-left: 3px solid #3B82F6;" data-simple="&lt;strong&gt;Key point:&lt;/strong&gt; Even in 2020, when everything was locked down, Delhi only had 5 days of truly clean air. Small fixes will not work. The whole system &mdash; transport, factories, cooking fuel &mdash; needs to change.">
+                    <div class="info-box" style="border-left: 3px solid var(--accent);" data-simple="&lt;strong&gt;Key point:&lt;/strong&gt; Even in 2020, when everything was locked down, Delhi only had 5 days of truly clean air. Small fixes will not work. The whole system &mdash; transport, factories, cooking fuel &mdash; needs to change.">
                         <strong>Key Insight:</strong> Even during 2020 (lockdown year), Delhi had only 5 "Good" days vs 2 in normal years. The problem is systemic — tinkering on margins won't help. It requires a system-wide solution.
                     </div>
                     <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Source: CPCB data analysis, The Hindu (Nov 22, 2024)</div>
@@ -128,8 +128,8 @@
                                 <p style="font-size: 0.875rem; margin-top: 0.5rem;">34% from exhaust + 24% from tyre/brake wear. This is why the only realistic solution is a <strong>massive shift from private to public transport</strong>.</p>
                             </div>
                             
-                            <div class="info-box mt-2" style="border-left: 3px solid #F59E0B;">
-                                <h4 style="color: var(--amber); margin-bottom: 0.5rem;"> The Stubble Burning Myth</h4>
+                            <div class="info-box mt-2" style="border-left: 3px solid var(--accent);">
+                                <h4 style="margin-bottom: 0.5rem"> The Stubble Burning Myth</h4>
                                 <p style="font-size: 0.875rem;">Even at its peak (Oct 15 - Nov 15), stubble burning contributes 15-35% of PM2.5. Even with <strong>zero stubble burning</strong>, Delhi's AQI would still be "Very Poor" (>300). Blaming Punjab is a red herring.</p>
                             </div>
                             
@@ -155,8 +155,8 @@
                     </p>
 
                     <!-- TRANSPORT -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #3B82F6; background: rgba(59,130,246,0.03);">
-                        <h4 style="color: var(--blue); margin-bottom: 0.5rem;"> Transport Measures</h4>
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(59,130,246,0.03);">
+                        <h4 style="margin-bottom: 0.5rem"> Transport Measures</h4>
                         <ul style="font-size: 0.875rem; line-height: 1.7; columns: 2; column-gap: 2rem;">
                             <li><strong>Car-Pooling:</strong> Min 3 occupants; dedicated carpool lanes with heavy fines</li>
                             <li><strong>Odd-Even:</strong> Include two-wheelers; no exemptions</li>
@@ -168,8 +168,8 @@
                     </div>
 
                     <!-- CONSTRUCTION -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #F59E0B; background: rgba(245,158,11,0.03);">
-                        <h4 style="color: var(--amber); margin-bottom: 0.5rem;"> Construction & Industry</h4>
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
+                        <h4 style="margin-bottom: 0.5rem"> Construction & Industry</h4>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>Construction Holiday:</strong> Shutdown non-essential construction Oct-Feb</li>
                             <li><strong>Industrial Compliance:</strong> Immediate shutdown of violators—no compromises</li>
@@ -179,7 +179,7 @@
                     </div>
 
                     <!-- BURNING -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #EF4444; background: rgba(239,68,68,0.03);">
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.03);">
                         <h4 style="color: var(--red); margin-bottom: 0.5rem;"> Open & Waste Burning</h4>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>Zero Tolerance:</strong> No wood/coal/waste burning, including Lohri</li>
@@ -189,8 +189,8 @@
                     </div>
 
                     <!-- GOVERNANCE -->
-                    <div class="info-box" style="border-left: 4px solid #7C3AED; background: rgba(124,58,237,0.03);">
-                        <h4 style="color: var(--purple); margin-bottom: 0.5rem;"> Enforcement & Governance</h4>
+                    <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
+                        <h4 style="margin-bottom: 0.5rem"> Enforcement & Governance</h4>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>High-Level Oversight:</strong> Monthly PM-CM-Chief Secretary reviews with public dashboards</li>
                             <li><strong>PUC Compliance:</strong> Quarterly mandatory; deny fuel to dirty vehicles</li>
@@ -206,13 +206,13 @@
             <!-- URBAN TRANSPORT -->
             <div class="card mb-2">
                 <div class="card-header">
-                    <span class="card-title" style="color: var(--blue);">
+                    <span class="card-title" style="color: var(--ink);">
                          Transforming Urban Transport — Paris-Singapore Model
                     </span>
                 </div>
                 <div class="card-body">
-                    <div class="alert mb-2" style="background: rgba(59,130,246,0.08); border-left: 4px solid #3B82F6;">
-                        <strong style="color: var(--blue);">Core Principle:</strong> Focus on moving <strong>people</strong>, not vehicles. Reduce <strong>trips</strong>, not just emissions.
+                    <div class="alert mb-2" style="background: rgba(59,130,246,0.08); border-left: 4px solid var(--accent);">
+                        <strong style="color: var(--ink);">Core Principle:</strong> Focus on moving <strong>people</strong>, not vehicles. Reduce <strong>trips</strong>, not just emissions.
                     </div>
                     <div class="grid-2" style="gap: 1rem;">
                         <div>
@@ -243,7 +243,7 @@
             <!-- CLASS DIVIDE -->
             <div class="card mb-2">
                 <div class="card-header">
-                    <span class="card-title" style="color: var(--pink);">
+                    <span class="card-title" style="color: var(--ink);">
                          The Class Gap — Pollution Exposure by Economic Status
                     </span>
                 </div>
@@ -258,7 +258,7 @@
                                 <li><strong>Impact: ~5 years shorter lifespan</strong></li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 4px solid #22C55E; background: rgba(34,197,94,0.03);">
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(34,197,94,0.03);">
                             <h4 style="color: var(--green-600); margin-bottom: 0.5rem; font-size: 0.875rem;"> Aamya — Affluent (Greater Kailash)</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.6;">
                                 <li>Peak exposure: <strong>~80 µg/m³</strong></li>
@@ -267,7 +267,7 @@
                             </ul>
                         </div>
                     </div>
-                    <div class="alert mt-2" style="background: rgba(124,58,237,0.08); border-left: 4px solid #7C3AED; font-size: 0.875rem;">
+                    <div class="alert mt-2" style="background: rgba(124,58,237,0.08); border-left: 4px solid var(--accent); font-size: 0.875rem;">
                         <strong>Key Insight:</strong> Poor children lose much more than affluent counterparts. Policy discourse centers on middle-class concerns while ignoring the disproportionate burden on the poor.
                     </div>
                 </div>

--- a/panels/legal.html
+++ b/panels/legal.html
@@ -17,17 +17,17 @@
                                 <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Article 21: Right to Life = Right to Clean Air</h4>
                                 <p style="font-size: 0.875rem;"><strong>Subhash Kumar v. State of Bihar (1991):</strong> Supreme Court declared that the right to life encompasses the right to enjoy pollution-free water and air.</p>
                             </div>
-                            <div class="info-box" style="border-left: 4px solid #3B82F6;">
-                                <h4 style="color: var(--blue); margin-bottom: 0.5rem; font-size: 0.875rem;">Right Against Climate Degradation (2024)</h4>
+                            <div class="info-box" style="border-left: 4px solid var(--accent);">
+                                <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Right Against Climate Degradation (2024)</h4>
                                 <p style="font-size: 0.875rem;"><strong>M.K. Ranjitsinh v. Union of India (2024):</strong> Fundamental right against climate degradation — frames air pollution as constitutional rights defense.</p>
                             </div>
                         </div>
                         <div>
-                            <div class="info-box mb-2" style="border-left: 4px solid #F59E0B;">
-                                <h4 style="color: var(--amber); margin-bottom: 0.5rem; font-size: 0.875rem;">Polluter Pays Principle</h4>
+                            <div class="info-box mb-2" style="border-left: 4px solid var(--accent);">
+                                <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Polluter Pays Principle</h4>
                                 <p style="font-size: 0.875rem;"><strong>Vellore Citizens v. UOI (1996):</strong> Integrated Precautionary and Polluter Pays Principles. Justifies pollution cess, fines on violators.</p>
                             </div>
-                            <div class="info-box" style="border-left: 4px solid #16803C;">
+                            <div class="info-box" style="border-left: 4px solid var(--accent);">
                                 <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Absolute Liability</h4>
                                 <p style="font-size: 0.875rem;"><strong>M.C. Mehta v. UOI (1987):</strong> Industries in hazardous activities are strictly liable regardless of negligence.</p>
                             </div>
@@ -115,7 +115,7 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="alert mt-2" style="background: rgba(22,128,60,0.08); border-left: 4px solid #16803C; font-size: 0.875rem;">
+                    <div class="alert mt-2" style="background: rgba(22,128,60,0.08); border-left: 4px solid var(--accent); font-size: 0.875rem;">
                         <strong>Worker Compensation (Nov 2024):</strong> SC directed NCR states to use labour cess to provide weekly subsistence allowance during GRAP III/IV.
                     </div>
                 </div>
@@ -137,12 +137,12 @@
                             <h4 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">NGT &mdash; Diesel-Generator Retrofit Notices</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>9 April 2026.</strong> NGT issues notices to <strong>every State Pollution Control Board</strong> and Pollution Control Committee for failing to enforce CPCB/CAQM directions on DG-set emissions retrofit. Establishes nationwide accountability beyond NCR. Next hearing 21 July 2026.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                            <h4 style="color: var(--purple); font-size: 0.875rem; margin-bottom: 0.5rem;">CAQM &mdash; First Off-Season GRAP Stage-I</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">CAQM &mdash; First Off-Season GRAP Stage-I</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>19 May 2026.</strong> Commission for Air Quality Management invokes GRAP Stage-I in Delhi-NCR at AQI 208 &mdash; the <strong>first-ever off-season activation</strong>. Revoked 4 May, re-invoked 15 days later. Signals year-round enforcement, not just October&ndash;March. <a href="https://caqm.nic.in/index1.aspx?lsid=4168&amp;lev=2&amp;lid=4171&amp;langid=1" target="_blank" rel="noopener">CAQM order index</a>.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #D97706;">
-                            <h4 style="color: var(--amber); font-size: 0.875rem; margin-bottom: 0.5rem;">NCAP Deadline Elapsed</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">NCAP Deadline Elapsed</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>31 March 2026.</strong> NCAP's original 40% PM10 reduction target deadline passed. 23/100 cities with sufficient data met the target (CREA); CSE's April 2026 review finds 37/131. <strong>No revised programme announced</strong> as of mid-May 2026. 15th Finance Commission grants (₹16,539 Cr) expired the same day.</p>
                         </div>
                     </div>
@@ -164,8 +164,8 @@
                                 <li><strong>Enforcement:</strong> De-registration + impounding active</li>
                             </ul>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="color: var(--blue); margin-bottom: 0.5rem; font-size: 0.875rem;">Proposed ICE Sales Ban (2026)</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Proposed ICE Sales Ban (2026)</h4>
                             <p style="font-size: 0.875rem;">Legally defensible under EPA Section 3 & 5, given vehicles are 58% of internal PM2.5. Article 21 (Right to Life) overrides Article 19(1)(g) (Right to Trade).</p>
                         </div>
                     </div>
@@ -181,7 +181,7 @@
                     <span class="badge" style="background: #F59E0B; color: white; margin-left: 0.5rem;">Dec 2025</span>
                 </div>
                 <div class="card-body">
-                    <div class="alert mb-2" style="background: rgba(245,158,11,0.1); border-left: 4px solid #F59E0B;">
+                    <div class="alert mb-2" style="background: rgba(245,158,11,0.1); border-left: 4px solid var(--accent);">
                         <div style="font-size: 0.875rem; font-style: italic;">
                             "No data exists on whether these three power plants are meeting SO₂ emission standards. The RTI reply makes it clear that Delhi-NCR's pollution crisis is not just about weather or vehicles, it is also about a <strong>complete lack of enforcement</strong>."
                         </div>
@@ -197,7 +197,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--blue); margin-bottom: 0.5rem;">Impact</h4>
+                            <h4 style="font-size: 0.875rem;  margin-bottom: 0.5rem">Impact</h4>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li><strong>281 kilo-tonnes SO₂</strong> released annually (CREA)</li>
                                 <li>FGD systems could cut to 93 kilo-tonnes (67% reduction)</li>
@@ -236,15 +236,15 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Supreme Court: Clean Air as Fundamental Right</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court said breathing clean air is your basic right under the Constitution."><strong>MC Mehta v Union of India (1986&ndash;ongoing):</strong> Clean air is a fundamental right under Article 21. This landmark WP (No. 13029/1985) has generated dozens of follow-up orders, including the basis for GRAP.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">NGT: 24/7 CAAQMS Operation</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: 24/7 CAAQMS Operation</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal ordered that all government air monitors must run 24 hours a day, 7 days a week."><strong>2024:</strong> Directed CPCB to ensure 24/7 operation of all Continuous Ambient Air Quality Monitoring Stations. Many stations were running at &lt;70% data availability.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">CAQM: First Off-Season GRAP Stage-I</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">CAQM: First Off-Season GRAP Stage-I</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="For the first time, Delhi's emergency pollution rules were turned on in summer, not just winter."><strong>19 May 2026:</strong> First-ever off-season GRAP Stage-I activation at AQI 208. Signals year-round enforcement, breaking the October&ndash;March-only pattern.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Four-Week Deadline on Stubble Burning</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court told state governments they have 4 weeks to make a plan to stop farmers burning crop waste."><strong>2025:</strong> Supreme Court directed Punjab, Haryana, UP, and Rajasthan to submit stubble-burning action plans within four weeks. Linked non-compliance to contempt proceedings.</p>
                         </div>
@@ -257,15 +257,15 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Sector-wise PM Reduction Roadmaps</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told all 6 southern states to make a plan showing exactly how they will reduce dust and soot pollution, with money set aside for it."><strong>April 2026:</strong> NGT Principal Bench directed all six south-Indian states to file sector-wise PM10/PM2.5 reduction roadmaps tied to state budgets. First order shifting the policy frame beyond the Indo-Gangetic Plain.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">Madras HC: Industrial Emissions in Ennore-Manali Belt</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Madras HC: Industrial Emissions in Ennore-Manali Belt</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Madras High Court ordered a check on factories in Chennai's heavily polluted Ennore-Manali area."><strong>2024:</strong> Directed TNPCB to conduct comprehensive stack-emission audits of all industries in the Ennore-Manali industrial belt and report within 90 days.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">Karnataka SPCB: Bengaluru Construction Dust Norms</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Karnataka SPCB: Bengaluru Construction Dust Norms</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="Bengaluru's pollution board now requires big construction projects to use water sprinklers and cover sites to control dust."><strong>2025:</strong> Mandatory dust-suppression measures for all construction sites &gt;500 sq.m. following NGT direction. Penalties up to ₹5 lakh for non-compliance.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Kerala HC: Waste-Burning Ban Enforcement</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed all local bodies in Kerala to strictly enforce the open-burning ban under SWM Rules 2016. Fines for non-compliant panchayats.</p>
                         </div>
@@ -278,12 +278,12 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: 10 Additional CAAQMS</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told Bihar to install 10 more air quality monitors by December 2026 because the state has too few."><strong>2025:</strong> Directed Bihar SPCB to install 10 additional Continuous Ambient Air Quality Monitoring Stations by December 2026. Patna had only 2 CAAQMS for a city of 2.5 million.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">Patna HC: Brick Kiln Compliance Audit</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Patna HC: Brick Kiln Compliance Audit</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Patna High Court ordered a check on all brick kilns within 60 days to see if they follow pollution rules."><strong>2025:</strong> Ordered Bihar SPCB to complete a compliance audit of all brick kilns in Patna, Gaya, and Muzaffarpur districts within 60 days. Kilns not converted to zigzag technology to be shut.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">NGT: Patna Waste-Burning Penalty</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Patna Waste-Burning Penalty</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Imposed environmental compensation of ₹25 lakh on Patna Municipal Corporation for failing to prevent open waste burning along the Ganga ghats despite repeated directions.</p>
                         </div>
                     </div>
@@ -295,15 +295,15 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Bombay HC: BMC Air Quality Action Plan</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Bombay High Court told Mumbai's corporation to make a proper plan to reduce air pollution."><strong>2025:</strong> Directed BMC to submit a comprehensive air quality action plan within 12 weeks, covering construction dust, vehicular emissions, and industrial pollution in the Mumbai Metropolitan Region.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">NGT: Construction Dust Norms for Mumbai Metro</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Construction Dust Norms for Mumbai Metro</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal set strict dust-control rules for Mumbai Metro construction sites after local complaints."><strong>2024:</strong> Directed Mumbai Metro Rail Corporation to install anti-smog guns, wheel-washing systems, and wind barriers at all active construction sites. Environmental compensation of ₹10 lakh imposed for previous violations.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">MPCB: Pune Industrial Zone Crackdown</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MPCB: Pune Industrial Zone Crackdown</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Maharashtra Pollution Control Board issued closure notices to 14 units in Chakan-Ranjangaon industrial belt for exceeding PM emission norms. Follow-up to NGT direction.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">NGT: Navi Mumbai Waste Burning</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Imposed ₹15 lakh penalty on Navi Mumbai Municipal Corporation for persistent open-waste burning in Turbhe and Airoli zones despite SWM Rules.</p>
                         </div>
@@ -316,15 +316,15 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Allahabad HC: Revive Manual Monitoring Stations</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Allahabad High Court told UP's pollution board to restart manual air monitoring stations that had stopped working."><strong>2025:</strong> Directed UPPCB to revive all non-functional manual air-monitoring stations across the state within 6 months. Out of 72 stations, 28 were found non-operational.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">NGT: Brick Kiln Compliance for UP Cluster</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Brick Kiln Compliance for UP Cluster</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal set a deadline for brick kilns in UP to switch to cleaner technology or shut down."><strong>2024:</strong> Set a hard deadline for all brick kilns in the Lucknow-Kanpur-Agra cluster to convert to zigzag or vertical shaft technology. Estimated 4,000+ kilns affected.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">NGT: Varanasi Ghat Cremation Emissions</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Varanasi Ghat Cremation Emissions</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed Varanasi Municipal Corporation and UPPCB to submit a plan for reducing emissions from traditional cremation at Manikarnika and Harishchandra ghats, including promotion of electric cremation facilities.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #16803C;">
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Kanpur Tannery Pollution</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>Ongoing:</strong> Follow-up orders on MC Mehta v Union of India (tanneries case). Kanpur tanneries directed to install CETP upgrades. Impacts both water and air (VOC/H₂S emissions).</p>
                         </div>
@@ -337,12 +337,12 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Calcutta HC: Vehicular Emission Checks</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Calcutta High Court ordered stricter vehicle pollution checks in Kolkata."><strong>2025:</strong> Directed Transport Department to set up 50 additional PUC-checking stations across Kolkata and strengthen impounding of vehicles without valid PUC certificates.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">NGT: East Kolkata Industrial Emissions</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: East Kolkata Industrial Emissions</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed WBPCB to conduct emission audits of all industries in the East Kolkata industrial belt (Bantala-Kasba) and submit compliance reports within 90 days.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">NGT: Howrah Foundry Cluster</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Howrah Foundry Cluster</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Imposed ₹50 lakh environmental compensation on the Howrah foundry cluster for PM10 exceedances. Directed conversion to induction furnaces within 18 months.</p>
                         </div>
                     </div>
@@ -354,12 +354,12 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">SC: Stubble-Burning Contempt Warning</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court warned Punjab and Haryana that they could face contempt charges if they don't stop farmers from burning crop stubble."><strong>2025:</strong> Supreme Court warned Punjab and Haryana of contempt proceedings for failing to curb paddy-stubble burning. Directed ₹2,500/acre incentive for in-situ management be disbursed before kharif season.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">NGT: Ludhiana Industrial Cluster</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Ludhiana Industrial Cluster</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed PPCB to submit comprehensive action plan for Ludhiana's dyeing and electroplating units. Over 3,000 small-scale units contributing to both air and water pollution.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">Punjab &amp; Haryana HC: Crop Residue Management</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Punjab &amp; Haryana HC: Crop Residue Management</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed state governments to ensure CRM machinery (Happy Seeders, Super SMS) reaches small and marginal farmers. Observed that machines were concentrated with large landholders.</p>
                         </div>
                     </div>
@@ -371,12 +371,12 @@
                             <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Singrauli Super-Thermal Power Cluster</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told power plants in Singrauli to install pollution-control equipment and pay fines for the damage they've already caused."><strong>2024:</strong> Directed all thermal power plants in the Singrauli-Sonbhadra cluster to comply with revised emission norms (SO₂, NOx, PM) by March 2026. Cumulative capacity &gt;20 GW makes this one of India's most polluted zones.</p>
                         </div>
-                        <div class="info-box mb-2" style="border-left: 3px solid #3B82F6;">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">MP HC: Bhopal Construction-Dust Controls</h4>
+                        <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MP HC: Bhopal Construction-Dust Controls</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed Bhopal Municipal Corporation and MPPCB to enforce mandatory dust-suppression measures at all construction sites &gt;500 sq.m, following a citizens' PIL.</p>
                         </div>
-                        <div class="info-box" style="border-left: 3px solid #F59E0B;">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">NGT: Korba Industrial Pollution</h4>
+                        <div class="info-box" style="border-left: 3px solid var(--accent);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Korba Industrial Pollution</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed Chhattisgarh SPCB to conduct health-impact assessment around the Korba coal-mining and thermal-power cluster. Residents reported PM10 levels 4&ndash;5&times; NAAQS during winter months.</p>
                         </div>
                     </div>
@@ -391,23 +391,23 @@
                 <div class="card-body">
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="You have at least five strong laws protecting your right to clean air. Here they are.">Five pillars of law that protect your right to breathe clean air. Know them &mdash; cite them in your complaints.</p>
                     <div class="grid-2" style="gap: 0.75rem;">
-                        <div class="info-box" style="border-left: 4px solid #1B6B4A; background: rgba(27,107,74,0.04);">
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(27,107,74,0.04);">
                             <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Article 21 &mdash; Constitution of India</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The right to life includes the right to breathe clean air. The Supreme Court has said so repeatedly.">Right to life includes the right to clean air. <em>MC Mehta v UoI (1986), Subhash Kumar v State of Bihar (1991).</em></p>
                         </div>
-                        <div class="info-box" style="border-left: 4px solid #3B82F6; background: rgba(59,130,246,0.04);">
-                            <h4 style="font-size: 0.8125rem; color: var(--blue); margin-bottom: 0.25rem;">Air (Prevention &amp; Control of Pollution) Act, 1981</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(59,130,246,0.04);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Air (Prevention &amp; Control of Pollution) Act, 1981</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="This law created CPCB and state pollution boards. Their job is to prevent and control air pollution.">Established CPCB and State Pollution Control Boards (SPCBs). Mandates them to prevent, control, and abate air pollution. <em>Section 31A:</em> binding closure/direction orders.</p>
                         </div>
-                        <div class="info-box" style="border-left: 4px solid #7C3AED; background: rgba(124,58,237,0.04);">
-                            <h4 style="font-size: 0.8125rem; color: var(--purple); margin-bottom: 0.25rem;">Environment (Protection) Act, 1986</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.04);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Environment (Protection) Act, 1986</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="This law lets the central government shut down any polluting factory and set rules for emissions.">Umbrella legislation. Central government can take measures for environmental protection, set emission standards, and order closure of polluting units. <em>Sections 3 &amp; 5.</em></p>
                         </div>
-                        <div class="info-box" style="border-left: 4px solid #D97706; background: rgba(217,119,6,0.04);">
-                            <h4 style="font-size: 0.8125rem; color: var(--amber); margin-bottom: 0.25rem;">National Green Tribunal Act, 2010</h4>
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(217,119,6,0.04);">
+                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">National Green Tribunal Act, 2010</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="India has a special environmental court (NGT) where any person can file a case. No lawyer needed for individual applications. Filing fee is just 1,000 rupees.">Created a dedicated tribunal for environmental disputes. Any person can file an application. Filing fee: ₹1,000 (waived for BPL). No lawyer required for individual applications.</p>
                         </div>
-                        <div class="info-box" style="border-left: 4px solid #EF4444; background: rgba(239,68,68,0.04);">
+                        <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.04);">
                             <h4 style="font-size: 0.8125rem; color: var(--red); margin-bottom: 0.25rem;">Right to Information Act, 2005</h4>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="You have the right to ask the government for any information about pollution data, funds spent, and enforcement actions &mdash; and they must reply within 30 days.">Right to access government data on pollution monitoring, NCAP funds, enforcement actions. Free for BPL; ₹10 otherwise. 30-day response mandate. <a href="#" onclick="showPanel('rti-assistant'); return false;" style="color: var(--red); font-weight: 600;">Use the RTI Assistant &rarr;</a></p>
                         </div>
@@ -416,7 +416,7 @@
             </div>
 
             <!-- WHAT CAN I DO FROM HOME? — CITIZEN RECOURSE -->
-            <div class="card mb-2" style="border-left: 4px solid #7C3AED; background: rgba(124,58,237,0.03);">
+            <div class="card mb-2" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
                 <div class="card-header" style="background: rgba(124,58,237,0.08);">
                     <span class="card-title" style="color: var(--purple);"><span class="si si-sm si-chat-help" style="margin-right: 0.3rem;"></span> What Can I Do from Home? &mdash; Step-by-Step Citizen Recourse</span>
                 </div>
@@ -424,7 +424,7 @@
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1.25rem;" data-simple="You don't need to be a lawyer or go to court. Here are 5 things you can do from your phone or computer to demand clean air.">You do not need to be a lawyer, activist, or expert. Here are five concrete steps any citizen can take from home to demand clean air. Each step is progressively more powerful.</p>
 
                     <!-- Step 1: RTI -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #22C55E; padding: 1rem;">
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #15803D; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 1</span>
                             <h4 style="font-size: 0.9375rem; color: #166534; margin: 0;">File an RTI &mdash; Free, 30-day response guaranteed</h4>
@@ -451,7 +451,7 @@
                     </div>
 
                     <!-- Step 2: CPCB Complaint -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #3B82F6; padding: 1rem;">
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #1D4ED8; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 2</span>
                             <h4 style="font-size: 0.9375rem; color: #1E40AF; margin: 0;">File a Complaint with CPCB</h4>
@@ -460,7 +460,7 @@
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">
                             <strong style="color: var(--ink);">How to file:</strong>
                             <ul style="margin: 0.25rem 0 0 1rem; line-height: 1.7; color: var(--text-2);">
-                                <li>Go to <a href="https://cpcb.nic.in/" target="_blank" rel="noopener" style="color: var(--blue);">cpcb.nic.in</a> &rarr; Grievance / Complaint section</li>
+                                <li>Go to <a href="https://cpcb.nic.in/" target="_blank" rel="noopener" style="color: var(--ink);">cpcb.nic.in</a> &rarr; Grievance / Complaint section</li>
                                 <li>Include: <strong>exact location</strong>, type of violation, date &amp; time, photos/videos if possible</li>
                                 <li>You can also file via the <strong>SAMEER app</strong> (CPCB's official app on Play Store)</li>
                                 <li>Expected response time: <strong>15&ndash;30 days</strong></li>
@@ -470,7 +470,7 @@
                     </div>
 
                     <!-- Step 3: Write to MP/MLA -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #F59E0B; padding: 1rem;">
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #F59E0B; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 3</span>
                             <h4 style="font-size: 0.9375rem; color: #92400E; margin: 0;">Write to Your MP / MLA</h4>
@@ -498,7 +498,7 @@ Yours faithfully,
                     </div>
 
                     <!-- Step 4: Approach NGT -->
-                    <div class="info-box mb-2" style="border-left: 4px solid #7C3AED; padding: 1rem;">
+                    <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #6D28D9; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 4</span>
                             <h4 style="font-size: 0.9375rem; color: #5B21B6; margin: 0;">Approach the National Green Tribunal (NGT)</h4>
@@ -518,7 +518,7 @@ Yours faithfully,
                     </div>
 
                     <!-- Step 5: PIL -->
-                    <div class="info-box" style="border-left: 4px solid #EF4444; padding: 1rem;">
+                    <div class="info-box" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #B91C1C; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 5</span>
                             <h4 style="font-size: 0.9375rem; color: #991B1B; margin: 0;">File a PIL (Public Interest Litigation)</h4>
@@ -546,7 +546,7 @@ Yours faithfully,
                     </div>
 
                     <!-- Encouragement note -->
-                    <div class="alert mt-2" style="background: rgba(34,197,94,0.08); border-left: 4px solid #22C55E; font-size: 0.875rem;">
+                    <div class="alert mt-2" style="background: rgba(34,197,94,0.08); border-left: 4px solid var(--accent); font-size: 0.875rem;">
                         <strong style="color: #166534;">You have more power than you think.</strong> An RTI application costs ₹10 and 15 minutes. A complaint to CPCB costs nothing. A letter to your MP costs a stamp. Start with Step 1 today &mdash; the law is on your side.
                     </div>
                 </div>

--- a/panels/progress.html
+++ b/panels/progress.html
@@ -62,13 +62,13 @@
 
     <!-- TRANSPORT ELECTRIFICATION -->
     <div class="card mb-2">
-        <div class="card-header"><span class="card-title"><span class="si si-sm si-lightning" style="color: var(--blue);"></span> Electric Mobility: India's Strongest Clean Air Story</span></div>
+        <div class="card-header"><span class="card-title"><span class="si si-sm si-lightning" style="color: var(--ink);"></span> Electric Mobility: India's Strongest Clean Air Story</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; line-height: 1.8; color: var(--text-2); margin-bottom: 1.25rem;">This is where the most tangible, independently verifiable progress is happening. Delhi's e-bus fleet has grown from zero to over 4,000 in under three years. The PM-eBus Sewa scheme could transform public transport in 169 cities.</p>
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.25rem;">
                 <div>
-                    <h4 style="color: var(--blue); font-size: 0.9375rem; margin-bottom: 0.75rem;">Delhi: Largest E-Bus Fleet in India</h4>
+                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Delhi: Largest E-Bus Fleet in India</h4>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         <p><strong>4,286 e-buses</strong> operational (last verified count, 9 Feb 2026 &mdash; overtaking Maharashtra's 4,001). CM Rekha Gupta flagged off 500 new buses at Ramlila Maidan.</p>
                         <p style="margin-top: 0.5rem;"><strong>Targets:</strong> 7,500 by end 2026, 14,000 by 2028. Delhi-Panipat interstate e-bus route launched. <em>Mid-year (Q2/Q3 2026) public count expected.</em></p>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
                 <div>
-                    <h4 style="color: var(--blue); font-size: 0.9375rem; margin-bottom: 0.75rem;">National E-Bus Landscape</h4>
+                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">National E-Bus Landscape</h4>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         <p><strong>PM-eBus Sewa:</strong> $2.4 billion scheme for 10,000 e-buses across 169 cities by 2026 (WRI India). Half of eligible cities currently lack any organised bus transport.</p>
                         <p style="margin-top: 0.5rem;"><strong>State leaderboard:</strong> Delhi (4,286), Maharashtra (4,001), Karnataka (1,989), Gujarat (1,041), Telangana (875), UP (874).</p>
@@ -87,8 +87,8 @@
                 </div>
             </div>
 
-            <div class="info-box" style="border-left: 3px solid #3B82F6;">
-                <h4 style="color: var(--blue); font-size: 0.8125rem;">Citizen-led "Double the Bus" campaigns</h4>
+            <div class="info-box" style="border-left: 3px solid var(--accent);">
+                <h4 style="font-size: 0.8125rem">Citizen-led "Double the Bus" campaigns</h4>
                 <p style="font-size: 0.8125rem; color: var(--text-2);">In Mumbai, Pune, and Nagpur, citizen groups have pressured municipal budgets to prioritise bus fleet expansion over new flyovers. Policy Circle documented the campaign in September 2025: an example of how informed citizens can redirect infrastructure spending toward public health outcomes.</p>
             </div>
         </div>
@@ -100,8 +100,8 @@
         <div class="card-body">
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.5rem;">
-                <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                    <h4 style="color: var(--purple); font-size: 0.875rem;">CAQM 27th Full Commission Meeting</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">CAQM 27th Full Commission Meeting</h4>
                     <div style="font-size: 0.75rem; color: var(--text-3);">Feb 20, 2026 (PIB)</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         33 domain experts submitted a meta-analysis of source apportionment studies (2015-2025) to the Supreme Court. Key finding: PM2.5 identified as the dominant pollutant in Delhi's AQI, with secondary particulates (27%), transport (23%), and biomass burning (20%) as top contributors. This is significant because it shifts official focus from PM10 (easier to show improvement) toward PM2.5 (what actually kills people).
@@ -111,8 +111,8 @@
                     </p>
                 </div>
 
-                <div class="info-box" style="border-left: 3px solid #7C3AED;">
-                    <h4 style="color: var(--purple); font-size: 0.875rem;">Year-Round Action Plans (2026)</h4>
+                <div class="info-box" style="border-left: 3px solid var(--accent);">
+                    <h4 style="font-size: 0.875rem">Year-Round Action Plans (2026)</h4>
                     <div style="font-size: 0.75rem; color: var(--text-3);">CAQM / DPCC, Feb 2026</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         For the first time, CAQM and DPCC have shifted from winter-emergency-only response to a year-round pollution mitigation framework. Twelve NCR cities submitted detailed action plans in Feb 2026. Delhi targets a 15% AQI reduction and PM2.5 reduction from 99 to 96 µg/m³.
@@ -154,13 +154,13 @@
         <div class="card-body">
             <div class="grid-2" style="gap: 1.25rem;">
                 <div>
-                    <h4 style="color: var(--amber); font-size: 0.9375rem; margin-bottom: 0.75rem;">Warrior Moms / Clean Air Fund</h4>
+                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Warrior Moms / Clean Air Fund</h4>
                     <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         The "Mera Planet Mera Ghar" campaign trained 1,600 children in Delhi to voice environmental concerns, reaching 6 million citizens. Warrior Moms has become one of India's most effective air quality advocacy networks, successfully pushing for school air purifier commitments in Delhi and air quality audits in schools.
                     </p>
                 </div>
                 <div>
-                    <h4 style="color: var(--amber); font-size: 0.9375rem; margin-bottom: 0.75rem;">RTI as Accountability Tool</h4>
+                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">RTI as Accountability Tool</h4>
                     <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         Citizen RTI applications have forced disclosure of NCAP fund utilisation data, CAQM inspection records, and public comment responses. The PMC study confirming CAQM incorporated public feedback was itself enabled by an RTI application. This right is arguably the single most powerful tool citizens have for clean air accountability.
                     </p>
@@ -168,7 +168,7 @@
             </div>
 
             <div style="margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid var(--border);">
-                <h4 style="color: var(--amber); font-size: 0.9375rem; margin-bottom: 0.75rem;">COVID Lockdown: The Accidental Proof</h4>
+                <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">COVID Lockdown: The Accidental Proof</h4>
                 <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                     April 2020 remains the most powerful data point in India's clean air story. PM2.5 dropped by over 50%. Blue skies were visible in Delhi for weeks. The Himalayas became visible from Punjab plains for the first time in decades. This was not a policy achievement, but it proved something essential: India's air pollution is entirely man-made and entirely reversible. That knowledge fuels every citizen campaign, every RTI filing, every "Double the Bus" rally. The question was never whether clean air is possible. It is whether there is political will.
                 </p>
@@ -188,12 +188,12 @@
                     <h5 style="color: var(--accent); font-size: 0.8125rem;">For advocacy</h5>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Use Varanasi and Bareilly as proof that NCAP targets are achievable. Ask your city why it hasn't matched them.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #3B82F6; padding: 0.75rem;">
-                    <h5 style="color: var(--blue); font-size: 0.8125rem;">For policy</h5>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
+                    <h5 style="font-size: 0.8125rem">For policy</h5>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Cite the CAQM public participation precedent in your submissions. File RTIs on your city's NCAP fund utilisation.</p>
                 </div>
-                <div class="info-box" style="border-left: 3px solid #7C3AED; padding: 0.75rem;">
-                    <h5 style="color: var(--purple); font-size: 0.8125rem;">For journalism</h5>
+                <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
+                    <h5 style="font-size: 0.8125rem">For journalism</h5>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Compare e-bus deployment pace across states. Ask why some cities achieve 70% reductions while others worsen.</p>
                 </div>
             </div>

--- a/panels/resources.html
+++ b/panels/resources.html
@@ -360,7 +360,7 @@
             <!-- NEW v19.0: 2025-26 RESEARCH REPORTS -->
             <div class="card mb-2" data-resource-category="featured data">
                 <div class="card-header">
-                    <span class="card-title" style="color: var(--blue);">
+                    <span class="card-title" style="color: var(--ink);">
                          2025-26 Research Reports
                     </span>
                 </div>
@@ -716,7 +716,7 @@
 
                 <!-- POLICY & LEGAL -->
                 <div class="card" data-resource-category="policy">
-                    <div class="card-header" style="background: rgba(59,130,246,0.08);"><span class="card-title" style="color: var(--blue);"> Policy & Legal</span></div>
+                    <div class="card-header" style="background: rgba(59,130,246,0.08);"><span class="card-title" style="color: var(--ink);"> Policy & Legal</span></div>
                     <div class="card-body resource-list">
                         <div class="resource-card" data-keywords="crea ncap 2025 progress report">
                             <a href="https://energyandcleanair.org/publication/tracing-the-hazy-air-2025-progress-report-on-national-clean-air-programme-ncap/" target="_blank">
@@ -773,7 +773,7 @@
                     <div class="grid-2" style="gap: 1rem;">
                         <!-- HAP & GENDER -->
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--pink); margin-bottom: 0.75rem;"> Household Air Pollution & Gender</h4>
+                            <h4 style="font-size: 0.875rem;  margin-bottom: 0.75rem"> Household Air Pollution & Gender</h4>
                             <div class="resource-card" data-keywords="gbd hap household mortality women solid fuel">
                                 <a href="https://www.stateofglobalair.org/health/hap" target="_blank">
                                     <div class="resource-type">Data Portal <span class="badge badge-danger">KEY</span></div>
@@ -799,7 +799,7 @@
                         
                         <!-- OCCUPATIONAL & CASTE -->
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--amber); margin-bottom: 0.75rem;"> Occupational Exposure & Marginalized Communities</h4>
+                            <h4 style="font-size: 0.875rem;  margin-bottom: 0.75rem"> Occupational Exposure & Marginalized Communities</h4>
                             <div class="resource-card" data-keywords="informal workers pollution exposure street vendors">
                                 <a href="https://www.wiego.org/publications/" target="_blank">
                                     <div class="resource-type">Policy Brief <span class="badge badge-success">PDF</span></div>
@@ -831,7 +831,7 @@
 
             <!-- IMPRI, MCW, ICW & LATEST UPDATES -->
             <div class="card mb-2 card-accent-blue" data-resource-category="policy action">
-                <div class="card-header" style="background: rgba(59,130,246,0.06);"><span class="card-title" style="color: var(--blue);"> Policy Research &amp; Climate Events (2025-26)</span></div>
+                <div class="card-header" style="background: rgba(59,130,246,0.06);"><span class="card-title" style="color: var(--ink);"> Policy Research &amp; Climate Events (2025-26)</span></div>
                 <div class="card-body resource-list">
                     <div class="grid-2" style="gap: 0.75rem;">
                         <div class="resource-card" data-keywords="impri ncap clean air programme policy enforcement">

--- a/panels/source-selector.html
+++ b/panels/source-selector.html
@@ -11,7 +11,7 @@
     <div style="display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 2rem;">
 
         <!-- CPCB CAAQMS Card -->
-        <div class="card" id="source-card-cpcb" style="border-left: 4px solid #059669; transition: opacity 0.3s;">
+        <div class="card" id="source-card-cpcb" style="border-left: 4px solid var(--accent); transition: opacity 0.3s;">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <span class="card-title" style="color: var(--green-600);">CPCB CAAQMS</span>
                 <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; user-select: none;">
@@ -48,9 +48,9 @@
         </div>
 
         <!-- WAQI / aqicn.org Card -->
-        <div class="card" id="source-card-waqi" style="border-left: 4px solid #2563EB; transition: opacity 0.3s;">
+        <div class="card" id="source-card-waqi" style="border-left: 4px solid var(--accent); transition: opacity 0.3s;">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                <span class="card-title" style="color: var(--blue);">WAQI / aqicn.org</span>
+                <span class="card-title" style="color: var(--ink);">WAQI / aqicn.org</span>
                 <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; user-select: none;">
                     <span style="font-size: 0.75rem; font-weight: 600; color: var(--text-3);">Include</span>
                     <span style="position: relative; display: inline-block; width: 44px; height: 24px;">
@@ -65,15 +65,15 @@
             </div>
             <div class="card-body">
                 <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;">
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--blue); font-weight: 600;">Aggregator</span>
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--blue); font-weight: 600;">Hourly</span>
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--blue); font-weight: 600;">Depends on upstream</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--ink); font-weight: 600;">Aggregator</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--ink); font-weight: 600;">Hourly</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(37,99,235,0.08); color: var(--ink); font-weight: 600;">Depends on upstream</span>
                 </div>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="WAQI collects air quality data from government monitors and community sensors around the world. It gives you one API for global data. But it only shows the nearest station, not a city average, and can lag behind CPCB by 1-2 hours."><strong>Instruments:</strong> Surfaces CPCB data + community sensors. Accuracy depends entirely on the upstream source.</p>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Coverage:</strong> Global &mdash; ~12,000 stations worldwide.</p>
                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-top: 0.75rem;">
                     <div style="padding: 0.625rem; background: rgba(37,99,235,0.04); border-radius: 6px; border: 1px solid rgba(37,99,235,0.1);">
-                        <div style="font-size: 0.6875rem; font-weight: 700; color: var(--blue); margin-bottom: 0.25rem;">STRENGTHS</div>
+                        <div style="font-size: 0.6875rem; font-weight: 700; color: var(--ink); margin-bottom: 0.25rem;">STRENGTHS</div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin: 0;">Single API for global comparison. JanVayu&rsquo;s primary data source for live AQI.</p>
                     </div>
                     <div style="padding: 0.625rem; background: rgba(239,68,68,0.04); border-radius: 6px; border: 1px solid rgba(239,68,68,0.1);">
@@ -85,7 +85,7 @@
         </div>
 
         <!-- IQAir Card -->
-        <div class="card" id="source-card-iqair" style="border-left: 4px solid #9333EA; transition: opacity 0.3s;">
+        <div class="card" id="source-card-iqair" style="border-left: 4px solid var(--accent); transition: opacity 0.3s;">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <span class="card-title" style="color: var(--purple);">IQAir</span>
                 <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; user-select: none;">
@@ -122,7 +122,7 @@
         </div>
 
         <!-- Sensor.Community Card -->
-        <div class="card" id="source-card-sensor" style="border-left: 4px solid #D97706; transition: opacity 0.3s;">
+        <div class="card" id="source-card-sensor" style="border-left: 4px solid var(--accent); transition: opacity 0.3s;">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <span class="card-title" style="color: var(--amber);">Sensor.Community</span>
                 <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; user-select: none;">
@@ -162,14 +162,14 @@
     <!-- ═══ Source Impact Simulator ═══ -->
     <h3 style="font-family: var(--serif); font-size: 1.375rem; margin-bottom: 1rem; color: var(--ink);">See How Sources Affect Your AQI</h3>
 
-    <div class="card mb-3" style="border-left: 4px solid #8B5CF6;">
+    <div class="card mb-3" style="border-left: 4px solid var(--accent);">
         <div class="card-header"><span class="card-title">Source Impact Simulator</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Click the button to see how the AQI changes when you turn sources on or off. This shows you why the same city can have different AQI numbers on different websites.">Toggle the sources above, then click Compute to see how different source combinations affect the reported AQI for your city. This demonstrates why the same city can show different numbers on CPCB, WAQI, and IQAir.</p>
 
             <div id="source-selection-summary" style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem;">
                 <span class="source-badge" data-badge="cpcb" style="font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 99px; background: rgba(5,150,105,0.1); color: var(--green-600); font-weight: 600; border: 1px solid rgba(5,150,105,0.2); transition: all 0.2s;">CPCB &#10003;</span>
-                <span class="source-badge" data-badge="waqi" style="font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 99px; background: rgba(37,99,235,0.1); color: var(--blue); font-weight: 600; border: 1px solid rgba(37,99,235,0.2); transition: all 0.2s;">WAQI &#10003;</span>
+                <span class="source-badge" data-badge="waqi" style="font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 99px; background: rgba(37,99,235,0.1); color: var(--ink); font-weight: 600; border: 1px solid rgba(37,99,235,0.2); transition: all 0.2s;">WAQI &#10003;</span>
                 <span class="source-badge" data-badge="iqair" style="font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 99px; background: rgba(147,51,234,0.1); color: var(--purple); font-weight: 600; border: 1px solid rgba(147,51,234,0.2); transition: all 0.2s;">IQAir &#10003;</span>
                 <span class="source-badge" data-badge="sensor" style="font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 99px; background: rgba(217,119,6,0.1); color: var(--amber); font-weight: 600; border: 1px solid rgba(217,119,6,0.2); transition: all 0.2s;">Sensor.Community &#10003;</span>
             </div>
@@ -191,14 +191,14 @@
                         <div style="font-size: 0.75rem; color: var(--text-3); margin-top: 0.25rem;">AQI</div>
                     </div>
                 </div>
-                <div id="source-comparison-explanation" class="info-box" style="background: rgba(139,92,246,0.06); border-left: 3px solid #8B5CF6;">
+                <div id="source-comparison-explanation" class="info-box" style="background: rgba(139,92,246,0.06); border-left: 3px solid var(--accent);">
                 </div>
             </div>
         </div>
     </div>
 
     <!-- ═══ Implications Callout ═══ -->
-    <div class="card" style="border-left: 4px solid #EF4444; background: rgba(239,68,68,0.02);">
+    <div class="card" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.02);">
         <div class="card-header"><span class="card-title" style="color: var(--red);">Why Source Transparency Matters</span></div>
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); line-height: 1.7;" data-simple="When a politician says pollution went down 20%, ask: which monitors said that? Which stations? Over what time? If the station near the highway shows improvement but the station near the school was shut down, the 20% number is meaningless. Always ask which data source is being cited.">This is why source transparency matters. When a politician says &ldquo;AQI improved 20%,&rdquo; ask: which monitors? Which stations? Over what period? A 20% improvement measured by one station near a highway is meaningless if the station near the school was decommissioned.</p>

--- a/panels/voices.html
+++ b/panels/voices.html
@@ -3,7 +3,7 @@
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="What are real people saying about air pollution online? Live posts from Reddit, Twitter, and news, plus hand-picked highlights and important moments.">Live from social media + curated highlights. Auto-updates from Reddit, X/Twitter, and news sources.</p>
 
             <!-- LIVE AUTO-UPDATING SECTION (auto-hidden if zero posts after load) -->
-            <div class="card mb-3" id="voices-live-card" style="border-left: 4px solid #1D9BF0;">
+            <div class="card mb-3" id="voices-live-card" style="border-left: 4px solid var(--accent);">
                 <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                     <span class="card-title" style="color: #1D9BF0;">Latest Social Media Coverage</span>
                     <span style="font-size: 0.7rem; color: var(--text-3);" id="voices-live-time">Loading...</span>
@@ -23,7 +23,7 @@
             <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem; color: var(--ink);">Curated Highlights &amp; Key Moments</h3>
 
                             <!-- June-July 2026 Updates -->
-                            <div class="voice-card" style="border-left: 3px solid #16A34A;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">CAQM &mdash; GRAP Stage-I Revoked as Monsoon Nears</div>
@@ -37,7 +37,7 @@
                                 <div class="voice-meta">29 May 2026 | CAQM GRAP Order Index | caqm.nic.in</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #2563EB;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Monsoon Respite, Not Clean Air</div>
@@ -51,7 +51,7 @@
                                 <div class="voice-meta">July 2026 | IQAir / aqi.in live readings</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">CREA &mdash; Up to 42% of India's PM2.5 Is Made in the Sky</div>
@@ -66,7 +66,7 @@
                             </div>
 
                             <!-- April-May 2026 Updates -->
-                            <div class="voice-card" style="border-left: 3px solid #16A34A;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">CAQM &mdash; First Off-Season GRAP Invocation</div>
@@ -80,7 +80,7 @@
                                 <div class="voice-meta">19 May 2026 | CAQM Order Index | caqm.nic.in</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1B6B4A;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Lancet Countdown 2025 Launch — India Chapter</div>
@@ -94,7 +94,7 @@
                                 <div class="voice-meta">May 2026 | Lancet Countdown 2025 | thelancet.com/countdown-health-climate</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #B91C1C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Loni residents speak after IQAir 2025</div>
@@ -108,7 +108,7 @@
                                 <div class="voice-meta">April 2026 | Down To Earth ground report | downtoearth.org.in</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #16A34A;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Dr. Soumya Swaminathan</div>
@@ -122,7 +122,7 @@
                                 <div class="voice-meta">April 2026 | "Be Cool" launch, Jio World Centre, Mumbai</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #2563EB;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Supreme Court of India</div>
@@ -136,7 +136,7 @@
                                 <div class="voice-meta">April 2026 | Supreme Court hearing | LiveLaw, Bar &amp; Bench</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Bhavreen Kandhari</div>
@@ -150,7 +150,7 @@
                                 <div class="voice-meta">May 2026 | The Quint, X/Twitter | #RightToBreathe</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">CSE NCAP Five-Year Review</div>
@@ -165,7 +165,7 @@
                             </div>
 
                             <!-- March 2026 Updates -->
-                            <div class="voice-card" style="border-left: 3px solid #DC2626;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">DAHRD Coalition</div>
@@ -179,7 +179,7 @@
                                 <div class="voice-meta">Feb 2026 | Global endorsement call | dahrd.org</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Newslaundry Ground Report</div>
@@ -193,7 +193,7 @@
                                 <div class="voice-meta">March 11-12, 2026 | Newslaundry series | Ground-level verification</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #EA580C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Harjeet Singh</div>
@@ -207,7 +207,7 @@
                                 <div class="voice-meta">Jan-Feb 2026 | Bloomberg, Japan Times, multiple outlets</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #2563EB;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Rahul Gandhi</div>
@@ -221,7 +221,7 @@
                                 <div class="voice-meta">Nov 2025 | Widely shared | Business Standard, The Quint</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #059669;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Japan Times / Bloomberg</div>
@@ -235,7 +235,7 @@
                                 <div class="voice-meta">Jan 2, 2026 | Japan Times | Mar 2026 updated</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div>
                                         <div class="voice-name">Oxygen Mask Wedding</div>
@@ -352,7 +352,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -367,7 +367,7 @@
                                 <div class="voice-meta">Nov 9, 2025 | #DelhiPollution trending | Multiple detentions</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -382,7 +382,7 @@
                                 <div class="voice-meta">Nov 2025 | Down To Earth eyewitness account</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -397,7 +397,7 @@
                                 <div class="voice-meta">Nov 9, 2025 | Viral tweet with video</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -414,7 +414,7 @@
                         </div>
 
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -429,7 +429,7 @@
                                 <div class="voice-meta">Nov 9, 2025 | Al Jazeera interview</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -444,7 +444,7 @@
                                 <div class="voice-meta">Nov 2025 | CNN India report</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #FF0000;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #FF0000;">YT</div>
                                     <div>
@@ -474,7 +474,7 @@
                                 <div class="voice-meta">Dec 2024 | 850K views</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #FF4500;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #FF4500;">R</div>
                                     <div>
@@ -505,7 +505,7 @@
                                 <div class="voice-meta">Nov 2025 | Instagram | Millions of views, national news pickup</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #1DA1F2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #1DA1F2;">X</div>
                                     <div>
@@ -520,7 +520,7 @@
                                 <div class="voice-meta">Nov 8, 2025 | X | Picked up by Deccan Herald, The Print, DNA India</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #EF4444;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #EF4444;">CM</div>
                                     <div>
@@ -550,7 +550,7 @@
                                 <div class="voice-meta">Nov 2025 | Instagram Reel | Viral, reported by India Daily</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #FF6B00;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #FF6B00;">BJP</div>
                                     <div>
@@ -565,7 +565,7 @@
                                 <div class="voice-meta">Feb 14, 2026 | ThePrint, multiple outlets | Intra-party embarrassment</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #00AAFF;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #00AAFF;">AAP</div>
                                     <div>
@@ -589,7 +589,7 @@
                 <div class="card-header"><span class="card-title"> International Media Coverage</span></div>
                 <div class="card-body">
                     <div class="grid-3">
-                        <div class="voice-card" style="border-left: 3px solid #1A1A1A;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #1A1A1A;">NYT</div>
                                 <div>
@@ -603,7 +603,7 @@
                             <div class="voice-meta">Nov 2024 | Front page feature</div>
                         </div>
 
-                        <div class="voice-card" style="border-left: 3px solid #BB1919;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #BB1919;">BBC</div>
                                 <div>
@@ -617,7 +617,7 @@
                             <div class="voice-meta">Nov 2024 | Video report: 3M views</div>
                         </div>
 
-                        <div class="voice-card" style="border-left: 3px solid #0080C6;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #0080C6;">WP</div>
                                 <div>
@@ -776,7 +776,7 @@
                     </div>
                     <div class="grid-2">
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #EC4899; background: rgba(236,72,153,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(236,72,153,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #EC4899;"></div>
                                     <div>
@@ -791,7 +791,7 @@
                                 <div class="voice-meta">TERI HAP Study | 2023 | Rural Jharkhand</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #F59E0B;"></div>
                                     <div>
@@ -806,7 +806,7 @@
                                 <div class="voice-meta">Scroll.in | Nov 2024 | Outdoor workers survey</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #7C3AED;"></div>
                                     <div>
@@ -821,7 +821,7 @@
                                 <div class="voice-meta">AICCTU | Dec 2024 | GRAP impact on workers</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #0EA5E9;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #0EA5E9;"></div>
                                     <div>
@@ -853,7 +853,7 @@
                                 <div class="voice-meta">AIW Documentation | 2024 | Ghazipur, Delhi</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #16803C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -868,7 +868,7 @@
                                 <div class="voice-meta">Delhi Police Association | 2024</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #EC4899;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #EC4899;"></div>
                                     <div>
@@ -883,7 +883,7 @@
                                 <div class="voice-meta">Domestic Workers Union | 2024</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #F59E0B;"></div>
                                     <div>
@@ -915,7 +915,7 @@
                                     "Our mortality studies use city-level PM2.5 averages. We never disaggregate by caste, class, occupation. A Dalit sanitation worker in Okhla and a CEO in Golf Links breathe very different air, but our data treats them as 'Delhi residents.' This methodological choice is political."
                                 </div>
                             </div>
-                            <div class="voice-card" style="margin-bottom: 0; border-left: 3px solid #16803C;">
+                            <div class="voice-card" style="margin-bottom: 0; border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -938,7 +938,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #EF4444; background: rgba(239,68,68,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(239,68,68,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: var(--green-700);"></div>
                                     <div>
@@ -954,7 +954,7 @@
                                 <div class="voice-meta">July 2024 | Official Rajya Sabha reply</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #F59E0B;"></div>
                                     <div>
@@ -970,7 +970,7 @@
                             </div>
                         </div>
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #22C55E; background: rgba(34,197,94,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(34,197,94,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16A34A;"></div>
                                     <div>
@@ -986,7 +986,7 @@
                                 <div class="voice-meta">January 2025 | Press Statement</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #3B82F6;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #2563EB;"></div>
                                     <div>
@@ -1017,7 +1017,7 @@
                 </div>
                 <div class="card-body">
                     <div class="grid-2">
-                        <div class="voice-card" style="border-left: 3px solid #0A66C2;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #0A66C2;">LI</div>
                                 <div>
@@ -1047,7 +1047,7 @@
                             <div class="voice-meta">Mar 2025 | Dialogue Earth | #RightToBreathe</div>
                         </div>
 
-                        <div class="voice-card" style="border-left: 3px solid #16803C;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #16803C;">PM</div>
                                 <div>
@@ -1062,7 +1062,7 @@
                             <div class="voice-meta">Nov 2024 | Tree Protection Activist</div>
                         </div>
 
-                        <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                        <div class="voice-card" style="border-left: 3px solid var(--accent);">
                             <div class="voice-header">
                                 <div class="voice-avatar" style="background: #F59E0B;">AK</div>
                                 <div>
@@ -1090,7 +1090,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #16803C; background: rgba(22,128,60,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(22,128,60,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -1105,7 +1105,7 @@
                                 <div class="voice-meta">40 by 2040 Calculator | UrbanEmissions.info</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #EC4899;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #EC4899;"></div>
                                     <div>
@@ -1120,7 +1120,7 @@
                                 <div class="voice-meta">Warrior Moms | Clean air advocacy network</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #2563EB;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #2563EB;"></div>
                                     <div>
@@ -1152,7 +1152,7 @@
                                 <div class="voice-meta">State of Global Air | HAP research</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #F59E0B;"></div>
                                     <div>
@@ -1167,7 +1167,7 @@
                                 <div class="voice-meta">Environmental justice advocacy | 2024</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #16803C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -1182,7 +1182,7 @@
                                 <div class="voice-meta">Gig workers & air pollution | 2025</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #DC2626;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #DC2626;"></div>
                                     <div>
@@ -1197,7 +1197,7 @@
                                 <div class="voice-meta">CREA March 2026 | Oct 2025–Feb 2026 Analysis</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #7C3AED;"></div>
                                     <div>
@@ -1212,7 +1212,7 @@
                                 <div class="voice-meta">Newslaundry March 2026 | Ground-level AQI verification</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #EA580C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #EA580C;"></div>
                                     <div>
@@ -1227,7 +1227,7 @@
                                 <div class="voice-meta">March 8, 2026 | Business Standard</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #0891B2;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #0891B2;"></div>
                                     <div>
@@ -1252,7 +1252,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #16803C; background: rgba(22,128,60,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(22,128,60,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -1267,7 +1267,7 @@
                                 <div class="voice-meta">Lancet 2024 | Global Burden of Disease Study</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #7C3AED;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #7C3AED;"></div>
                                     <div>
@@ -1298,7 +1298,7 @@
                             </div>
                         </div>
                         <div>
-                            <div class="voice-card" style="border-left: 3px solid #0EA5E9; background: rgba(14,165,233,0.03);">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent); background: rgba(14,165,233,0.03);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #0EA5E9;"></div>
                                     <div>
@@ -1313,7 +1313,7 @@
                                 <div class="voice-meta">December 2024 | de Bont et al., Lancet Planetary Health</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #F59E0B;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #F59E0B;"></div>
                                     <div>
@@ -1328,7 +1328,7 @@
                                 <div class="voice-meta">PNAS 2018 | Gold standard for PM2.5 mortality</div>
                             </div>
 
-                            <div class="voice-card" style="border-left: 3px solid #16803C;">
+                            <div class="voice-card" style="border-left: 3px solid var(--accent);">
                                 <div class="voice-header">
                                     <div class="voice-avatar" style="background: #16803C;"></div>
                                     <div>
@@ -1352,17 +1352,17 @@
                 <div class="card-header"><span class="card-title"> Viral Impact</span></div>
                 <div class="card-body">
                     <div class="grid-4">
-                        <div class="stat-card" style="border-left: 3px solid #1DA1F2;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1.25rem;">#DelhiChokes</div>
                             <div class="stat-label">2.3M tweets in 48 hrs</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Peak: Nov 2023</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #E1306C;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1.25rem;">850K+</div>
                             <div class="stat-label">Reels on #DelhiSmog</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Instagram 2024</div>
                         </div>
-                        <div class="stat-card" style="border-left: 3px solid #FF0000;">
+                        <div class="stat-card" style="border-left: 3px solid var(--accent);">
                             <div class="stat-value" style="font-size: 1.25rem;">50M+</div>
                             <div class="stat-label">YouTube views on Delhi AQI</div>
                             <div style="font-size: 0.8125rem; color: var(--text-3);">Nov-Dec 2024</div>

--- a/styles.css
+++ b/styles.css
@@ -725,7 +725,7 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 48px;
-    align-items: center;
+    align-items: start;
 }
 @media (max-width: 768px) {
     .hero-grid { grid-template-columns: 1fr; gap: 32px; }
@@ -937,7 +937,7 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     gap: 8px;
     color: var(--text);
 }
-.card-body { padding: 20px; font-size: 0.9rem; line-height: 1.7; }
+.card-body { padding: 20px; font-size: 0.95rem; line-height: 1.7; }
 .card-footer {
     padding: 12px 20px;
     border-top: 1px solid var(--border-light);

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260683';
+const CACHE_VERSION = 'janvayu-20260684';
 const SHELL_ASSETS = [
   '/',
   '/index.html',

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260684';
+const CACHE_VERSION = 'janvayu-20260685';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Two commits addressing "the whole thing" + your latest feedback.

### v26.6.84 — full colour discipline across all content panels
Extended dashboard colour discipline to the ~20 interior panels (per-category rainbow was the clearest "assembled" tell):
- **82** decorative heading colours → ink (kept brand-green + semantic-red)
- **248** hardcoded-hex card rails → brand accent green
- **45** blue/sky/pink text colours → ink; **6** "Did You Know" stat numbers → ink
- AQI-band amber/purple on real readings preserved (colour now = severity, not decoration)

### v26.6.85 — layout fixes from your feedback
- **Fixed the big gap under the nav.** The hero grid was `align-items: center`, vertically centring the short headline column against the tall data column and pushing the headline ~150px down. Now `align-items: start` — headline sits right under the nav (56px, the intended hero padding).
- **Moved the "How JanVayu works" diagram up** to immediately after the hero.
- Bumped `.card-body` 0.9rem → 0.95rem for projected readability.

## Verification (Chromium)
Dashboard + interior panels de-rainbowed; nav→headline gap 56px (was ~150); diagram in new position; zero page errors; 12/12 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_