### PR TITLE
Team page: add Komal's LinkedIn

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.98"
+version: "26.6.99"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260698-v98';
+const CACHE_NAME = 'ask-janvayu-20260699-v99';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=20260698">
+    <link rel="stylesheet" href="/styles.css?v=20260699">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1333,7 +1333,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=20260698"></script>
+    <script src="/app.js?v=20260699"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.98",
+  "version": "26.6.99",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/team.html
+++ b/panels/team.html
@@ -42,7 +42,7 @@
     <span class="team-role">Testing &amp; Feedback</span>
     <p class="team-bio">Puts every new feature through its paces before it ships &mdash; the reason JanVayu works across devices, languages, and real-world use. <em>(Placeholder bio &mdash; edit me.)</em></p>
     <div class="team-links">
-      <a href="#" onclick="return false;" aria-disabled="true">Notes</a>
+      <a href="https://www.linkedin.com/in/komaldaal" target="_blank" rel="noopener">LinkedIn</a>
     </div>
   </article>
 

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260698';
+const CACHE_VERSION = 'janvayu-20260699';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=20260698',
-  '/app.js?v=20260698',
+  '/styles.css?v=20260699',
+  '/app.js?v=20260699',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Replaces the placeholder "Notes" link on Komal's team card with her LinkedIn profile. Version 26.6.99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_