### PR TITLE
Quick-nav Research tile + nav Ask dedup + v26.6.88 docs (v26.6.89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.89] - 2026-07-16
+
+### Design — quick-nav completeness + nav dedup
+
+- **Filled the empty quick-nav slot with "Research & Reading"** — a homepage entry into the 29 India-focused peer-reviewed studies (Reading List), so the tool's evidence base is one tap from the dashboard.
+- **Removed the duplicate "Ask JanVayu" button from the top-right nav** — it is already featured as a hero call-to-action; the persistent search icon stays. (Ask JanVayu remains reachable from the My Air nav menu and `/ask/`.)
+
 ## [v26.6.88] - 2026-07-16
 
 ### Design — homepage section headers, mobile diagram, no duplicate tiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.88] - 2026-07-16
+
+### Design — homepage section headers, mobile diagram, no duplicate tiles
+
+- **The homepage now reads as an ordered outline, not one long scroll.** Added a reusable labelled section header (accent eyebrow + Fraunces serif title + one-line intro) between the major dashboard blocks, each separated by a hairline rule: *For you* (what today's air means for you) → *Under the hood* (where every number comes from) → *The bigger picture* (GRAP + national rankings) → *Explore every tool* → *The evidence* (Did You Know).
+- **The "How JanVayu works" diagram is now mobile-friendly.** The wide horizontal flow forced a squished horizontal scroll on phones; added a **portrait, top-to-bottom hand-drawn (`rough.js`, Kalam font) variant** shown below 680px, with the wide version on desktop. Same Excalidraw charm, legible in portrait.
+- **No duplicate tiles.** Walkthrough and Ask JanVayu are now featured in the hero, so their duplicate quick-nav tiles were removed; **Photo Gallery** takes a slot in the grid (it was reachable only from the nav/footer before).
+
+Verified in Chromium over HTTP at 1280px and 390px: section headers render with dividers/eyebrows/serif titles; the diagram toggles horizontal↔vertical at the 680px breakpoint; the mobile vertical diagram is fully legible.
+
 ## [v26.6.87] - 2026-07-16
 
 ### Design — hand-drawn diagram, photo gallery, Share-AQI cleanup

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.88"
+version: "26.6.89"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260688-v88';
+const CACHE_NAME = 'ask-janvayu-20260689-v89';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -4,6 +4,18 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 
 ---
 
+## Phase 5.18: Conference-ready visual refresh (✅ Completed — v26.6.84–88)
+
+A mid-July 2026 design pass to make the platform read as a credible, considered
+tool rather than a hobby project — ahead of a conference presentation slot.
+
+- [x] **Colour discipline** — swept decorative heading/rail/number colours across the dashboard and every panel to a restrained ink + single-accent palette, so data (not chrome) carries the colour. (v26.6.84)
+- [x] **Typography** — self-hosted **Fraunces** as the headline serif (with Kalam for hand-drawn labels); larger, balanced headings and a tightened type scale. Motion: hero rise, scroll-reveal, and panel fades, all `prefers-reduced-motion`-guarded.
+- [x] **Hand-drawn system diagram** — "How JanVayu works" is a genuine Excalidraw-style `rough.js` sketch on its own light "paper", now with a **desktop horizontal** and a **mobile portrait** variant so it stays legible on phones. (v26.6.87–88)
+- [x] **Photo gallery** — "The air, in pictures": 24 openly-licensed documentary photographs (Wikimedia Commons) in a masonry grid + full-screen lightbox with per-image credit and source. (v26.6.87)
+- [x] **Decluttering** — floating Install / Search / Ask buttons moved into the section-nav; the Share-AQI card removed from prime dashboard space. (v26.6.86–87)
+- [x] **Layout & ordering** — a feature walkthrough + Ask CTA fill the hero; the footer rebalanced to three even columns; the dashboard reordered top-to-bottom; **labelled section headers** (eyebrow + serif title) break the homepage into an ordered outline; duplicate quick-nav tiles removed. (v26.6.88)
+
 ## Phase 5.17: Multilingual fix, accessibility & a lighter site (✅ Completed — v26.6.58–71)
 
 A mid-July 2026 platform-quality drop — mostly plumbing, and one significant bug fix.

--- a/index.html
+++ b/index.html
@@ -800,7 +800,6 @@
                 </div>
             </div>
             <div class="nav-actions-right">
-                <button class="nav-cta-btn" onclick="openWidget('askai')">Ask JanVayu</button>
                 <button class="nav-icon-btn" onclick="openWidget('search')" title="Search JanVayu (Ctrl+K)" aria-label="Search JanVayu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg></button>
                 <button class="nav-cta-btn nav-install-btn" id="navInstallBtn" onclick="installJanVayuPWA()" style="display:none;">Install app</button>
             </div>
@@ -1132,6 +1131,10 @@
                     <div class="quick-link" onclick="showPanel('rankings')">
                         <div class="quick-link-icon" style="background: #FEF2F2; color: var(--red);"><span class="si si-bar-chart" style="width:20px;height:20px;"></span></div>
                         <div><h4>City Rankings</h4><p>Cleanest &amp; most polluted &mdash; live, 7-day, 30-day</p></div>
+                    </div>
+                    <div class="quick-link" onclick="showPanel('resources')">
+                        <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-book" style="width:20px;height:20px;"></span></div>
+                        <div><h4>Research &amp; Reading</h4><p>29 India-focused peer-reviewed studies, with citations</p></div>
                     </div>
                 </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.88",
+  "version": "26.6.89",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260688';
+const CACHE_VERSION = 'janvayu-20260689';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
Follow-up to the conference visual refresh, two small design tweaks + the docs.

**Code (v26.6.89):**
- **Filled the empty quick-nav slot** with a "Research & Reading" tile that opens the 29-paper India-focused Reading List — the evidence base is now one tap from the dashboard.
- **Removed the duplicate "Ask JanVayu" button from the top-right nav** — it's already a hero call-to-action. The search icon stays; Ask JanVayu remains in the My Air menu and at `/ask/`.

**Docs:**
- `CHANGELOG.md` — `v26.6.88` and `v26.6.89` entries.
- `docs/wiki/Roadmap.md` — new "Phase 5.18: Conference-ready visual refresh (✅ Completed — v26.6.84–88)".

## Verification
Rendered locally over HTTP at 1280px: the quick-nav last row now shows four aligned tiles (Learning Games · Photo Gallery · City Rankings · Research & Reading); confirmed the Ask button is no longer present in `.nav-actions-right`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce