### PR TITLE
Fix stale-cache: version-stamp CSS/JS URLs + no-cache HTML (v26.6.92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.92] - 2026-07-17
+
+### Fix — deploys now appear on the first refresh (no more stale cache)
+
+The service worker serves `styles.css`/`app.js` cache-first, and `index.html` referenced them by unversioned URL — so after a deploy the browser kept showing the old CSS/JS until the SW cache happened to swap, sometimes for a long time.
+
+- **Version-stamped asset URLs** — `index.html` now loads `/styles.css?v=<stamp>` and `/app.js?v=<stamp>`, and the SW precache list matches. Each release changes the URL, so a fresh deploy can never hit a stale cache entry. `bump-version.mjs` rewrites the stamp automatically on every version bump.
+- **No-cache on the HTML entry points** — `/` and `/index.html` are now `max-age=0, must-revalidate` (like `/sw.js` already was), so the new HTML — carrying the new asset stamp — always reaches the browser immediately.
+
+Net effect: one normal refresh after a deploy shows the latest version; no more fully-closing the tab to clear the PWA cache.
+
 ## [v26.6.91] - 2026-07-16
 
 ### Design — five more hand-drawn diagrams (panels + blog)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-07-16"
-version: "26.6.91"
+date-released: "2026-07-17"
+version: "26.6.92"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260691-v91';
+const CACHE_NAME = 'ask-janvayu-20260692-v92';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/styles.css?v=20260692">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1327,7 +1327,7 @@
         </div>
     </footer>
 
-    <script src="/app.js"></script>
+    <script src="/app.js?v=20260692"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,20 @@
     Cache-Control = "public, max-age=0, must-revalidate"
     Service-Worker-Allowed = "/"
 
+# The HTML entry points must always be revalidated so a fresh deploy (and its
+# version-stamped CSS/JS URLs) reaches the browser immediately — never served
+# from a stale HTTP cache. The version-stamped assets themselves are safe to
+# cache for a long time because each release changes their URL.
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
 # Redirect non-www to www (canonical domain)
 [[redirects]]
   from = "https://janvayu.in/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.91",
+  "version": "26.6.92",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -113,14 +113,39 @@ console.log(`Version: ${version}  Date: ${isoDate}  Stamp: ${dateStamp}`);
   const file = 'sw.js';
   let content = readFile(file);
 
-  const updated = content.replace(
+  let updated = content.replace(
     /const CACHE_VERSION\s*=\s*'janvayu-[^']*'/,
     `const CACHE_VERSION = 'janvayu-${dateStamp}'`
   );
+  // Keep the precached shell URLs version-stamped so they match the versioned
+  // <link>/<script> requests from index.html (cache-busting; see section 5).
+  updated = updated
+    .replace(/'\/styles\.css(?:\?v=\d+)?'/, `'/styles.css?v=${dateStamp}'`)
+    .replace(/'\/app\.js(?:\?v=\d+)?'/, `'/app.js?v=${dateStamp}'`);
 
   if (updated !== content) {
     writeFile(file, updated);
-    console.log(`${file}: CACHE_VERSION = 'janvayu-${dateStamp}'`);
+    console.log(`${file}: CACHE_VERSION = 'janvayu-${dateStamp}' + stamped shell assets`);
+  } else {
+    console.log(`${file}: already up to date`);
+  }
+}
+
+// --- 5. Version-stamp the CSS/JS URLs in index.html ------------------------
+// The service worker serves same-origin CSS/JS cache-first, so an unversioned
+// /styles.css would keep being served from the old cache after a deploy. Adding
+// ?v=<stamp> makes every release request a *new* URL that cannot hit a stale
+// cache entry — index.html itself is network-first, so the new HTML (with the
+// new stamp) always reaches the browser, and the fresh assets follow.
+{
+  const file = 'index.html';
+  let content = readFile(file);
+  const updated = content
+    .replace(/href="\/styles\.css(?:\?v=\d+)?"/, `href="/styles.css?v=${dateStamp}"`)
+    .replace(/src="\/app\.js(?:\?v=\d+)?"/, `src="/app.js?v=${dateStamp}"`);
+  if (updated !== content) {
+    writeFile(file, updated);
+    console.log(`${file}: styles.css + app.js stamped ?v=${dateStamp}`);
   } else {
     console.log(`${file}: already up to date`);
   }

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260691';
+const CACHE_VERSION = 'janvayu-20260692';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css',
-  '/app.js',
+  '/styles.css?v=20260692',
+  '/app.js?v=20260692',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Fixes the recurring "the site is behind on my phone" problem.

## Root cause
The service worker serves same-origin `styles.css`/`app.js` **cache-first**, and `index.html` referenced them by **unversioned** URL. So after a deploy the browser kept serving the old CSS/JS from the SW cache until the cache happened to swap — sometimes for a long time, needing a full tab close to clear.

## Fix
- **Version-stamped asset URLs** — `index.html` now loads `/styles.css?v=<stamp>` and `/app.js?v=<stamp>`, and the SW precache list (`SHELL_ASSETS`) matches. Each release changes the URL, so a fresh deploy can never hit a stale cache entry. `scripts/bump-version.mjs` rewrites the stamp automatically on every bump (kept in sync with `CACHE_VERSION`).
- **No-cache on the HTML entry points** — added `Cache-Control: max-age=0, must-revalidate` for `/` and `/index.html` in `netlify.toml` (matching what `/sw.js` already had), so the new HTML — carrying the new asset stamp — always reaches the browser immediately.

Net effect: **one normal refresh after a deploy shows the latest version** — no more fully closing the tab to clear the PWA cache. The stamped assets themselves remain long-cacheable because their URL changes each release.

## Verification
Bumped to 26.6.92 and confirmed `index.html`, `sw.js` `SHELL_ASSETS`, and `CACHE_VERSION` all carry `20260692`; `/styles.css?v=20260692` and `/app.js?v=20260692` resolve 200 (query strings are ignored by static hosting, so the file is served normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_