### PR TITLE
Content-sweep flag resolutions + accessibility contrast pass + Phase 5.20 log

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -47,6 +47,11 @@ jobs:
           mkdir -p axe-results
           set +e
           # The four most-visited surfaces. Add more as needed.
+          # axe-core/cli ships its own ChromeDriver (built for the newest
+          # Chrome) which drifts ahead of the runner's Chrome. Point it at the
+          # version-matched driver that setup-chromedriver put on PATH.
+          DRIVER="$(command -v chromedriver || true)"
+          echo "Using chromedriver: ${DRIVER:-<bundled>}"
           for path in "" "ask/" "blog/" "downloads/"; do
             url="http://127.0.0.1:8888/${path}"
             slug=${path:-root}
@@ -54,6 +59,7 @@ jobs:
             echo "::group::axe ${slug}"
             axe "$url" \
               --tags wcag2a,wcag2aa \
+              ${DRIVER:+--chromedriver-path "$DRIVER"} \
               --save "axe-results/${slug}.json" \
               --exit || true
             echo "::endgroup::"

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           node-version: '22'
 
+      # axe-core/cli drives Chrome via ChromeDriver. The runner's Chrome and a
+      # freshly-installed ChromeDriver can drift a major version apart (e.g.
+      # Chrome 150 vs a driver built for 151), which makes every axe run fail
+      # with "session not created" and silently produce zero results. This
+      # action installs a ChromeDriver matching the runner's Chrome.
+      - name: Install matching ChromeDriver
+        uses: nanasess/setup-chromedriver@v2
+
       - name: Install axe-core/cli + http-server
         run: |
           npm install -g @axe-core/cli@4.10.1 http-server@14.1.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.101"
+version: "26.6.102"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.102"
+version: "26.6.103"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.103"
+version: "26.6.104"

--- a/ask/index.html
+++ b/ask/index.html
@@ -19,13 +19,13 @@
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     :root {
-      --accent: #16A34A;
+      --accent: #146c33; /* darkened from #16A34A for AA 4.5:1 as text on white */
       --accent-hover: #15803d;
       --bg: #FFFEF9;
       --bg-card: #fff;
       --text: #1a1a18;
       --text-2: #4a4a46;
-      --text-3: #7a7a74;
+      --text-3: #6a6a63; /* darkened from #7a7a74 to meet AA 4.5:1 on white */
       --text-4: #a0a09a;
       --border: #e5e5df;
       --border-light: #f0f0ea;

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606103-v103';
+const CACHE_NAME = 'ask-janvayu-202606104-v104';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606102-v102';
+const CACHE_NAME = 'ask-janvayu-202606103-v103';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606101-v101';
+const CACHE_NAME = 'ask-janvayu-202606102-v102';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/blog/posts/2026-04-12-iqair-2025-india.md
+++ b/blog/posts/2026-04-12-iqair-2025-india.md
@@ -28,7 +28,7 @@ The Centre for Research on Energy and Clean Air (CREA) reported that monitoring 
 
 The IQAir report landed alongside two landmark studies in The Lancet Planetary Health that, for the first time, established causal links between PM2.5 exposure and mortality in India using rigorous econometric methods rather than correlational analysis.
 
-The first study (Jaganathan et al. 2024), using a difference-in-differences approach, estimated 1.5 million additional deaths per year compared to conditions where India met WHO guidelines. *(The Lancet Countdown 2025, published in October 2025, has since revised this headline India figure upward to 1.72 million.)* The second, a multi-city causal modelling study covering ten Indian cities, confirmed significant short-term mortality effects from daily PM2.5 exposure.
+The first study (Jaganathan et al. 2024), using a difference-in-differences approach, estimated 1.5 million additional deaths per year compared to conditions where India met WHO guidelines. *(This is distinct from the Lancet Countdown 2025 (published October 2025), which separately estimated over 1.72 million deaths in India in 2022 attributable to anthropogenic PM2.5 — up 38% since 2010. That is a total-attributable-deaths count for a single year, not a same-method revision of the excess-deaths figure above.)* The second, a multi-city causal modelling study covering ten Indian cities, confirmed significant short-term mortality effects from daily PM2.5 exposure.
 
 A separate study in Science Advances demonstrated that whatever air quality improvements India has achieved in recent years have been distributed unequally. Wealthier urban areas have seen modest gains; poorer and rural regions have seen none.
 

--- a/blog/posts/2026-06-10-urban-heat-island.md
+++ b/blog/posts/2026-06-10-urban-heat-island.md
@@ -4,7 +4,7 @@
 
 ---
 
-On one summer afternoon, a thermal survey of Delhi recorded **52°C in Mubarakpur** and **34°C in Mehrauli** — at the same hour, under the same sun, just kilometres apart. That is an 18°C gap inside a single city. The sun did not change. The ground did.
+On a peak summer afternoon, a CSE satellite thermal survey of Delhi recorded land-surface temperatures reaching nearly **61°C** in its most built-up, treeless zones while tree-covered areas like Lutyens' Delhi and the Yamuna floodplain stayed near **33°C** — under the same sun, within a single city. That is a gap of more than 25°C. The sun did not change. The ground did.
 
 This is the **urban heat island effect**, and we have just added a panel about it to JanVayu — [Urban Heat Island](/index.html#urban-heat), under *Health & Trends*. But a fair question came up while we built it, and it is worth answering in the open: **what is heat doing on an air-quality website?**
 
@@ -47,4 +47,4 @@ Explore it: [**Urban Heat Island on JanVayu**](/index.html#urban-heat).
 
 ---
 
-*Sources: Sircar, N. et al. (2026), "Mapping Heat Inequality Across Neighbourhoods in Delhi," Artha Global; surface-temperature map via India Today; Bloomer, B.J. et al. (2009), Geophysical Research Letters 36, L09803; Jacob, D.J. & Winner, D.A. (2009), Atmospheric Environment 43(1):51–63; Analitis, A. et al. (2014), Epidemiology 25(1):15–22; Stafoggia, M. et al. (2023), Environment International 181:108258; Salamanca, F. et al. (2014), J. Geophysical Research: Atmospheres 119:5949–5965; Nowak, D.J. et al. (2014), Environmental Pollution 193:119–129. Live hourly ozone and temperature via Open-Meteo (CAMS).*
+*Sources: Sircar, N. et al. (2026), "Mapping Heat Inequality Across Neighbourhoods in Delhi," Artha Global; surface-temperature figures from Centre for Science and Environment, *Making Delhi Heat-Resilient: A Roadmap with the Focus on Vulnerable Groups* (2026); Bloomer, B.J. et al. (2009), Geophysical Research Letters 36, L09803; Jacob, D.J. & Winner, D.A. (2009), Atmospheric Environment 43(1):51–63; Analitis, A. et al. (2014), Epidemiology 25(1):15–22; Stafoggia, M. et al. (2023), Environment International 181:108258; Salamanca, F. et al. (2014), J. Geophysical Research: Atmospheres 119:5949–5965; Nowak, D.J. et al. (2014), Environmental Pollution 193:119–129. Live hourly ozone and temperature via Open-Meteo (CAMS).*

--- a/docs/fact-check-2026-07c.md
+++ b/docs/fact-check-2026-07c.md
@@ -130,3 +130,148 @@ These need a human call — mostly unsourced figures to remove/re-source, a few 
 25. **a 2026 study of 298 Chennai street vendors with measurably weaker lung function** (unverifiable)  
    The general finding (street vendors have elevated PM exposure and reduced lung function) is well supported by published literature (e.g. Kolkata street-vendor studies). However, I could not independently locate a 2026 Chennai study with the specific sample size of 298. Recommend confirming the exact figure against the linked Reading List source before treating '298' as verified; not removing, since the qualitative point is supportable and the number is a citation to the platform's own reading list.
 
+
+
+---
+
+## Flag resolutions (applied)
+
+The flagged items were re-verified and resolved: **fix** (corrected value/attribution), **harmonize** (aligned an inconsistent live figure), **remove** (dropped an unsourced number), **reframe** (neutral sourced restatement), **skip** (confirmed fine / historical record / platform own model output — left as-is).
+
+**Totals:** 2 remove, 16 fix, 4 harmonize, 1 reframe, 11 skip.
+
+### panels/legal.html
+
+- **[remove]** CSE's April 2026 review finds 37/131 cities met the NCAP 40% PM10 target  
+  The '37/131' figure attributed to a CSE 'April 2026 review' is unverifiable: CSE's NCAP assessment ('National Clean Air Programme — An Agenda for Reform', cseindia.org) is dated July 2024 and states no such city count (it notes city-wise success data is not even publicly reported). No CSE April 2026 publication carrying '37/131' could be located. The paired CREA figure (23 of 100 cities with adequate data met the revised 40% PM10 target) IS confirmed current (CREA, 'Tracing the Hazy Air 2026', Jan 2026), so I surgically remove only the unsourced CSE clause and retain the verified CREA figure and surrounding structure.  
+  *Source:* CREA 'Tracing the Hazy Air 2026' (Jan 2026) — 23 cities met revised 40% PM10 target; CSE 'NCAP: An Agenda for Reform' (cseindia.org, Jul 2024) contains no 37/131 count
+- **[fix]** vehicles are 58% of internal PM2.5  
+  The '58% of internal PM2.5' figure has no locatable credible source and is not supported by mainstream Delhi source-apportionment work. The named primary study, TERI-ARAI 2018 (Source Apportionment of PM2.5 & PM10 in Delhi NCR), puts the transport sector at ~39% of PM2.5 emissions (19% of PM10) — the largest single local source, per CSE's summary of that study. Because a sourced, method-consistent replacement exists, I fix rather than merely remove: the number is corrected to the TERI-ARAI value and the legal argument (largest local source → EPA s.3&5 / Art.21) is preserved without an invented figure.  
+  *Source:* TERI-ARAI 2018 'Source Apportionment of PM2.5 & PM10 in Delhi NCR' (teriin.org / data.gov.in), as summarised by CSE ('Mobility crisis is behind the pollution in Delhi', cseindia.org): transport ~39% of Delhi PM2.5
+
+### panels/progress.html
+
+- **[harmonize]** 4,286 e-buses operational in Delhi (verified 9 Feb 2026, overtaking Maharashtra's 4,001) — headline stat  
+  This is a LIVE panel, not a dated blog/changelog, so the dated-record rule does not lock the figure — platform rule (1) favours the newest sourced count. The 4,286 (9 Feb 2026) figure was honestly dated and not wrong, but a newer primary-sourced count exists: 4,845 as of 9 Jul 2026 after 300 buses were added. Aligning this headline instance to the single best-sourced current value; the same quantity recurs in three other places in this file (body count, CO2 math, state leaderboard), all updated in this edit set.  
+  *Source:* electrive, 'India: Delhi adds 300 electric buses to its public transport fleet,' 9 Jul 2026 — Delhi fleet total = 4,845 (India's largest).
+- **[harmonize]** 4,286 e-buses operational (last verified count, 9 Feb 2026 — overtaking Maharashtra's 4,001) — body text  
+  Refresh to newest sourced count (4,845, electrive 9 Jul 2026) while preserving the genuine milestone context: Delhi overtook Maharashtra's 4,001 and CM Rekha Gupta's 500-bus Ramlila Maidan flag-off were the February 2026 events, so those are retained as past-tense context and the July count is attributed to its own dated source. Inline citation added in the same style the panel uses elsewhere.  
+  *Source:* electrive, 9 Jul 2026 (fleet total 4,845 after +300); Feb-2026 overtaking/flag-off milestone unchanged.
+- **[fix]** At 4,286 e-buses, that's ~107,000 tonnes CO2 avoided annually — impact math  
+  Dependent arithmetic that must be recomputed once the bus count is refreshed, otherwise it becomes an internal error. The panel's own stated factor is ~25 t CO2/yr per replaced diesel bus: 4,845 × 25 = 121,125 ≈ 121,000 t (the original 4,286 × 25 = 107,150 ≈ 107,000 t was itself correct for the old count). Same-method recompute, no new assumption.  
+  *Source:* electrive, 9 Jul 2026 (4,845 buses) × panel's stated ~25 t CO2/bus/yr = ~121,000 t.
+- **[harmonize]** State leaderboard: Delhi (4,286), Maharashtra (4,001), Karnataka (1,989)...  
+  Align Delhi's leaderboard figure to the same 4,845 (Jul 2026) value used elsewhere in the file so the panel is internally consistent. Added an explicit '(Jul 2026)' tag on Delhi because the other states' figures are from earlier snapshots and are not independently re-verified here — this avoids implying all six numbers share one snapshot date. Delhi's #1 ranking over Maharashtra's 4,001 is unaffected. Other states' counts left unchanged (not verifiable to a newer primary source in this check).  
+  *Source:* electrive, 9 Jul 2026 (Delhi 4,845). Other-state figures retained as-is; not re-verified.
+
+### panels/resources.html
+
+- **[fix]** WHO Air Quality Guidelines card: 'Annual PM2.5 limit: 5 µg/m³. India is 20× over.'  
+  The 5 µg/m³ WHO annual guideline is correct, but '20× over' is arithmetically wrong for the national mean. India's annual average PM2.5 is ~48.9 µg/m³ in the IQAir 2025 World Air Quality Report (and 50.6 in the 2024 report); 48.9 ÷ 5 ≈ 9.8, i.e. ~10×. A ~20× multiple (~100 µg/m³) applies only to the worst cities (Delhi ~82, Byrnihat ~128), not the country. Live card (no date badge), so correcting is appropriate. Neutral same-metric fix.  
+  *Source:* IQAir World Air Quality Report 2025 (pub. Mar 2026), India annual mean 48.9 µg/m³; WHO 2021 annual PM2.5 guideline 5 µg/m³
+- **[harmonize]** CSE NCAP Five-Year Review card: '27 of 96 cities with sufficient data met the 40% PM10 target by the elapsed 2026 deadline (CREA).'  
+  The '27 of 96' number is attributed to CREA but does not match CREA's Jan 2026 'Tracing the Hazy Air' figure of 23 cities meeting the 40% PM10 target, and it contradicts this same file's Health Studies card (line 655: 'Only 23/100 NCAP cities met target'). Aligning this instance to the best-sourced value (CREA 23/100). Note: the file also carries a 64% vs 68% dust-spend discrepancy between the CSE card here and the CREA card at line 655 (64% is CSE's number, 68% CREA's); left as-is since each is attributed to its own org and not part of this flag.  
+  *Source:* CREA, 'Tracing the Hazy Air' (9 Jan 2026): 23 of 100 NCAP cities met the 40% PM10 reduction target
+- **[reframe]** AQLI 2025 card: 'Indo-Gangetic Plain residents lose 7-8 years.'  
+  AQLI 2025 (2023 data) confirms the national figure of 3.5 years already in the card, but the IGP is not uniformly '7-8 years' on the WHO-guideline metric: Delhi-NCR ~8.2 yr, Bihar ~5.6, Haryana ~5.3, UP ~5. The recurring '7 years' is either an older-edition value or the different 'vs. rest of India' metric — mixing it with the 3.5 (vs. WHO) figure collapses two methods. Reframed to a same-metric current range (5–8 yr, Delhi-NCR up to 8.2) so both numbers share the AQLI vs-WHO basis. States the current reality plainly.  
+  *Source:* AQLI 2025 (EPIC, Univ. of Chicago), India fact sheet: national 3.5 yr; Delhi-NCR ~8.2 yr; Bihar 5.6; Haryana 5.3; UP ~5
+- **[fix]** IQAir Feb 2026 alert card: 'India avg PM2.5 50.6 ug/m3 (11x WHO). 5th globally.'  
+  Dated alert card (FEB 2026) correctly describing then-current 2024 data — 50.6 µg/m³ was India's 2024 annual mean and '5th globally' was the 2024 ranking, both correct as of the card's date, so per the dated-record rule those are left intact. Only the multiplier is bad arithmetic: 50.6 ÷ 5 = 10.1, i.e. ~10×, not 11×. Fixing the arithmetic error only.  
+  *Source:* IQAir World Air Quality Report 2024 (India annual mean 50.6 µg/m³); WHO annual PM2.5 guideline 5 µg/m³ → 50.6/5 ≈ 10×
+- **[skip]** IQAir 2025 card: 'Delhi 8th straight year as worst capital.'  
+  Verification CONFIRMS the current value. IQAir's 2025 World Air Quality Report (pub. Mar 2026) names New Delhi the most polluted capital city 'for the eighth consecutive year.' Loni #1 at 112.5 µg/m³ and 'only 14% of cities meet WHO' are also confirmed for this edition. No edit needed.  
+  *Source:* IQAir World Air Quality Report 2025 (via IQAir newsroom / Health Policy Watch, Mar 2026): New Delhi most polluted capital for the 8th consecutive year; 14% of cities met WHO guideline
+- **[remove]** State of Global Air HAP card: '481,700 deaths/year in India. 60% women.'  
+  The card links to stateofglobalair.org/health/hap, but that page does not carry '481,700' or a '60% women' split — 481,700 matches the older GBD-2017-era India HAP estimate (~0.48M), and the 60% figure is not locatable in any current primary source. Removing the two unverifiable specifics while preserving the supportable qualitative point: SoGA/WHO both state women and children bear the greatest household-air-pollution burden, and India's HAP toll remains in the hundreds of thousands per year (GBD 2019 ~0.6M). Valid source retained.  
+  *Source:* State of Global Air / HEI, Health Impacts of Household Air Pollution (stateofglobalair.org/health/hap): women and children bear greatest burden; India+China ~42% of global HAP deaths (2019). GBD 2017 India HAP ~0.48M.
+
+### panels/about.html
+
+- **[skip]** Loni 112.5 µg/m³ named most-polluted city 'up 23% from 2024' (line 595) and og-image 'Loni 112.5 µg/m³' (line 546), attributed to IQAir 2025  
+  Prior flag was wrong. The primary source — IQAir 2025 World Air Quality Report, released 24 Mar 2026 — confirms Loni as the most polluted city at 112.5 µg/m³, a ~23% increase from 2024. The file's values match the cited report exactly, so there is no error to fix. These are also dated changelog entries (v25.4, 12 Apr 2026; v26.5.8, 8 May 2026) — historical records that must not be anachronistically 'updated'. No safe edit; confirmed accurate.  
+  *Source:* IQAir 2025 World Air Quality Report, iqair.com/newsroom/waqr-2025-pr (released 24 Mar 2026): Loni 112.5 µg/m³, ~23% rise from 2024
+- **[skip]** 'Only 14% of global cities meet WHO guideline' and 'India average PM2.5: 48.9 µg/m³ (~10× WHO limit)' attributed to IQAir 2025 (line 595)  
+  Prior flag ('should be 17%') was wrong. IQAir 2025 World Air Quality Report (pub 24 Mar 2026) states exactly 14% of cities met the WHO PM2.5 guideline (down from 17% the year before) and India's average was 48.9 µg/m³ (~9.78× the 5 µg/m³ guideline, i.e. ~10×). Both figures match the cited report verbatim. Also a dated changelog entry (v25.4, 12 Apr 2026) — a historical record. No edit needed; confirmed accurate.  
+  *Source:* IQAir 2025 World Air Quality Report, iqair.com/newsroom/waqr-2025-pr: 14% of cities meet WHO guideline (down from 17%); India 48.9 µg/m³
+- **[skip]** '70% rural women on solid fuels, NFHS-5' (line 309, v26.6.22 entry)  
+  This sits inside the v26.6.22 (26 May 2026) dated changelog entry recording what the Women & Air Quality panel shipped with — a historical record. Per the dated-record rule, a dated log entry is only edited for a genuine fabrication, and 70% is not a fabrication: it falls within the range of credible solid-fuel-dependence estimates (NFHS-5 rural clean-fuel access ~43-49%, i.e. solid-fuel reliance ~50-57%; older census/biomass estimates run to ~70-80%). Any tightening of the number belongs in the live Women & Air Quality panel where the claim is actually made, not in this changelog. No safe in-place edit here.  
+  *Source:* NFHS-5 (2019-21) household clean-fuel indicators; changelog is a dated historical record (about.html line 432 states the archive-preservation commitment)
+- **[skip]** '~533 CAAQMS stations across ~250 cities' national CPCB reference (line 411, v26.6.12 entry)  
+  Inside the v26.6.12 (20 May 2026) dated changelog entry, describing the Ask JanVayu prompt's reference figure as it stood at that time — a historical record, not a live claim. The figure was roughly right as of the entry's date; the CAAQMS network has since grown (~560+ stations / ~290+ cities in 2024-25), but per the dated-record rule that refresh belongs in the live prompt/reference data, not in this preserved changelog. No safe in-place edit here.  
+  *Source:* CPCB CAAQMS network (~500+ real-time stations, 2024-25); changelog entry is a dated historical record
+
+### panels/actions.html
+
+- **[fix]** PM2.5 from chulha = smoking 400 cigarettes/day  
+  Kirk Smith's (UC Berkeley) established figure is that an open wood cookfire produces ~6g / ~400 cigarettes' worth of PM2.5 per HOUR, not per day — the file understated the interval by ~24x. Corrected 'day' to 'hour', softened '=' to '≈' (it is a smoke-production analogy, not an inhaled-dose equivalence), and added the Kirk Smith attribution inline.  
+  *Source:* Prof. Kirk R. Smith, UC Berkeley; wood cookfire ≈ 400 cigarettes/hour of PM2.5 — National Geographic (2017), Lancet obituary (PMC7411313, 2020)
+- **[fix]** Home-GRAP band label: 51-100 Moderate  
+  CPCB National AQI (2014) labels 51-100 as 'Satisfactory', not 'Moderate' (a US-EPA name blended onto Indian numeric bands). The numeric band already matches CPCB; only the label was wrong. Relabelled; the row's household guidance escalates by AQI number so it remains coherent.  
+  *Source:* CPCB National Air Quality Index (2014), cpcb.nic.in/National-Air-Quality-Index
+- **[fix]** Home-GRAP band label: 101-200 Poor  
+  CPCB National AQI (2014) labels 101-200 as 'Moderate', not 'Poor'. Numeric band matches CPCB; label corrected.  
+  *Source:* CPCB National Air Quality Index (2014), cpcb.nic.in/National-Air-Quality-Index
+- **[fix]** Home-GRAP band label: 201-300 Very Poor  
+  CPCB National AQI (2014) labels 201-300 as 'Poor', not 'Very Poor'. Numeric band matches CPCB; label corrected.  
+  *Source:* CPCB National Air Quality Index (2014), cpcb.nic.in/National-Air-Quality-Index
+- **[fix]** Home-GRAP band label: 301-400 Severe  
+  CPCB National AQI (2014) labels 301-400 as 'Very Poor', not 'Severe'. Numeric band matches CPCB; label corrected.  
+  *Source:* CPCB National Air Quality Index (2014), cpcb.nic.in/National-Air-Quality-Index
+- **[fix]** Home-GRAP band label: 400+ Hazardous  
+  India's CPCB National AQI has no 'Hazardous' tier (that is a US-EPA category); the top CPCB band is 'Severe' at 401-500. Corrected label and numeric range to CPCB. The row's emergency-response guidance is preserved.  
+  *Source:* CPCB National Air Quality Index (2014), cpcb.nic.in/National-Air-Quality-Index
+- **[fix]** Purifier sizing: CADR ≥ 2/3 of room volume (m³)  
+  AHAM's '2/3 rule' is CADR (in CFM) ≥ 2/3 of room FLOOR AREA in square feet — not '2/3 of room volume (m³)', which is not a recognized standard and has ambiguous units. Restated to the actual AHAM area-based rule (using Smoke CADR, per AHAM guidance).  
+  *Source:* Association of Home Appliance Manufacturers (AHAM) 2/3 rule, ahamverifide.org/ahams-air-filtration-standards
+
+### panels/citizen-action.html
+
+- **[fix]** Vehicles = 58% of Delhi's internal PM2.5 (34% from exhaust + 24% from tyre/brake wear)  
+  The vehicle-total is sourceable but the exhaust/tyre-brake SPLIT is fabricated. CSE's analysis of the IITM Decision Support System real-time data finds transport is the single largest LOCAL source of Delhi winter PM2.5 at ~51-53% (avg of Nov 10-20 across 2023-25). No credible Delhi apportionment (CSE/IITM-DSS, IIT-Kanpur, TERI) assigns ~24% to tyre/brake wear; the sourced non-exhaust/road-dust share is only ~3-4%. So '24% tyre/brake wear' and the derived '58%' are unsupported. Replace with the sourced aggregate (~half / 51-53%) and drop the invented split. Keeps the (accurate, well-sourced) accountability point that vehicles dominate local emissions.  
+  *Source:* CSE, 'Vehicles are the biggest contributors to winter pollution in Delhi' (cseindia.org); Down To Earth, 'From episodic smog to structural pollution' — CSE analysis of IITM-DSS real-time data, 2023-25 (transport 51-53% of local emissions).
+- **[fix]** Bar chart: Vehicles (exhaust) 34% and Tyre/brake wear 24% as separate internal-source shares  
+  The two-bar split (exhaust 34% + tyre/brake wear 24%) is not supported by any located apportionment; the 24% tyre/brake bar is the fabricated component (real non-exhaust/road-dust share ~3-4%). Consolidate to a single sourced 'Vehicles (transport) ~51%' bar matching CSE/IITM-DSS. This removes the invented number while preserving the chart structure and the (correct) point that vehicles are the dominant local source. The remaining bars (coal 14%, SIA 11%, LPG+MSW+dust 16%) are left untouched — they were not the fabricated item and I lack a clean primary source to re-derive them, so per 'do not alter numbers without the source in hand' they stay.  
+  *Source:* CSE / Down To Earth analysis of IITM Decision Support System real-time data, winter 2023-25 (vehicles/transport 51-53% of Delhi local PM2.5; household ~13%, industry ~10-14%, construction ~7-8%, road dust ~4%).
+- **[skip]** Dr. Soumya Swaminathan highlights 3x mortality on combined high-heat + high-pollution days (Mumbai Climate Week, Feb 2026)  
+  Confirmed accurate — leave as-is. Health Policy Watch's coverage of Mumbai Climate Week (published 19 Feb 2026) directly quotes Swaminathan: 'on the days when you have the highest heat and high air pollution, the deaths which occur on those days are three times more than when you have either heat or high air pollution,' citing a peer-reviewed California study. Both the '3x' figure, the speaker, and the Feb 2026 event date are verified. No edit needed.  
+  *Source:* Health Policy Watch, 'Air Pollution and Heatwaves Take Centre Stage at Mumbai Climate Week' (19 Feb 2026), citing the California study at atsjournals.org (rccm.202204-0657OC).
+
+### blog/posts/2026-04-12-iqair-2025-india.md
+
+- **[fix]** The Lancet Countdown 2025 "has since revised this headline India figure upward to 1.72 million" (framing 1.72M as an update of Jaganathan et al.'s 1.5M).  
+  Both figures verify against primary sources, but they are different metrics computed by different methods, so calling 1.72M a 'revision upward' of 1.5M collapses two honest methods into one (platform rule 2) and falsely implies same-method continuity. Jaganathan et al. 2024 (Lancet Planetary Health, Dec 2024) reports ~1.5M EXCESS deaths/year vs a WHO-guideline counterfactual using difference-in-differences on 2009-2019 data. The Lancet Countdown 2025 (published 29 Oct 2025) reports over 1,718,000 deaths attributable to anthropogenic PM2.5 in India for the single year 2022, up 38% since 2010 — a total-attributable-deaths figure. This is a genuine framing error, not a vintage/anachronism issue, so it is fixed rather than skipped. The edit keeps both sourced numbers but labels them as distinct metrics with their own year and method.  
+  *Source:* Jaganathan et al., Lancet Planetary Health Dec 2024 (thelancet.com/journals/lanplh/article/PIIS2542-5196(24)00248-1/fulltext) = ~1.5M excess deaths, difference-in-differences; Lancet Countdown 2025 India data sheet, pub 29 Oct 2025 (lancetcountdown.org) = 1,718,000 anthropogenic-PM2.5-attributable deaths in 2022, +38% since 2010.
+
+### blog/posts/2026-06-10-how-polluted-is-your-ward.md
+
+- **[skip]** Delhi (290 wards), Mumbai (227), Bengaluru (243), Hyderabad (145), Chennai (201), Kolkata (141), Jaipur (77), Pune (58) and Ahmedabad (48)  
+  These are counts of ward polygons in the platform's OWN boundary files (attributed to DataMeet Municipal Spatial Data and the Mumbai spatial-data project in the post's source note, line 49), not official council strengths. Per the task rule for the platform's own model/dataset output already framed as such, this needs no external source. The flag's own divergence examples (MCD 250 vs 290, GHMC 150 vs 145) confirm these describe boundary-file vintage, not official strength, so there is no correct external substitute and removal would gut the post. No safe edit.  
+  *Source:* Post's own source note, line 49: 'Ward boundaries: DataMeet Municipal Spatial Data and the Mumbai spatial-data project (open).' Self-reported dataset — no external primary source applicable.
+- **[skip]** On a typical Delhi afternoon, the PM2.5 range runs from roughly 45 to 270 µg/m³ across wards — a 6× difference  
+  This is an illustrative output of the platform's own IDW interpolation model for a 'typical' afternoon, explicitly presented and caveated as a model spread in the same paragraph and the entire 'The honest part' section (lines 28-36). 270/45 = 6 is internally consistent arithmetic. No external primary source exists or is claimed; per the task rule, self-reported model output framed as such needs no external source. Skip.  
+  *Source:* Post lines 24-34 self-describe the value as interpolated model output; internal arithmetic 270/45 = 6 verified.
+
+### blog/posts/2026-06-10-urban-heat-island.md
+
+- **[fix]** A thermal survey of Delhi recorded 52°C in Mubarakpur and 34°C in Mehrauli — an 18°C gap (source: surface-temperature map via India Today).  
+  The exact pairing (52°C Kotla Mubarakpur / 34°C Mehrauli / 18°C gap) and the 'India Today' surface-temperature map could not be located in any primary source. The underlying phenomenon IS strongly documented: CSE's 2026 report 'Making Delhi Heat-Resilient' records peak-summer land-surface temperatures up to 60.77°C in built-up/treeless zones while tree-covered areas (Lutyens' Delhi, Civil Lines, Cantonment) and the Yamuna floodplain stay near 33°C — a gap well over 25°C. Replacing the unverifiable specific numbers/source with the sourced CSE figures preserves the lede's point without inventing. Note: paired source-line edit below re-attributes the citation from India Today to CSE.  
+  *Source:* Centre for Science and Environment, 'Making Delhi Heat-Resilient: A Roadmap with the Focus on Vulnerable Groups' (2026); reported Business Standard 3 Jun 2026 and Down To Earth/CSE India (LST up to 60.77°C; cooler tree-covered zones and Yamuna ~33°C)
+- **[fix]** Source attribution: 'surface-temperature map via India Today'  
+  The 'India Today' surface-temperature map cited as the lede's source is unverifiable. Re-attribute to the actual primary source used for the corrected figures — the CSE 2026 Delhi heat-resilience report — so the footer citation matches the reframed lede.  
+  *Source:* Centre for Science and Environment, 'Making Delhi Heat-Resilient: A Roadmap with the Focus on Vulnerable Groups' (2026)
+
+### blog/posts/2026-06-11-live-vs-annual-honest-ward-data.md
+
+- **[skip]** comparing the spatial pattern of heat against built-up across wards on the same day ... in Delhi it's strong (correlation ≈ 0.69)  
+  This is JanVayu's OWN Pearson correlation computed on its own ward-level heat and built-up layers, and the sentence already frames it as an internal cross-sectional computation ('comparing the spatial pattern of heat against built-up across wards on the same day'). Per the platform's own-model-output rule it needs no external source. It is also directionally consistent with published Delhi UHI literature linking surface temperature to impervious/built-up surface (e.g. Mallick et al. 2013, R²≈0.81), so it is not contradicted. No safe edit improves it; leaving as-is preserves the transparent methodology explanation.  
+  *Source:* JanVayu internal computation (own heat/built-up layers); corroborated directionally by Mallick, Kant & Bharath 2013, J. Indian Soc. Remote Sens. (surface temp vs impervious surface, Delhi)
+- **[skip]** on one clean-air afternoon, Delhi's 'worst-air' ward came out as a leafy rural fringe (76% green)  
+  Self-reported result of the platform's own live-snapshot analysis (one hour's interpolated PM2.5 plus the ward's ESA WorldCover green-cover value), and the surrounding text already frames it explicitly as an internal observation ('We checked: on one clean-air afternoon...') used to make a methodological point about not conflating live air with annual structure. Per the own-model-output rule it needs no external source; it is not contradicted by any source, and removal would gut the post's central example. Leave as-is.  
+  *Source:* JanVayu internal live-snapshot analysis (interpolated PM2.5 + ESA WorldCover 2021 green cover)
+
+### blog/posts/2026-07-14-forecast-fire-and-beyond-the-lungs.md
+
+- **[skip]** a 2026 study of 298 Chennai street vendors with measurably weaker lung function  
+  Verification upgrades this from 'unsourced' to sourced-and-safe. The 298 figure traces to a real, RESOLVING DOI — 10.1186/s12889-026-28270-8 (Muruganantham et al., BMC Public Health, 3 Jul 2026): doi.org issues a 302 to link.springer.com/10.1186/s12889-026-28270-8 (a fabricated DOI returns 'DOI Not Found'; this one is registered), with only the Springer login wall blocking the full text. The figure is internally consistent across the platform's own Reading List (panels/resources.html:353), the live evidence card in index.html:3318 (which links the DOI), and CHANGELOG.md:557 — all stating 298 Chennai street vendors / reduced peak expiratory flow. General web search doesn't yet index the paper, but that is expected lag for a 3 Jul 2026 paper cited in a 14 Jul 2026 post, not fabrication. This is a DATED historical blog post citing the platform's own Reading List and a genuine DOI; the qualitative claim is well-supported by street-vendor lung-function literature (Kolkata, Bhopal). No genuine error or invented number to fix, and removing a real sourced figure from a dated record would be anachronistic. Skip.  
+  *Source:* Muruganantham et al., 'Occupational air-pollution exposure & respiratory health among urban street vendors in South India', BMC Public Health, DOI 10.1186/s12889-026-28270-8 (3 Jul 2026) — DOI resolves via doi.org 302 to Springer; cross-confirmed in-repo at panels/resources.html:352-353, index.html:3317-3318, CHANGELOG.md:557.
+

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -4,6 +4,16 @@ Track progress on [GitHub Issues](https://github.com/JanVayu/JanVayu/issues) and
 
 ---
 
+## Phase 5.20: Native deck, deeper fact-checks & the source-apportionment ring (✅ Completed — v26.6.95–101)
+
+A mid-July 2026 batch: replace the stale slide deck, push the fact-check to the whole content surface, and ship the long-planned apportionment ring.
+
+- [x] **Native HTML walkthrough deck** — the Google Slides embed is replaced by a self-hosted 13-slide deck (`walkthrough/deck.html`) with keyboard nav, speaker notes, overview grid, fullscreen, deep-links, touch swipe, and print-to-PDF. Self-hosts its fonts and inlines the hand-drawn diagrams, so it stays in sync with the site and needs no re-export. (v26.6.96)
+- [x] **Fact-check rounds 2 & 2b** — a 12-agent verification pass re-checked the prior findings against the live files and fresh sources: **37 verified corrections** (incl. restoring CREA's 23/100 NCAP figure, removing a fabricated "CSE Apr 2026" citation, refreshing NCAP fund figures to CREA 2026) and **43 resolutions** of flagged items (neutral, sourced reframes of stale accountability claims — Delhi e-buses, odd-even, FGD — plus removals of unsourced figures). Logs in `docs/fact-check-2026-07b.md`. (v26.6.97–98)
+- [x] **Content sweep** — extended the fact-check to the 8 panels and 10 data/research posts the earlier rounds hadn't reached: **327 statistics checked, 116 confirmed current, 8 corrected, 25 flagged** for review (`docs/fact-check-2026-07c.md`). (v26.6.101)
+- [x] **Source-apportionment ring** (`#apportionment`) — "Where PM2.5 comes from": a doughnut with a 12-city picker (Delhi–Jaipur) showing each source's share of ambient PM2.5, each city sourced to its own study (CREA, UrbanEmissions.info, CSIR-NEERI, CSTEP, TERI, IIT Kanpur, state boards) with an honest method/season caveat and a methodology note. *(Delivers the Phase 10 "source apportionment ring" item.)* (v26.6.100)
+- [x] **Team page** (`#team`) with Varna, Atul, and Komal (both with LinkedIn); **detailed FAQ page** (`#faq`); and a transparency **blog post** on the fact-check. (v26.6.95–99)
+
 ## Phase 5.19: Accuracy, reliability & more diagrams (✅ Completed — v26.6.89–93)
 
 The follow-through after the visual refresh — correctness and trust.
@@ -390,7 +400,7 @@ Recommended next-build list, drawing on the latest scan of NCAP Tracker (Climate
 
 - [~] **NCAP city scorecard upgrade** — ✅ one-click pre-filled RTI to the state board shipped v26.6.45 (see Phase 5.16); ⏳ station-level fund utilization + PM2.5-vs-target chart still to do.
 - [x] **Stubble-burning live tracker** — ✅ shipped v26.6.47 as the [Farm Fire Tracker](#fire-tracker) panel (NASA FIRMS, VIIRS/NOAA-20). See Phase 5.16.
-- [ ] **Source apportionment ring** — per-city %-from transport / industry / biomass / construction / dust, sourced from CREA + UrbanEmissions inventories. Interactive city picker.
+- [x] **Source apportionment ring** — ✅ shipped v26.6.100 as the [Where PM2.5 Comes From](#apportionment) panel: per-city %-from transport / industry / biomass / construction / dust / power, a 12-city interactive picker, each city sourced to its own study with method + season caveats. See Phase 5.20.
 - [x] **AQI forecast 24–72hr** — ✅ shipped v26.6.44 as a live 5-day Open-Meteo/CAMS forecast (mean + peak, day-by-day). See Phase 5.16.
 - [x] **Push notifications** — ✅ shipped v26.6.49: real Web Push (VAPID), gated on user-picked AQI thresholds, delivered even when the site is closed. Complement to email digest.
 - [ ] **In-browser AQ literacy quiz** — companion to Sharath's Jeopardy game; runs on the Workshops page.

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -22,7 +22,7 @@
   .file-title { font-weight: 700; font-size: 1.05rem; color: var(--ink); margin: 0; }
   .file-title a { color: inherit; text-decoration: none; }
   .file-title a:hover { color: var(--accent); }
-  .file-meta { display: flex; gap: 14px; flex-wrap: wrap; font-size: 0.78rem; color: var(--text-3); align-items: center; }
+  .file-meta { display: flex; gap: 14px; flex-wrap: wrap; font-size: 0.78rem; color: var(--text-2); align-items: center; }
   .file-meta strong { color: var(--text-2); font-weight: 600; }
   .file-desc { color: var(--text-2); font-size: 0.92rem; margin: 4px 0 0; }
   .file-pill { display: inline-block; background: rgba(27, 107, 74, 0.08); color: var(--accent); padding: 2px 8px; border-radius: 999px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606103">
+    <link rel="stylesheet" href="/styles.css?v=202606104">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1335,7 +1335,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606103"></script>
+    <script src="/app.js?v=202606104"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606101">
+    <link rel="stylesheet" href="/styles.css?v=202606102">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1335,7 +1335,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606101"></script>
+    <script src="/app.js?v=202606102"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606102">
+    <link rel="stylesheet" href="/styles.css?v=202606103">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -525,7 +525,7 @@
                     </svg>
                 </span>
                 <span class="logo-mark">JanVayu</span>
-                <span class="logo-scripts">
+                <span class="logo-scripts" aria-hidden="true">
                     <span class="logo-script active" data-script-lang="hi">जनवायु</span>
                     <span class="logo-script" data-script-lang="ta">ஜன்வாயு</span>
                     <span class="logo-script" data-script-lang="bn">জনবায়ু</span>
@@ -1335,7 +1335,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606102"></script>
+    <script src="/app.js?v=202606103"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.102",
+  "version": "26.6.103",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.101",
+  "version": "26.6.102",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.103",
+  "version": "26.6.104",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/accountability.html
+++ b/panels/accountability.html
@@ -216,7 +216,7 @@
                                 <span style="color: var(--text-2);">Announcement Only</span>
                             </div>
                             <div style="padding: 0.5rem; background: rgba(249,115,22,0.1); border-radius: 6px; text-align: center;">
-                                <strong style="color: #EA580C;">E2</strong><br>
+                                <strong style="color: #C2410C;">E2</strong><br>
                                 <span style="color: var(--text-2);">Pilot/Partial</span>
                             </div>
                             <div style="padding: 0.5rem; background: rgba(234,179,8,0.1); border-radius: 6px; text-align: center;">

--- a/panels/actions.html
+++ b/panels/actions.html
@@ -41,31 +41,31 @@
                                     <td> All outdoor activities</td>
                                 </tr>
                                 <tr style="background: rgba(234,179,8,0.1);">
-                                    <td><strong style="color: #EAB308;">51-100 Moderate</strong></td>
+                                    <td><strong style="color: #EAB308;">51-100 Satisfactory</strong></td>
                                     <td>Sensitive individuals limit prolonged outdoor exertion</td>
                                     <td>Reduce intense outdoor play</td>
                                     <td> Limit strenuous exercise</td>
                                 </tr>
                                 <tr style="background: rgba(249,115,22,0.1);">
-                                    <td><strong style="color: #F97316;">101-200 Poor</strong></td>
+                                    <td><strong style="color: #F97316;">101-200 Moderate</strong></td>
                                     <td>Keep windows closed. Run air purifier if available.</td>
                                     <td>Indoor play preferred</td>
                                     <td> No jogging/cycling outdoors</td>
                                 </tr>
                                 <tr style="background: rgba(27,107,74,0.08);">
-                                    <td><strong style="color: var(--red);">201-300 Very Poor</strong></td>
+                                    <td><strong style="color: var(--red);">201-300 Poor</strong></td>
                                     <td>Seal windows. Wet mop floors. N95 if going out.</td>
                                     <td>Stay indoors. No school commute if possible.</td>
                                     <td> Essential trips only with N95</td>
                                 </tr>
                                 <tr style="background: rgba(127,29,29,0.15);">
-                                    <td><strong style="color: #991B1B;">301-400 Severe</strong></td>
+                                    <td><strong style="color: #991B1B;">301-400 Very Poor</strong></td>
                                     <td>DIY air filter running. Damp towels on gaps. Mask indoors if no purifier.</td>
                                     <td>Consider staying with relatives in cleaner area</td>
                                     <td> Stay home. Work from home if possible.</td>
                                 </tr>
                                 <tr style="background: rgba(127,29,29,0.25);">
-                                    <td><strong style="color: #7F1D1D;">400+ Hazardous</strong></td>
+                                    <td><strong style="color: #7F1D1D;">401-500 Severe</strong></td>
                                     <td>Emergency mode. Multiple purifiers. Consider temporary relocation.</td>
                                     <td>Relocate if child/elderly has respiratory condition</td>
                                     <td> Complete lockdown. Emergency only.</td>
@@ -127,7 +127,7 @@
                                 <li><strong>Multiple purifiers</strong> — One per bedroom + living area for severe season</li>
                                 <li><strong>Electric cooking</strong> — Induction > LPG for indoor air quality</li>
                             </ul>
-                            <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Purifier sizing: CADR ≥ 2/3 of room volume (m³)</div>
+                            <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Purifier sizing: Smoke CADR (CFM) ≥ 2/3 of room floor area (sq ft) — AHAM rule</div>
                         </div>
                     </div>
                 </div>
@@ -336,7 +336,7 @@
                                         <li>In-situ decomposition with PUSA bio-decomposer (free from govt)</li>
                                     </ul>
                                 </li>
-                                <li><strong>Cooking:</strong> LPG > biomass chulha. PM2.5 from chulha = smoking 400 cigarettes/day</li>
+                                <li><strong>Cooking:</strong> LPG > biomass chulha. PM2.5 from chulha &asymp; smoking 400 cigarettes/hour (Prof. Kirk Smith, UC Berkeley)</li>
                                 <li><strong>Brick kilns:</strong> Report illegal kilns to SPCB. Zigzag technology mandate.</li>
                                 <li><strong>Road dust:</strong> Demand paving from Gram Panchayat. MGNREGA funds available.</li>
                                 <li><strong>Timing:</strong> Avoid working in fields early morning (mist traps pollution)</li>

--- a/panels/citizen-action.html
+++ b/panels/citizen-action.html
@@ -59,18 +59,10 @@
                             
                             <div style="margin-bottom: 0.75rem;">
                                 <div style="display: flex; justify-content: space-between; font-size: 0.875rem; margin-bottom: 0.25rem;">
-                                    <span> Vehicles (exhaust)</span><span style="font-weight: 600;">34%</span>
+                                    <span> Vehicles (transport)</span><span style="font-weight: 600;">~51%</span>
                                 </div>
                                 <div style="background: var(--bg); border-radius: 4px; height: 16px; overflow: hidden;">
-                                    <div style="width: 34%; height: 100%; background: #3B82F6;"></div>
-                                </div>
-                            </div>
-                            <div style="margin-bottom: 0.75rem;">
-                                <div style="display: flex; justify-content: space-between; font-size: 0.875rem; margin-bottom: 0.25rem;">
-                                    <span> Tyre/brake wear</span><span style="font-weight: 600;">24%</span>
-                                </div>
-                                <div style="background: var(--bg); border-radius: 4px; height: 16px; overflow: hidden;">
-                                    <div style="width: 24%; height: 100%; background: #6366F1;"></div>
+                                    <div style="width: 51%; height: 100%; background: #3B82F6;"></div>
                                 </div>
                             </div>
                             <div style="margin-bottom: 0.75rem;">
@@ -124,8 +116,8 @@
                         </div>
                         <div>
                             <div class="alert" style="background: rgba(27,107,74,0.08); border-left: 4px solid var(--green-700);">
-                                <strong style="color: var(--green-700);"> Vehicles = 58% of Delhi's internal PM2.5</strong>
-                                <p style="font-size: 0.875rem; margin-top: 0.5rem;">34% from exhaust + 24% from tyre/brake wear. This is why the only realistic solution is a <strong>massive shift from private to public transport</strong>.</p>
+                                <strong style="color: var(--green-700);"> Vehicles &asymp; half of Delhi's internal PM2.5</strong>
+                                <p style="font-size: 0.875rem; margin-top: 0.5rem;">Transport is the single largest local source &mdash; around 51-53% of Delhi's own winter PM2.5 (CSE analysis of IITM Decision Support System real-time data, 2023-25). This is why the only realistic solution is a <strong>massive shift from private to public transport</strong>.</p>
                             </div>
                             
                             <div class="info-box mt-2" style="border-left: 3px solid var(--accent);">

--- a/panels/legal.html
+++ b/panels/legal.html
@@ -178,7 +178,7 @@
                     <span class="card-title" style="color: var(--amber);">
                          RTI Reveals: CPCB Lacks Emission Data for Power Plants
                     </span>
-                    <span class="badge" style="background: #F59E0B; color: white; margin-left: 0.5rem;">Dec 2025</span>
+                    <span class="badge" style="background: #B45309; color: white; margin-left: 0.5rem;">Dec 2025</span>
                 </div>
                 <div class="card-body">
                     <div class="alert mb-2" style="background: rgba(245,158,11,0.1); border-left: 4px solid var(--accent);">
@@ -217,7 +217,7 @@
                 <div class="card-body">
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Courts across India have ordered governments to clean up the air. Pick your state or region below to see the orders that apply to you.">Key judicial and tribunal orders by state/region. Select a region to see orders relevant to your area.</p>
 
-                    <select class="form-select mb-2" id="legal-state-selector" onchange="document.querySelectorAll('.legal-state-block').forEach(function(b){b.style.display='none'}); var v=this.value; if(v) document.getElementById('legal-state-'+v).style.display='block';" style="max-width: 22rem;">
+                    <select class="form-select mb-2" id="legal-state-selector" aria-label="Choose a state to see its air-quality court rulings" onchange="document.querySelectorAll('.legal-state-block').forEach(function(b){b.style.display='none'}); var v=this.value; if(v) document.getElementById('legal-state-'+v).style.display='block';" style="max-width: 22rem;">
                         <option value="">-- Select State / Region --</option>
                         <option value="delhi-ncr">Delhi-NCR</option>
                         <option value="south">South India (TN / KL / KA / AP / TS / PY)</option>
@@ -472,7 +472,7 @@
                     <!-- Step 3: Write to MP/MLA -->
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <span style="background: #F59E0B; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 3</span>
+                            <span style="background: #B45309; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 3</span>
                             <h4 style="font-size: 0.9375rem; color: #92400E; margin: 0;">Write to Your MP / MLA</h4>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Write a letter to your local elected representative. Elected officials care about complaints from voters. Use the template below.">Elected representatives respond to constituent pressure. A well-written letter citing local data is surprisingly effective.</p>

--- a/panels/legal.html
+++ b/panels/legal.html
@@ -143,7 +143,7 @@
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">NCAP Deadline Elapsed</h4>
-                            <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>31 March 2026.</strong> NCAP's original 40% PM10 reduction target deadline passed. 23/100 cities with sufficient data met the target (CREA); CSE's April 2026 review finds 37/131. <strong>No revised programme announced</strong> as of mid-May 2026. 15th Finance Commission grants expired the same day.</p>
+                            <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>31 March 2026.</strong> NCAP's original 40% PM10 reduction target deadline passed. 23/100 cities with sufficient data met the target (CREA). <strong>No revised programme announced</strong> as of mid-May 2026. 15th Finance Commission grants expired the same day.</p>
                         </div>
                     </div>
                 </div>
@@ -166,7 +166,7 @@
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
                             <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Proposed ICE Sales Ban (2026)</h4>
-                            <p style="font-size: 0.875rem;">Legally defensible under EPA Section 3 & 5, given vehicles are 58% of internal PM2.5. Article 21 (Right to Life) overrides Article 19(1)(g) (Right to Trade).</p>
+                            <p style="font-size: 0.875rem;">Legally defensible under EPA Section 3 & 5, given vehicles are the largest single local source of Delhi&rsquo;s PM2.5 (~39%, TERI&ndash;ARAI 2018). Article 21 (Right to Life) overrides Article 19(1)(g) (Right to Trade).</p>
                         </div>
                     </div>
                 </div>

--- a/panels/progress.html
+++ b/panels/progress.html
@@ -6,7 +6,7 @@
 
     <!-- HEADLINE WINS -->
     <div class="stat-strip" style="margin-bottom: 2rem;">
-        <div class="stat-item"><div class="stat-value" style="color: var(--accent);">4,286</div><div class="stat-label">E-buses in Delhi (largest in India; verified Feb 9, 2026)</div></div>
+        <div class="stat-item"><div class="stat-value" style="color: var(--accent);">4,845</div><div class="stat-label">E-buses in Delhi (largest in India; latest count 9 Jul 2026)</div></div>
         <div class="stat-item"><div class="stat-value" style="color: var(--accent);">26.8%</div><div class="stat-label">Nationwide PM reduction 2019-2024 (NCAP aggregate)</div></div>
         <div class="stat-item"><div class="stat-value" style="color: var(--accent);">62,219</div><div class="stat-label">Excess deaths avoided in 20 cities (IIT Kharagpur, 2018-2022)</div></div>
         <div class="stat-item"><div class="stat-value" style="color: var(--accent);">6</div><div class="stat-label">South-Indian states ordered to file sector-wise PM roadmaps (NGT, Apr 2026)</div></div>
@@ -70,9 +70,9 @@
                 <div>
                     <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Delhi: Largest E-Bus Fleet in India</h4>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
-                        <p><strong>4,286 e-buses</strong> operational (last verified count, 9 Feb 2026 &mdash; overtaking Maharashtra's 4,001). CM Rekha Gupta flagged off 500 new buses at Ramlila Maidan.</p>
+                        <p><strong>4,845 e-buses</strong> operational (latest count, 9 Jul 2026, after 300 more were added &mdash; <a href="https://www.electrive.com/2026/07/09/india-delhi-adds-300-electric-buses-to-its-public-transport-fleet/" target="_blank" rel="noopener">electrive</a>); India's largest fleet, having overtaken Maharashtra's 4,001 in Feb 2026, when CM Rekha Gupta flagged off 500 new buses at Ramlila Maidan.</p>
                         <p style="margin-top: 0.5rem;"><strong>Targets:</strong> 7,500 by end 2026, 14,000 by 2028. Delhi-Panipat interstate e-bus route launched. <em>Mid-year (Q2/Q3 2026) public count expected.</em></p>
-                        <p style="margin-top: 0.5rem;"><strong>Impact math:</strong> Each diesel bus replaced eliminates ~25 tonnes CO2/year plus PM, NOx, SO2. At 4,286 e-buses, that's ~107,000 tonnes CO2 avoided annually.</p>
+                        <p style="margin-top: 0.5rem;"><strong>Impact math:</strong> Each diesel bus replaced eliminates ~25 tonnes CO2/year plus PM, NOx, SO2. At 4,845 e-buses, that's ~121,000 tonnes CO2 avoided annually.</p>
                         <p style="margin-top: 0.5rem;"><strong>Infrastructure:</strong> 8,849 EV charging stations (Dec 2025), 7,000 more planned across 2026. EV Policy 2.0 was initially expected by March 2026; <em>draft still awaited as of mid-May 2026</em>.</p>
                     </div>
                 </div>
@@ -80,7 +80,7 @@
                     <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">National E-Bus Landscape</h4>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         <p><strong>PM-eBus Sewa:</strong> $2.4 billion scheme for 10,000 e-buses across 169 cities by 2026 (WRI India). Half of eligible cities currently lack any organised bus transport.</p>
-                        <p style="margin-top: 0.5rem;"><strong>State leaderboard:</strong> Delhi (4,286), Maharashtra (4,001), Karnataka (1,989), Gujarat (1,041), Telangana (875), UP (874).</p>
+                        <p style="margin-top: 0.5rem;"><strong>State leaderboard:</strong> Delhi (4,845, Jul 2026), Maharashtra (4,001), Karnataka (1,989), Gujarat (1,041), Telangana (875), UP (874).</p>
                         <p style="margin-top: 0.5rem;"><strong>Surat:</strong> Phasing out all diesel buses by 2026, targeting 1,300 e-buses by 2030 through BRTS corridors.</p>
                         <p style="margin-top: 0.5rem;"><strong>Guwahati:</strong> Planning to become India's first city with a fully green public transport system. 271 e-buses operational.</p>
                     </div>

--- a/panels/resources.html
+++ b/panels/resources.html
@@ -103,7 +103,7 @@
                             <a href="https://aqli.epic.uchicago.edu/" target="_blank" rel="noopener">
                                 <div class="resource-type">Index <span class="badge badge-info">2025</span></div>
                                 <div class="resource-title">AQLI 2025: Air Quality Life Index</div>
-                                <div class="resource-desc">Average Indian loses 3.5 years of life expectancy; Indo-Gangetic Plain residents lose 7-8 years.</div>
+                                <div class="resource-desc">Average Indian loses 3.5 years of life expectancy; Indo-Gangetic Plain residents lose 5&ndash;8 years (Delhi-NCR up to 8.2, AQLI 2025).</div>
                             </a>
                         </div>
                         <div class="resource-card" data-keywords="iqair 2025 world air quality report loni delhi most polluted">
@@ -117,7 +117,7 @@
                             <a href="https://www.cseindia.org/is-india-s-national-clean-air-programme-ncap-achieving-its-objectives-a-new-cse-assessment-says-there-are-concerns-presents-an-agenda-for-reform-12290" target="_blank" rel="noopener">
                                 <div class="resource-type">Policy Review <span class="badge badge-warning">Apr 2026</span></div>
                                 <div class="resource-title">CSE NCAP Five-Year Review</div>
-                                <div class="resource-desc">27 of 96 cities with sufficient data met the 40% PM10 target by the elapsed 2026 deadline (CREA). 64% of NCAP funds went to dust suppression, not combustion sources.</div>
+                                <div class="resource-desc">23 of 100 NCAP cities met the 40% PM10 reduction target (CREA, Jan 2026). 64% of NCAP funds went to dust suppression, not combustion sources.</div>
                             </a>
                         </div>
                         <div class="resource-card" data-keywords="jaganathan lancet planetary health 2024 india causal pm25 mortality 8.6 difference-in-differences">
@@ -624,7 +624,7 @@
                             <a href="https://www.who.int/publications/i/item/9789240034228" target="_blank">
                                 <div class="resource-type">Guidelines <span class="badge badge-success">Open</span></div>
                                 <div class="resource-title">WHO Air Quality Guidelines 2021</div>
-                                <div class="resource-desc">Annual PM2.5 limit: 5 µg/m³. India is 20× over.</div>
+                                <div class="resource-desc">Annual PM2.5 limit: 5 µg/m³. India's national average is ~10× over (IQAir 2025).</div>
                             </a>
                         </div>
                         <div class="resource-card" data-keywords="gemm model burnett pnas mortality">
@@ -778,7 +778,7 @@
                                 <a href="https://www.stateofglobalair.org/health/hap" target="_blank">
                                     <div class="resource-type">Data Portal <span class="badge badge-danger">KEY</span></div>
                                     <div class="resource-title">State of Global Air: Household Air Pollution</div>
-                                    <div class="resource-desc">481,700 deaths/year in India. 60% women. Solid fuel cooking focus.</div>
+                                    <div class="resource-desc">Hundreds of thousands of deaths a year in India; women and children bear the greatest burden. Solid fuel cooking focus.</div>
                                 </a>
                             </div>
                             <div class="resource-card" data-keywords="ujjwala lpg scheme refill women">
@@ -873,7 +873,7 @@
                             <a href="https://www.iqair.com/in-en/newsroom/india-air-quality-alert" target="_blank">
                                 <div class="resource-type">Alert <span class="badge badge-danger">FEB 2026</span></div>
                                 <div class="resource-title">IQAir India Alert: Feb 2026</div>
-                                <div class="resource-desc">India avg PM2.5 50.6 ug/m3 (11x WHO). 5th globally. New studies: coal-crop impact, PM2.5 hotspots.</div>
+                                <div class="resource-desc">India avg PM2.5 50.6 ug/m3 (10x WHO). 5th globally. New studies: coal-crop impact, PM2.5 hotspots.</div>
                             </a>
                         </div>
                         <div class="resource-card" data-keywords="crea march 2026 naaqs 238 cities pm2.5 congress">

--- a/panels/source-selector.html
+++ b/panels/source-selector.html
@@ -28,9 +28,9 @@
             </div>
             <div class="card-body">
                 <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;">
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-600); font-weight: 600;">Government regulatory</span>
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-600); font-weight: 600;">Hourly</span>
-                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-600); font-weight: 600;">&plusmn;5-10% accuracy</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-700); font-weight: 600;">Government regulatory</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-700); font-weight: 600;">Hourly</span>
+                    <span style="font-size: 0.6875rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(5,150,105,0.08); color: var(--green-700); font-weight: 600;">&plusmn;5-10% accuracy</span>
                 </div>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="CPCB is the government's official air monitoring network. They use expensive, high-quality instruments. The data is legally valid. But many cities have only 2-3 stations, and investigations found many stations are poorly placed &mdash; 88% in one 2025 field survey, and 13 of 24 Delhi stations in a government (CAG) audit."><strong>Instruments:</strong> BAM/TEOM (beta attenuation / tapered element oscillating microbalance) &mdash; reference-grade instruments used worldwide for regulatory monitoring.</p>
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Coverage:</strong> ~586 continuous real-time (CAAQMS) stations in CPCB&rsquo;s national network (aqicn.org CPCB network count, 2026).</p>

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@
 
     --green-900: #0f2b1c;
     --green-800: #14532D;
-    --green-700: #15803D;
+    --green-700: #146c33; /* darkened from #15803D so green text meets AA 4.5:1 on tinted card backgrounds, not just white */
     --green-600: #157f3c; /* darkened from #16A34A so green text meets AA 4.5:1 on white */
     --green-500: #22C55E;
     --green-400: #4ADE80;
@@ -36,7 +36,7 @@
     --ink-faint: #5a5a54;
 
     --red: #c0392b;
-    --amber: #a86008; /* darkened to meet WCAG AA 4.5:1 for normal text on white */
+    --amber: #8a5300; /* darkened so amber text meets AA 4.5:1 on tinted backgrounds, not just white */
     --blue: #2563EB;
     --purple: #6D28D9;
     --sky: #0284c7; /* accessible sky-blue for stat text on white */

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606101';
+const CACHE_VERSION = 'janvayu-202606102';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606101',
-  '/app.js?v=202606101',
+  '/styles.css?v=202606102',
+  '/app.js?v=202606102',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606103';
+const CACHE_VERSION = 'janvayu-202606104';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606103',
-  '/app.js?v=202606103',
+  '/styles.css?v=202606104',
+  '/app.js?v=202606104',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606102';
+const CACHE_VERSION = 'janvayu-202606103';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606102',
-  '/app.js?v=202606102',
+  '/styles.css?v=202606103',
+  '/app.js?v=202606103',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Three quality items bundled (all merged-to-main safe):

## 1. Resolve the 25 content-sweep flags
A verification pass produced **23 edits** (16 fixes, 4 harmonisations, 2 removals, 1 reframe); **11 confirmed fine and left as-is** (the about-panel changelog + ward-blogs' own honestly-framed model outputs).
- **legal / citizen-action**: unsourced "vehicles = 58% of Delhi's PM2.5" → sourced (**~39% TERI-ARAI 2018** in legal; **~51% / "≈ half"** in citizen-action).
- **progress**: Delhi e-bus count refreshed to **4,845** (electrive, 9 Jul 2026) consistently, CO₂ math recomputed.
- **resources**: WHO card "20× over" → **"~10× over"** (national mean 48.9); NCAP "27" → **23** (CREA).
- **actions**: AQI band labels → CPCB's **official names** (51–100 *Satisfactory*), AHAM CADR rule, chulha↔cigarettes attribution.

Full log: `docs/fact-check-2026-07c.md`.

## 2. Accessibility contrast pass (axe WCAG 2.1 AA)
Ran axe-core across the key pages + panels and fixed every serious/critical violation found:
- Darkened `--green-700` (#15803D→**#146c33**) and `--amber` (#a86008→**#8a5300**) so green/amber label text clears 4.5:1 on the **tinted** card backgrounds (they passed on white but failed on the ~8% tints in budget / accountability / legal).
- Accountability "E2" orange #EA580C→**#C2410C**; legal badges white-on-#F59E0B (2.2:1) → white-on-**#B45309** (5.0:1).
- **Ask page** had its own tokens: darkened its `--accent` and `--text-3` (fixes the title, subtitle, header links, and white-on-accent city chips).
- Downloads meta text → `--text-2`; source-selector sensor badges → green-700.
- Decorative rotating logo scripts (हिन्दी/தமிழ்/বাংলা @ 0.5 opacity) marked **`aria-hidden`** (the "JanVayu" wordmark remains for SRs); legal state `<select>` given an **`aria-label`** (was a critical `select-name` violation).

The PR's own axe-audit CI re-checks `/`, `/ask/`, `/blog/`, `/downloads/`.

## 3. Roadmap
Logged **Phase 5.20** (native deck, fact-check rounds, apportionment ring) and marked the Phase 10 apportionment item done.

`node --test` 12/12. Version **26.6.104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)