### PR TITLE
Source-apportionment ring panel

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.99"
+version: "26.6.100"

--- a/app.js
+++ b/app.js
@@ -1121,7 +1121,7 @@
 
     // Panels whose (large) markup lives in an external fragment, fetched on first
     // open instead of being inlined + parsed on every page load. Cached after first use.
-    const LAZY_PANELS = { voices: '/panels/voices.html', resources: '/panels/resources.html', legal: '/panels/legal.html', about: '/panels/about.html' , accountability: '/panels/accountability.html', actions: '/panels/actions.html', 'source-selector': '/panels/source-selector.html', 'aqi-explainer': '/panels/aqi-explainer.html', budget: '/panels/budget.html', progress: '/panels/progress.html', 'citizen-action': '/panels/citizen-action.html', economic: '/panels/economic.html', gallery: '/panels/gallery.html', faq: '/panels/faq.html', team: '/panels/team.html' };
+    const LAZY_PANELS = { voices: '/panels/voices.html', resources: '/panels/resources.html', legal: '/panels/legal.html', about: '/panels/about.html' , accountability: '/panels/accountability.html', actions: '/panels/actions.html', 'source-selector': '/panels/source-selector.html', 'aqi-explainer': '/panels/aqi-explainer.html', budget: '/panels/budget.html', progress: '/panels/progress.html', 'citizen-action': '/panels/citizen-action.html', economic: '/panels/economic.html', gallery: '/panels/gallery.html', faq: '/panels/faq.html', team: '/panels/team.html', apportionment: '/panels/apportionment.html' };
     const __panelFragmentCache = {};
     function fetchPanelFragment(panelId) {
         if (__panelFragmentCache[panelId] !== undefined) return Promise.resolve(__panelFragmentCache[panelId]);
@@ -1190,6 +1190,7 @@
                 if (panelId === 'ward-map') { try { window.initWardMap && window.initWardMap(); } catch(e) { console.warn('Ward map init:', e); } }
                 if (panelId === 'forecast') { try { initForecastPanel(); } catch(e) { console.warn('Forecast init:', e); } }
                 if (panelId === 'fire-tracker') { try { initFireTracker(); } catch(e) { console.warn('Fire tracker init:', e); } }
+                if (panelId === 'apportionment') { try { window.initApportionment && window.initApportionment(); } catch(e) { console.warn('Apportionment init:', e); } }
             }, 150);
     }
 
@@ -3153,6 +3154,110 @@
     }
     window.initFireTracker = initFireTracker;
     window.loadFires = loadFires;
+
+    // ── Source apportionment ring: where a city's PM2.5 comes from ──
+    let apportionData = null;
+    let apportionChart = null;
+    const APPORTION_BUCKETS = [
+        { key: 'transport',          label: 'Transport',          color: '#EA580C' },
+        { key: 'industry',           label: 'Industry',           color: '#7C3AED' },
+        { key: 'residential_biomass',label: 'Biomass & burning',  color: '#CA8A04' },
+        { key: 'dust_construction',  label: 'Dust & construction',color: '#A16207' },
+        { key: 'power',              label: 'Power',              color: '#0891B2' },
+        { key: 'other',              label: 'Other (secondary, transboundary)', color: '#64748B' }
+    ];
+    window.initApportionment = async function initApportionment() {
+        const sel = document.getElementById('apportion-city');
+        if (!sel) return;
+        if (!apportionData) {
+            try {
+                const r = await fetch('/data/apportionment.json');
+                apportionData = await r.json();
+            } catch (e) {
+                const legend = document.getElementById('apportion-legend');
+                if (legend) legend.innerHTML = '<p style="color:var(--text-3);">Apportionment data could not load. Please refresh.</p>';
+                return;
+            }
+        }
+        if (sel.options.length === 0) {
+            apportionData.cities.forEach(function (c) {
+                const opt = document.createElement('option');
+                opt.value = c.key; opt.textContent = c.name;
+                sel.appendChild(opt);
+            });
+            sel.value = 'delhi';
+            sel.onchange = function () { window.renderApportionRing(sel.value); };
+        }
+        try { await ensureChartJs(); } catch (e) {
+            const legend = document.getElementById('apportion-legend');
+            if (legend) legend.innerHTML = '<p style="color:var(--text-3);">Chart library could not load.</p>';
+            return;
+        }
+        window.renderApportionRing(sel.value || 'delhi');
+    };
+    window.renderApportionRing = function renderApportionRing(cityKey) {
+        if (!apportionData) return;
+        const c = apportionData.cities.find(function (x) { return x.key === cityKey; });
+        if (!c) return;
+        const canvas = document.getElementById('apportionRing');
+        const legend = document.getElementById('apportion-legend');
+        const basisEl = document.getElementById('apportion-basis');
+        const sourceEl = document.getElementById('apportion-source');
+        const centerEl = document.getElementById('apportion-center');
+        if (!canvas) return;
+
+        const rows = APPORTION_BUCKETS
+            .map(function (b) { return { b: b, val: c.shares[b.key] || 0 }; })
+            .filter(function (r) { return r.val > 0; })
+            .sort(function (a, b) { return b.val - a.val; });
+
+        if (basisEl) basisEl.textContent = c.basis;
+        if (centerEl && rows.length) {
+            centerEl.innerHTML = '<span class="apportion-center-pct">' + Math.round(rows[0].val) + '%</span>' +
+                '<span class="apportion-center-lbl">' + rows[0].b.label + '</span>';
+        }
+
+        if (legend) {
+            legend.innerHTML = rows.map(function (r) {
+                return '<div class="apportion-row">' +
+                    '<span class="apportion-swatch" style="background:' + r.b.color + ';"></span>' +
+                    '<span class="apportion-rowlabel">' + r.b.label + '</span>' +
+                    '<span class="apportion-rowbar"><span class="apportion-rowbar-fill" style="width:' + Math.min(100, r.val) + '%;background:' + r.b.color + ';"></span></span>' +
+                    '<span class="apportion-rowval">' + (Math.round(r.val * 10) / 10) + '%</span>' +
+                    '</div>';
+            }).join('');
+        }
+
+        if (sourceEl) {
+            const conf = c.confidence ? (c.confidence.charAt(0).toUpperCase() + c.confidence.slice(1)) : '';
+            sourceEl.innerHTML = '<p class="apportion-src-line"><strong>Source:</strong> ' + escapeHtml(c.source) +
+                (c.year ? ' (' + escapeHtml(c.year) + ')' : '') + ' &middot; ' + escapeHtml(c.basis) +
+                (conf ? ' &middot; confidence: ' + conf : '') + '</p>' +
+                '<p class="apportion-caveat">' + escapeHtml(c.caveat || '') + '</p>';
+        }
+
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        if (apportionChart) { try { apportionChart.destroy(); } catch (e) {} apportionChart = null; }
+        apportionChart = new Chart(canvas.getContext('2d'), {
+            type: 'doughnut',
+            data: {
+                labels: rows.map(function (r) { return r.b.label; }),
+                datasets: [{
+                    data: rows.map(function (r) { return r.val; }),
+                    backgroundColor: rows.map(function (r) { return r.b.color; }),
+                    borderColor: isDark ? '#0f172a' : '#ffffff',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true, maintainAspectRatio: false, cutout: '62%',
+                plugins: {
+                    legend: { display: false },
+                    tooltip: { callbacks: { label: function (ctx) { return ctx.label + ': ' + (Math.round(ctx.parsed * 10) / 10) + '%'; } } }
+                }
+            }
+        });
+    };
 
     function updateMapMarkers() {
             if (!map || !mapMarkerLayer) return;

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-20260699-v99';
+const CACHE_NAME = 'ask-janvayu-202606100-v100';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/data/apportionment.json
+++ b/data/apportionment.json
@@ -1,0 +1,224 @@
+{
+  "meta": {
+    "updated": "2026-07",
+    "note": "Percentages are contributions to ambient PM2.5. Source-apportionment studies differ by method (receptor model vs emission inventory), season, and year — so cross-city comparison is indicative, not exact. Each city names its own study."
+  },
+  "cities": [
+    {
+      "key": "delhi",
+      "name": "Delhi",
+      "shares": {
+        "transport": 28,
+        "industry": 30,
+        "residential_biomass": 14,
+        "dust_construction": 17,
+        "power": 0,
+        "other": 11
+      },
+      "source": "ARAI & TERI (Dept. of Heavy Industry)",
+      "source_full": "The Automotive Research Association of India (ARAI) & The Energy and Resources Institute (TERI), 'Source Apportionment of PM2.5 & PM10 Concentrations of Delhi NCR for Identification of Major Sources' — prepared for Dept. of Heavy Industry, Govt. of India (Executive Summary, Table E.2, dispersion-modelling ambient shares for Delhi city)",
+      "year": "2018",
+      "basis": "Dispersion model · winter",
+      "caveat": "Power-sector emissions are counted within \"industry\". Stubble-burning is under-counted (the study window missed the October peak).",
+      "confidence": "high"
+    },
+    {
+      "key": "mumbai",
+      "name": "Mumbai",
+      "shares": {
+        "transport": 19.1,
+        "industry": 53.5,
+        "residential_biomass": 7.3,
+        "dust_construction": 14.2,
+        "power": 5.8,
+        "other": 0
+      },
+      "source": "UrbanEmissions.info (APnA)",
+      "source_full": "UrbanEmissions.Info — Air Quality Analysis for Mumbai (Bombay)-Thane, India (APnA City Program), PM2.5 sector emissions inventory modelled via CAMx",
+      "year": "2018",
+      "basis": "Emission inventory · annual",
+      "caveat": "Emission-inventory split (primary PM2.5), so secondary aerosol and long-range transport are not broken out.",
+      "confidence": "medium"
+    },
+    {
+      "key": "kolkata",
+      "name": "Kolkata",
+      "shares": {
+        "transport": 23.6,
+        "industry": 7.7,
+        "residential_biomass": 40.1,
+        "dust_construction": 28,
+        "power": 0.7,
+        "other": 0
+      },
+      "source": "CSIR-NEERI (WBPCB)",
+      "source_full": "CSIR-NEERI, \"PM10 and PM2.5 Source Apportionment Study and Development of Emission Inventory of Twin Cities Kolkata and Howrah of West Bengal\" (Final Report, Table 3.17 PM2.5 emissions by sector), commissioned by West Bengal Pollution Control Board (WBPCB)",
+      "year": "2020",
+      "basis": "Emission inventory · annual",
+      "caveat": "Emission inventory: secondary aerosol and transboundary transport not captured. The study's receptor model puts secondary aerosol at 20–32%.",
+      "confidence": "high"
+    },
+    {
+      "key": "chennai",
+      "name": "Chennai",
+      "shares": {
+        "transport": 24.5,
+        "industry": 15.9,
+        "residential_biomass": 19.1,
+        "dust_construction": 23.5,
+        "power": 1.6,
+        "other": 15.4
+      },
+      "source": "UrbanEmissions.info (Guttikunda et al.)",
+      "source_full": "Guttikunda, S.K., Nishadh, K.A., Jawahar, P. — \"Air pollution knowledge assessments (APnA) for 20 Indian cities\", Table 9 (annual-average WRF-CAMx modeled source contributions to PM2.5, Chennai), UrbanEmissions.info APnA City Program",
+      "year": "2019",
+      "basis": "Dispersion model · annual",
+      "caveat": "\"Other\" (~15%) is mostly regional/transboundary transport into this coastal airshed; power is inside \"industry\".",
+      "confidence": "high"
+    },
+    {
+      "key": "bengaluru",
+      "name": "Bengaluru",
+      "shares": {
+        "transport": 40,
+        "industry": 6,
+        "residential_biomass": 4,
+        "dust_construction": 26,
+        "power": 1,
+        "other": 23
+      },
+      "source": "CSTEP (KSPCB / NCAP)",
+      "source_full": "CSTEP (Center for Study of Science, Technology and Policy), \"Source Apportionment Study for Bengaluru\" (CSTEP-RR-2022-05), authored by Dr Pratima Singh and Dr Vignesh Prabhu, commissioned under KSPCB / NCAP, supported by Shakti Sustainable Energy Foundation and Bloomberg Philanthropies",
+      "year": "2022",
+      "basis": "Receptor model (CMB) · annual",
+      "caveat": "\"Other\" (~23%) is chiefly secondary aerosol plus unexplained mass, typical of receptor models.",
+      "confidence": "high"
+    },
+    {
+      "key": "hyderabad",
+      "name": "Hyderabad",
+      "shares": {
+        "transport": 20.8,
+        "industry": 33.4,
+        "residential_biomass": 13.3,
+        "dust_construction": 26.3,
+        "power": 6,
+        "other": 0.2
+      },
+      "source": "UrbanEmissions.info (APnA)",
+      "source_full": "UrbanEmissions.info APnA (Air Pollution knowledge Assessment) city program — Hyderabad gridded emissions inventory (Guttikunda / SIM-air, CAMx-based analysis)",
+      "year": "2018",
+      "basis": "Emission inventory · annual",
+      "caveat": "Local emission inventory only — excludes secondary formation and long-range transport.",
+      "confidence": "medium"
+    },
+    {
+      "key": "pune",
+      "name": "Pune",
+      "shares": {
+        "transport": 30,
+        "industry": 20,
+        "residential_biomass": 3,
+        "dust_construction": 47,
+        "power": 0,
+        "other": 0
+      },
+      "source": "MPCB (CPCB / NCAP)",
+      "source_full": "Air Quality Assessment, Emission Inventory & Source Apportionment Study Report for Pune City (Pune SA&EI Report, R3), Maharashtra Pollution Control Board (MPCB) under CPCB / NCAP",
+      "year": "2021",
+      "basis": "Emission inventory · annual",
+      "caveat": "Emission-inventory split; road dust dominates the primary-emission share. Secondary aerosol not separated.",
+      "confidence": "medium"
+    },
+    {
+      "key": "ahmedabad",
+      "name": "Ahmedabad",
+      "shares": {
+        "transport": 11,
+        "industry": 67,
+        "residential_biomass": 6,
+        "dust_construction": 12,
+        "power": 4,
+        "other": 0
+      },
+      "source": "UrbanEmissions.info (APnA)",
+      "source_full": "UrbanEmissions.Info — Air Quality Analysis for Ahmedabad, India (APNA city program): gridded emissions inventory + WRF-CAMx chemical transport modeling, by S. Guttikunda et al.",
+      "year": "2018",
+      "basis": "Emission inventory · annual",
+      "caveat": "Local emission inventory; industry share reflects a heavy industrial base. Secondary/transboundary not broken out.",
+      "confidence": "medium"
+    },
+    {
+      "key": "kanpur",
+      "name": "Kanpur",
+      "shares": {
+        "transport": 17.4,
+        "industry": 14.3,
+        "residential_biomass": 17.3,
+        "dust_construction": 21.9,
+        "power": 0,
+        "other": 29.1
+      },
+      "source": "IIT Kanpur (CPCB / UPPCB, NCAP)",
+      "source_full": "Sharma M. (IIT Kanpur), \"Air Quality Assessment, Trend Analysis, Emission Inventory and Source Apportionment Study in Kanpur City\" - report to CPCB / Uttar Pradesh Pollution Control Board under NCAP; CMB receptor modelling in two seasons (winter/summer)",
+      "year": "2022",
+      "basis": "Receptor model (CMB) · seasonal avg",
+      "caveat": "Winter+summer receptor splits averaged to approximate an annual figure. \"Other\" includes secondary aerosol.",
+      "confidence": "medium"
+    },
+    {
+      "key": "lucknow",
+      "name": "Lucknow",
+      "shares": {
+        "transport": 16.6,
+        "industry": 29.7,
+        "residential_biomass": 29,
+        "dust_construction": 20.4,
+        "power": 4.2,
+        "other": 0
+      },
+      "source": "UrbanEmissions.info (APnA)",
+      "source_full": "UrbanEmissions.info — APnA (Air Pollution knowledge Assessments) city program, 'Air Quality Analysis for Lucknow, India' (gridded emissions inventory + WRF meteorology + CAMx chemical transport model)",
+      "year": "2018",
+      "basis": "Emission inventory · annual",
+      "caveat": "Primary-emission inventory only; secondary aerosol and transboundary transport excluded.",
+      "confidence": "medium"
+    },
+    {
+      "key": "patna",
+      "name": "Patna",
+      "shares": {
+        "transport": 18,
+        "industry": 10,
+        "residential_biomass": 26,
+        "dust_construction": 5,
+        "power": 4,
+        "other": 37
+      },
+      "source": "TERI (BSPCB / ADRI)",
+      "source_full": "TERI, \"Receptor Modelling Based Source Apportionment Study of Ambient Particulate Matter in Patna City, Bihar\" (Chemical Mass Balance receptor model; with BSPCB and ADRI, funded by Bloomberg Philanthropies)",
+      "year": "2021",
+      "basis": "Receptor model (CMB) · winter",
+      "caveat": "Winter receptor split (Delhi-like season). \"Other\" (~37%) is largely secondary aerosol and unresolved mass.",
+      "confidence": "high"
+    },
+    {
+      "key": "jaipur",
+      "name": "Jaipur",
+      "shares": {
+        "transport": 16,
+        "industry": 0,
+        "residential_biomass": 38,
+        "dust_construction": 27,
+        "power": 3,
+        "other": 16
+      },
+      "source": "IIT Kanpur (RPCB)",
+      "source_full": "IIT Kanpur, \"Air Quality Assessment, Trend Analysis, Emission Inventory and Source Apportionment Study in Jaipur City\" (receptor CMB modelling), prepared for the Rajasthan State Pollution Control Board (RPCB)",
+      "year": "2020",
+      "basis": "Receptor model (CMB) · seasonal avg",
+      "caveat": "Winter+summer receptor splits averaged. Soil/road dust is large in this arid region; \"other\" is secondary aerosol.",
+      "confidence": "medium"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=20260699">
+    <link rel="stylesheet" href="/styles.css?v=202606100">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -651,6 +651,7 @@
             <div class="mobile-nav-group">
                 <div class="mobile-nav-group-label" data-i18n="navgroup_learn">Learn</div>
                 <button class="mobile-nav-item" data-panel="aqi-explainer" data-i18n="nav_aqi_explainer">Understanding AQI</button>
+                <button class="mobile-nav-item" data-panel="apportionment" data-i18n="nav_apportionment">Where PM2.5 Comes From</button>
                 <button class="mobile-nav-item" data-panel="source-selector" data-i18n="nav_source_selector">Data Source Selector</button>
                 <button class="mobile-nav-item" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
                 <button class="mobile-nav-item" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
@@ -755,6 +756,7 @@
                 <button class="nav-link" data-panel="aqi-explainer" data-i18n="nav_learn">Learn <span class="nav-caret"></span></button>
                 <div class="nav-dropdown">
                     <button class="nav-dropdown-link" data-panel="aqi-explainer" data-i18n="nav_aqi_explainer">Understanding AQI</button>
+                    <button class="nav-dropdown-link" data-panel="apportionment" data-i18n="nav_apportionment">Where PM2.5 Comes From</button>
                     <button class="nav-dropdown-link" data-panel="source-selector" data-i18n="nav_source_selector">Data Source Selector</button>
                     <button class="nav-dropdown-link" data-panel="correlations" data-i18n="nav_correlations">Pollution Correlations</button>
                     <button class="nav-dropdown-link" data-panel="glossary" data-i18n="nav_glossary">Glossary</button>
@@ -1333,7 +1335,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=20260699"></script>
+    <script src="/app.js?v=202606100"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.99",
+  "version": "26.6.100",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/apportionment.html
+++ b/panels/apportionment.html
@@ -1,0 +1,34 @@
+<div class="section-intro" style="margin-bottom: 1.5rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border);">
+    <h2 style="font-family: var(--serif); font-size: clamp(1.5rem, 3vw, 2.25rem); line-height: 1.2; margin-bottom: 0.75rem; color: var(--ink);"><span class="si si-pie-chart" style="color: var(--green-700); margin-right: 0.4rem;"></span>Where your city's PM2.5 comes from</h2>
+    <p style="font-size: 1.0625rem; line-height: 1.7; color: var(--text-2); max-width: 48rem;" data-simple="Different things pollute the air in different cities — vehicles, industry, cooking fires, dust. This shows the mix for your city, from the best study we could find.">Cleaning the air means knowing what's dirtying it. This ring shows the share of fine-particle (PM2.5) pollution from each major source in a city &mdash; drawn from the most credible source-apportionment study we could find for that city. Pick a city to see its mix.</p>
+</div>
+
+<div class="apportion-controls">
+    <label for="apportion-city" class="apportion-label">City</label>
+    <select id="apportion-city" class="apportion-select" aria-label="Choose a city"></select>
+    <span id="apportion-basis" class="apportion-basis"></span>
+</div>
+
+<div class="apportion-layout">
+    <div class="apportion-ringwrap">
+        <canvas id="apportionRing" role="img" aria-label="Source apportionment doughnut chart" height="300"></canvas>
+        <div id="apportion-center" class="apportion-center" aria-hidden="true"></div>
+    </div>
+    <div class="apportion-legend" id="apportion-legend"></div>
+</div>
+
+<div id="apportion-source" class="apportion-source"></div>
+
+<details class="apportion-method">
+    <summary>How to read this &mdash; and its limits</summary>
+    <div class="apportion-method-body">
+        <p><strong>What "source apportionment" means.</strong> Scientists work out how much each type of source contributes to the fine particles (PM2.5) you breathe, using one of two methods:</p>
+        <ul>
+            <li><strong>Receptor models</strong> (like Chemical Mass Balance) chemically fingerprint the particles actually measured in the air &mdash; so they capture <em>secondary</em> particles that form in the atmosphere, which show up here under "Other".</li>
+            <li><strong>Emission inventories</strong> add up what each source <em>emits</em>. They're good on primary particles but don't separate out secondary aerosol or long-range transport, so their "Other" is often near zero.</li>
+        </ul>
+        <p><strong>Why you can't cleanly compare cities.</strong> Studies differ by method, by season (winter peaks look very different from annual averages), and by year. The mix is <em>indicative</em>, not a precise league table &mdash; each city names its own study and basis above the ring. Where a study only reported winter and summer, we've said so.</p>
+        <p><strong>The buckets.</strong> <em>Transport</em> = vehicles. <em>Industry</em> = manufacturing (and, in some studies, thermal power). <em>Biomass &amp; burning</em> = household cooking fuel, waste and crop-residue burning. <em>Dust &amp; construction</em> = road/soil dust and building sites. <em>Power</em> = thermal power where the study separates it. <em>Other</em> = secondary aerosol, transboundary transport, and miscellaneous.</p>
+        <p>Primary sources: CREA, UrbanEmissions.info (APnA), CSIR-NEERI, CSTEP, TERI, IIT Kanpur, and state pollution control boards under NCAP.</p>
+    </div>
+</details>

--- a/styles.css
+++ b/styles.css
@@ -2702,3 +2702,33 @@ body {
     .stat-strip { grid-template-columns: 1fr; }
     .grid-5 { grid-template-columns: 1fr; }
 }
+
+/* ── Source apportionment ring ─────────────────────────────────────────── */
+.apportion-controls { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+.apportion-label { font-size: 0.8125rem; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.04em; }
+.apportion-select { font: inherit; font-size: 0.95rem; padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 0.5rem; background: var(--bg-card); color: var(--ink); min-width: 11rem; }
+.apportion-basis { font-size: 0.8125rem; color: var(--text-3); font-style: italic; }
+.apportion-layout { display: grid; grid-template-columns: minmax(0, 300px) 1fr; gap: 1.75rem; align-items: center; }
+.apportion-ringwrap { position: relative; min-height: 260px; }
+.apportion-center { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; pointer-events: none; text-align: center; }
+.apportion-center-pct { font-family: var(--serif, Georgia, serif); font-size: 2rem; font-weight: 700; line-height: 1; color: var(--ink); }
+.apportion-center-lbl { font-size: 0.8125rem; color: var(--text-3); margin-top: 0.25rem; max-width: 8rem; }
+.apportion-legend { display: flex; flex-direction: column; gap: 0.6rem; }
+.apportion-row { display: grid; grid-template-columns: 0.85rem minmax(6rem, auto) 1fr 2.75rem; align-items: center; gap: 0.6rem; }
+.apportion-swatch { width: 0.85rem; height: 0.85rem; border-radius: 0.2rem; flex-shrink: 0; }
+.apportion-rowlabel { font-size: 0.9rem; color: var(--ink); }
+.apportion-rowbar { height: 0.5rem; background: var(--bg-section); border-radius: 999px; overflow: hidden; }
+.apportion-rowbar-fill { display: block; height: 100%; border-radius: 999px; }
+.apportion-rowval { font-size: 0.9rem; font-weight: 600; color: var(--ink); text-align: right; font-variant-numeric: tabular-nums; }
+.apportion-source { margin-top: 1.5rem; padding: 1rem 1.1rem; background: var(--bg-section); border: 1px solid var(--border); border-radius: 0.6rem; }
+.apportion-src-line { font-size: 0.85rem; color: var(--text-2); margin: 0 0 0.4rem; }
+.apportion-caveat { font-size: 0.8125rem; color: var(--text-3); margin: 0; line-height: 1.55; }
+.apportion-method { margin-top: 1.25rem; }
+.apportion-method > summary { cursor: pointer; font-weight: 600; color: var(--green-700); font-size: 0.95rem; padding: 0.4rem 0; }
+.apportion-method-body { font-size: 0.9rem; color: var(--text-2); line-height: 1.65; padding-top: 0.5rem; }
+.apportion-method-body ul { margin: 0.5rem 0 0.75rem 1.1rem; }
+.apportion-method-body li { margin-bottom: 0.4rem; }
+@media (max-width: 640px) {
+    .apportion-layout { grid-template-columns: 1fr; gap: 1.25rem; }
+    .apportion-ringwrap { max-width: 300px; margin: 0 auto; }
+}

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-20260699';
+const CACHE_VERSION = 'janvayu-202606100';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=20260699',
-  '/app.js?v=20260699',
+  '/styles.css?v=202606100',
+  '/app.js?v=202606100',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
## What

A new **"Where PM2.5 comes from"** panel (`#apportionment`) — the Phase 10 source-apportionment ring. A doughnut chart shows each source's share of a city's fine-particle pollution, with an interactive **12-city picker** (Delhi, Mumbai, Kolkata, Chennai, Bengaluru, Hyderabad, Pune, Ahmedabad, Kanpur, Lucknow, Patna, Jaipur).

Six source buckets: **transport, industry, biomass & burning, dust & construction, power, other (secondary/transboundary).** Legend shows ranked bars with %; a centre callout names the top source.

## Sourcing & honesty

Each city draws on the most credible source-apportionment study I could find, **named inline with its year, method, and a scope caveat** — CREA, UrbanEmissions.info (APnA), CSIR-NEERI, CSTEP, TERI, IIT Kanpur, and state pollution boards under NCAP. The data was gathered by a 12-agent research pass, each web-verifying against a primary study.

A **methodology `<details>`** explains the limits plainly: receptor models vs emission inventories, why winter and annual splits differ, and why the mix is *indicative* — not a precise cross-city league table. Where a study only reported seasonal splits, that's stated.

## Implementation

- Data: `data/apportionment.json` (12 cities, shares normalized to ~100, with `source`, `year`, `basis`, `caveat`, `confidence`).
- Panel fragment: `panels/apportionment.html`; registered in `LAZY_PANELS` + `loadPanelInits`.
- `window.initApportionment` / `renderApportionRing` in `app.js`: Chart.js doughnut (lazy-loaded), theme-aware, with legend, ranked bars, centre callout, source line + caveat.
- Wired into the **Learn** nav (desktop dropdown + mobile).

Verified end-to-end via Playwright (stubbed Chart loader, since the CDN is blocked in-sandbox): 12 cities populate, data sorts correctly (`[30,28,17,14,11]` for Delhi), legend/centre/source render, and switching city (→ Bengaluru, `[40,26,23,6,4,1]`) re-renders. `node -c` clean.

Version **26.6.100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_