### PR TITLE
Mobile layout fixes + gallery anchor + Voices/Testimony naming (v26.6.90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.90] - 2026-07-16
+
+### Fixes — mobile layout + gallery anchor + clearer naming
+
+- **Photo Gallery anchor now works.** `#gallery` (and every other lazy-loaded panel's hash) opened nothing because the hash router only recognised inline `tmpl-*` templates; it now also opens any registered lazy panel.
+- **Mobile quick-nav cards** — top-aligned the icon so it no longer floats in the middle of a tall card, and stopped headings breaking mid-word ("Accounta​bility"): the global `body { word-break: break-word }` was splitting labels, now overridden to wrap between words.
+- **Mobile footer** — the link lists were stacking into one very long single column; they now sit two-up with the brand/intro spanning the full width, and the back-to-home button hides once you reach the footer so it never covers a link.
+- **"Citizen Voices" vs "Citizen Testimony"** — renamed to **"Voices Online"** (a curated social-media archive of public reaction) and **"Field Testimony"** (first-person accounts recorded on the ground — 100+ people, 13 languages), so the two are no longer easy to confuse.
+
 ## [v26.6.89] - 2026-07-16
 
 ### Design — quick-nav completeness + nav dedup

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-16"
-version: "26.6.89"
+version: "26.6.90"

--- a/app.js
+++ b/app.js
@@ -1062,6 +1062,10 @@
             const panelContainer = document.getElementById('panel-container');
             // .children only counts element nodes — ignores the placeholder HTML comment
             const hasOpenPanel = !!(panelContainer && panelContainer.children.length > 0);
+            // Hide once the footer is reached so the button never sits on top of
+            // (and blocks taps on) the footer links on mobile.
+            const nearBottom = (window.innerHeight + window.scrollY) >= (document.body.offsetHeight - 140);
+            if (nearBottom) return false;
             return hasOpenPanel || window.scrollY > 320;
         }
         function update() {
@@ -2886,7 +2890,11 @@
             const hash = window.location.hash.replace('#', '');
             if (hash && hash !== 'dashboard') {
                 const tmpl = document.getElementById('tmpl-' + hash);
-                if (tmpl) { showPanel(hash); }
+                // Lazy panels (gallery, voices, resources, …) have no inline
+                // tmpl-* template — they load from an external fragment — so
+                // also accept any registered LAZY_PANELS id here, otherwise a
+                // #gallery-style anchor link silently does nothing.
+                if (tmpl || LAZY_PANELS[hash]) { showPanel(hash); }
             }
         }
         handleHash();

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260689-v89';
+const CACHE_NAME = 'ask-janvayu-20260690-v90';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -674,8 +674,8 @@
                 <button class="mobile-nav-item" data-panel="citizen-action" data-i18n="nav_citizen_action">Citizen Plan</button>
                 <button class="mobile-nav-item" data-panel="rti-assistant" data-i18n="nav_rti_assistant">RTI Assistant</button>
                 <button class="mobile-nav-item" data-panel="legal" data-i18n="nav_legal">Legal Framework</button>
-                <button class="mobile-nav-item" data-panel="voices" data-i18n="nav_voices">Citizen Voices</button>
-                <button class="mobile-nav-item" data-panel="testimony" data-i18n="nav_testimony">Citizen Testimony</button>
+                <button class="mobile-nav-item" data-panel="voices" data-i18n="nav_voices">Voices Online</button>
+                <button class="mobile-nav-item" data-panel="testimony" data-i18n="nav_testimony">Field Testimony</button>
                 <button class="mobile-nav-item" data-panel="workshops" data-i18n="nav_workshops">Workshops</button>
                 <button class="mobile-nav-item" data-panel="games" data-i18n="nav_games">Learning Games</button>
                 <button class="mobile-nav-item" data-panel="migration" data-i18n="nav_migration">Migration &amp; Displacement</button>
@@ -780,8 +780,8 @@
                     <button class="nav-dropdown-link" data-panel="citizen-action" data-i18n="nav_citizen_action">Citizen Plan</button>
                     <button class="nav-dropdown-link" data-panel="rti-assistant" data-i18n="nav_rti_assistant">RTI Assistant</button>
                     <button class="nav-dropdown-link" data-panel="legal" data-i18n="nav_legal">Legal Framework</button>
-                    <button class="nav-dropdown-link" data-panel="voices" data-i18n="nav_voices">Citizen Voices</button>
-                    <button class="nav-dropdown-link" data-panel="testimony" data-i18n="nav_testimony">Citizen Testimony</button>
+                    <button class="nav-dropdown-link" data-panel="voices" data-i18n="nav_voices">Voices Online</button>
+                    <button class="nav-dropdown-link" data-panel="testimony" data-i18n="nav_testimony">Field Testimony</button>
                     <button class="nav-dropdown-link" data-panel="workshops" data-i18n="nav_workshops">Workshops</button>
                     <button class="nav-dropdown-link" data-panel="games" data-i18n="nav_games">Learning Games</button>
                     <button class="nav-dropdown-link" data-panel="migration" data-i18n="nav_migration">Migration &amp; Displacement</button>
@@ -1090,11 +1090,11 @@
                     </div>
                     <div class="quick-link" onclick="showPanel('voices')">
                         <div class="quick-link-icon tools"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_voices_t">Citizen Voices</h4><p data-i18n="ql_voices_d">Public response</p></div>
+                        <div><h4 data-i18n="ql_voices_t">Voices Online</h4><p data-i18n="ql_voices_d">What India is posting about its air &mdash; a curated social-media archive</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('testimony')">
                         <div class="quick-link-icon" style="background: #ECFDF5; color: var(--green-600);"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_testimony_t">Citizen Testimony</h4><p data-i18n="ql_testimony_d">100+ voices, 13 languages</p></div>
+                        <div><h4 data-i18n="ql_testimony_t">Field Testimony</h4><p data-i18n="ql_testimony_d">First-person accounts recorded on the ground &mdash; 100+ people, 13 languages</p></div>
                     </div>
                     <div class="quick-link" onclick="loadPanel('ward-map')">
                         <div class="quick-link-icon" style="background: #ECFEFF; color: #0891B2;"><span class="si si-pin" style="width:20px;height:20px;"></span></div>
@@ -1281,7 +1281,7 @@
     <footer class="site-footer">
         <div class="container">
             <div class="footer-grid">
-                <div>
+                <div class="footer-brand">
                     <div class="footer-title">JanVayu &#2332;&#2344;&#2357;&#2366;&#2351;&#2369;</div>
                     <p class="footer-desc">Independent citizen-led air quality monitoring, health impact analysis, and government accountability tracking for India. Clean air is not a privilege, it is a right.</p>
                     <p class="footer-credits">Part of <strong style="color:rgba(255,255,255,0.7)">AirQuality for Janhit</strong> by <a href="#" onclick="showPanel('about');return false;" style="color:rgba(255,255,255,0.5)">MMSF Fellows, AIPC</a> &mdash; see <a href="#" onclick="showPanel('about');return false;" style="color:rgba(255,255,255,0.5)">Janhit Partners</a>. Data from WAQI, CPCB, WHO, CREA, and <a href="https://urbanemissions.info" target="_blank" style="color:rgba(255,255,255,0.5)">UrbanEmissions.info</a>.</p>
@@ -1482,7 +1482,7 @@
 <template id="tmpl-testimony">
 
             <div class="section-intro" style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: var(--green-700); margin-right: 0.4rem;"></span>Citizen Testimony</h2>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: var(--green-700); margin-right: 0.4rem;"></span>Field Testimony</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 50rem;" data-simple="Real people across India say in their own languages how bad the air is in their city.">On-the-ground voices from across India &mdash; in Hindi, English and a dozen Indian languages &mdash; on what the air crisis feels like where people actually live, breathe and work.</p>
                 <p id="testimony-stat-line" style="font-size: 0.9rem; color: var(--text-2); margin-top: 0.75rem;"></p>
             </div>
@@ -5577,7 +5577,7 @@ const ROLE_CONFIG = {
         panels: [
             { panel: 'budget', title: 'Budget Tracker', desc: 'Follow the money — NCAP spending' },
             { panel: 'corporate', title: 'Industrial Sources', desc: 'Who is polluting and how much' },
-            { panel: 'voices', title: 'Citizen Voices', desc: 'Social media sentiment archive' },
+            { panel: 'voices', title: 'Voices Online', desc: 'Social media sentiment archive' },
             { panel: 'downloads', title: 'Downloads', desc: 'Reports & presentations' },
             { panel: 'resources', title: 'Reading List', desc: 'Verified data sources' },
             { panel: 'social-feed', title: 'Social Media Feed', desc: 'Reddit, Twitter, Instagram, YouTube' }
@@ -5615,7 +5615,7 @@ const ROLE_CONFIG = {
             { panel: 'accountability-brief', title: 'Accountability Brief (AI)', desc: 'Brief your ward councillor' },
             { panel: 'budget', title: 'Budget Tracker', desc: 'Is your city spending its funds?' },
             { panel: 'city-policy', title: 'City Policy Tracker', desc: 'City-wise targets & actions' },
-            { panel: 'voices', title: 'Citizen Voices', desc: 'Join the movement' },
+            { panel: 'voices', title: 'Voices Online', desc: 'Join the movement' },
             { panel: 'policy', title: 'Policy Tracker', desc: 'NCAP targets vs reality' },
             { panel: 'migration', title: 'Migration & Displacement', desc: 'Climate displacement data' }
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.89",
+  "version": "26.6.90",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/voices.html
+++ b/panels/voices.html
@@ -1,5 +1,5 @@
 <div class="section-intro" style="margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border);">
-                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: #1D9BF0; margin-right: 0.4rem;"></span>Citizen Voices &amp; Viral Moments</h2>
+                <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-chat" style="color: #1D9BF0; margin-right: 0.4rem;"></span>Voices Online &mdash; Social Media &amp; Viral Moments</h2>
                 <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="What are real people saying about air pollution online? Live posts from Reddit, Twitter, and news, plus hand-picked highlights and important moments.">Live from social media + curated highlights. Auto-updates from Reddit, X/Twitter, and news sources.</p>
 
             <!-- LIVE AUTO-UPDATING SECTION (auto-hidden if zero posts after load) -->

--- a/styles.css
+++ b/styles.css
@@ -1424,6 +1424,14 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
 .quick-link-icon.tools { background: var(--green-50); }
 .quick-link h4 { font-size: 0.88rem; font-weight: 600; color: var(--text); }
 .quick-link p { font-size: 0.75rem; color: var(--text-3); margin: 0; }
+/* Mobile: in the 2-up tablet/large-phone range the cards get narrow. Top-align
+   the icon (so it doesn't float in the vertical centre of a tall card) and let
+   the heading wrap between words rather than break mid-word — the global
+   body{word-break:break-word} was splitting labels like "Accountability". */
+@media (max-width: 1024px) {
+    .quick-link { align-items: flex-start; gap: 12px; }
+    .quick-link h4, .quick-link p { word-break: normal; overflow-wrap: break-word; hyphens: none; }
+}
 
 /* Result boxes */
 .result-box {
@@ -1550,7 +1558,12 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     gap: 40px;
 }
 @media (max-width: 1000px) { .footer-grid { grid-template-columns: 1fr 1fr; } }
-@media (max-width: 768px) { .footer-grid { grid-template-columns: 1fr; gap: 24px; } }
+/* Keep the footer link lists two-up on phones (they were stacking into one
+   very long single column). The brand/intro cell spans the full width above. */
+@media (max-width: 768px) {
+    .footer-grid { grid-template-columns: 1fr 1fr; gap: 22px 20px; }
+    .footer-brand { grid-column: 1 / -1; }
+}
 .footer-title { font-weight: 600; font-size: 0.85rem; margin-bottom: 14px; color: rgba(255,255,255,0.8); }
 .footer-link { color: rgba(255,255,255,0.62); display: block; padding: 3px 0; font-size: 0.82rem; text-decoration: none; transition: color 0.12s; }
 .footer-link:hover { color: rgba(255,255,255,0.85); text-decoration: none; }
@@ -1610,7 +1623,7 @@ h3 svg, h4 svg { max-width: 20px; max-height: 20px; }
     .stat-strip { grid-template-columns: repeat(2, 1fr); }
     .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
     .table { min-width: 500px; }
-    .footer-grid { grid-template-columns: 1fr; gap: 16px; }
+    .footer-grid { grid-template-columns: 1fr 1fr; gap: 20px 16px; }
     .pull-quote { font-size: 1rem; padding: 1rem; }
     .tool-card { margin-bottom: 1rem; }
     .info-box { padding: 1rem; }
@@ -2582,7 +2595,7 @@ body {
 
     /* Footer: single column */
     .footer { padding: 24px 0; }
-    .footer-grid { grid-template-columns: 1fr; gap: 16px; }
+    .footer-grid { grid-template-columns: 1fr 1fr; gap: 20px 16px; }
     .footer-link { padding: 6px 0; font-size: 0.8rem; }
 
     /* Section intros: readable */

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260689';
+const CACHE_VERSION = 'janvayu-20260690';
 const SHELL_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
Four fixes from mobile testing.

**1. Photo Gallery anchor was broken** — `#gallery` opened nothing. The hash router only recognised inline `tmpl-*` templates, but gallery (and every lazy-loaded panel) has no template — it loads from a fragment. Now the router also opens any registered lazy panel.

**2. Mobile quick-nav cards** — the icon floated in the vertical centre of tall cards, and headings broke mid-word ("Accountability"). The global `body { word-break: break-word }` was splitting labels in the narrow 2-up card column. Now: icon top-aligned, headings wrap between words. (screenshot 1)

**3. Mobile footer** — the link lists stacked into one very long single column. They now sit two-up with the brand/intro spanning full width, and the back-to-home button hides once you reach the footer so it never covers a link. (screenshot 2)

**4. "Citizen Voices" vs "Citizen Testimony"** were too easy to confuse. Renamed to **"Voices Online"** (a curated social-media archive of public reaction) and **"Field Testimony"** (first-person accounts recorded on the ground — 100+ people, 13 languages), across the quick-nav tiles, nav menus, panel headers, and search index.

## Files
- `app.js` — lazy-panel hash routing; back-to-home hides at footer
- `styles.css` — quick-link mobile layout; footer 2-up on phones
- `index.html` / `panels/voices.html` — renamed pair + sharper descriptions
- version bump to 26.6.90

## Verification
Rendered locally over HTTP: quick-nav cards at 720px show top-aligned icons and no mid-word breaks; footer computes to two columns at 390px; navigating to `index.html#gallery` loads the gallery panel; tile labels read "Voices Online" / "Field Testimony".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_