### PR TITLE
CI: auto-open PR for the weekly fact-check branch

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -7,7 +7,7 @@ name: Accessibility Audit (axe)
 
 on:
   push:
-    branches: [main]
+    branches: [main, claude/weekly-factcheck]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/auto-pr-factcheck.yml
+++ b/.github/workflows/auto-pr-factcheck.yml
@@ -1,0 +1,34 @@
+name: Auto-PR weekly fact-check
+
+# When the weekly fact-check routine pushes its branch, open (or update) a PR to
+# main automatically, so guaranteed PR creation does not depend on the scheduled
+# session holding GitHub connector tools. CI runs on the branch push (see the
+# push trigger added to ci.yml / accessibility.yml), so the checks appear on the
+# PR by commit SHA. A human still reviews and merges — this never auto-merges.
+on:
+  push:
+    branches: [claude/weekly-factcheck]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open or update the weekly fact-check PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --head claude/weekly-factcheck --base main --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "PR #$existing is already open for claude/weekly-factcheck; this push updates it."
+            exit 0
+          fi
+          gh pr create \
+            --base main \
+            --head claude/weekly-factcheck \
+            --title "Weekly fact-check — $(date -u +%Y-%m-%d)" \
+            --body "Automated weekly fact-check. The routine web-verified the site's statistics and calculator constants against current primary sources and applied the verified corrections. See \`docs/fact-check-*.md\` (newest) for the findings table. **Please review the diff and CI before merging — this PR is never auto-merged.**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, claude/weekly-factcheck]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,7 +6,7 @@ name: Code Quality (HTML + JS)
 
 on:
   push:
-    branches: [main]
+    branches: [main, claude/weekly-factcheck]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Makes the **weekly fact-check routine** produce a PR automatically, without depending on the scheduled session holding GitHub connector tools (it can `git push` but can't open a PR itself).

- **`.github/workflows/auto-pr-factcheck.yml`** — on push to `claude/weekly-factcheck`, opens (or, if one is already open, updates) a PR to `main` using the built-in `GITHUB_TOKEN`. It never auto-merges — a human reviews and merges.
- **Push trigger on `claude/weekly-factcheck`** added to `ci.yml`, `accessibility.yml`, `quality.yml` — because a PR opened by `GITHUB_TOKEN` does not retrigger `pull_request` workflows, the checks instead run on the branch **push** and surface on the PR by commit SHA. Netlify's deploy-preview checks run via its own GitHub App and are unaffected.

## One-time repo setting required
For `GITHUB_TOKEN` to open PRs, enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests."** Without it the action fails with a permissions error. (This is the only manual step, and it avoids needing a personal access token.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_