### PR TITLE
Story of the week + air-literacy self-check quiz

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.105"
+version: "26.6.106"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.104"
+version: "26.6.105"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606104-v104';
+const CACHE_NAME = 'ask-janvayu-202606105-v105';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606105-v105';
+const CACHE_NAME = 'ask-janvayu-202606106-v106';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/data/stories.json
+++ b/data/stories.json
@@ -1,0 +1,53 @@
+{
+  "note": "Featured blog posts rotated weekly on the dashboard 'Story of the week' card. Ordered newest-ish first; rotation is deterministic by ISO week so it changes without a deploy. Edit freely.",
+  "stories": [
+    {
+      "title": "We Fact-Checked Our Own Site — and Changed 33 Numbers",
+      "blurb": "We turned our own scrutiny on ourselves: a site-wide audit of every statistic against current primary sources. Here's what was wrong, and how we now check every week.",
+      "tag": "Transparency",
+      "url": "/blog/#/posts/2026-07-17-we-factchecked-ourselves"
+    },
+    {
+      "title": "The Pollution You Can't See Being Emitted",
+      "blurb": "Up to 42% of India's PM2.5 isn't emitted directly — it forms in the sky from gases like SO₂. Dust-first clean-air spending misses most of it.",
+      "tag": "Data",
+      "url": "/blog/#/posts/2026-07-08-secondary-pm25"
+    },
+    {
+      "title": "NCAP at the Finish Line: Has It Worked?",
+      "blurb": "The National Clean Air Programme's deadline has elapsed. We follow the promises and the money to see which cities delivered — and which moved backwards.",
+      "tag": "Policy",
+      "url": "/blog/#/posts/2026-04-05-ncap-deadline"
+    },
+    {
+      "title": "The $339 Billion Question: What Pollution Costs India",
+      "blurb": "Dirty air isn't only a health story — it's an economic one. Lost workdays, lower yields, and a bill worth about 9.5% of GDP.",
+      "tag": "Economics",
+      "url": "/blog/#/posts/2026-03-25-economic-cost"
+    },
+    {
+      "title": "India's Children Are Paying the Price",
+      "blurb": "Smaller lungs, higher exposure, developing brains. Why children carry a disproportionate share of the air-pollution burden.",
+      "tag": "Health",
+      "url": "/blog/#/posts/2026-04-01-children-air-pollution"
+    },
+    {
+      "title": "How Farmers Outsmart Satellites: The Stubble-Burning Shell Game",
+      "blurb": "Fire counts fell — but so did the satellites' ability to see them. A look at what the overpass-timing shift hides.",
+      "tag": "Investigation",
+      "url": "/blog/#/posts/2026-03-28-stubble-burning-satellites"
+    },
+    {
+      "title": "A City Is Not One Number: Mapping India's Air Ward by Ward",
+      "blurb": "Your city's headline AQI hides enormous variation. We map fine-particle pollution down to the municipal ward.",
+      "tag": "Data",
+      "url": "/blog/#/posts/2026-06-10-how-polluted-is-your-ward"
+    },
+    {
+      "title": "The Lancet's Causal Evidence: 1.5 Million Deaths",
+      "blurb": "Correlation isn't causation — until it is. How Jaganathan et al. 2024 established a causal link between PM2.5 and mortality in India.",
+      "tag": "Research",
+      "url": "/blog/#/posts/2026-04-08-lancet-causal-evidence"
+    }
+  ]
+}

--- a/games.js
+++ b/games.js
@@ -971,3 +971,127 @@ function switchGame(name) {
         };
     }
 })();
+
+// ── AIR-LITERACY SELF-CHECK (Workshops panel) ──────────────────────────────
+// A standalone 10-question knowledge check, separate from the Games-panel quiz.
+// Same render pattern; its own `aqlit-*` element IDs. Facts align with the
+// site's verified figures (WHO annual PM2.5 = 5, India NAAQS = 40, etc.).
+const AQLIT_QUESTIONS = [
+    {
+        q: 'What does an AQI number mainly tell you?',
+        opts: ['The temperature outside', 'How polluted the air is, on a health-risk scale', 'The chance of rain', 'How many vehicles are on the road'],
+        ans: 1,
+        why: 'The Air Quality Index converts pollutant concentrations into a single 0-500+ health-risk scale with named bands (Good, Satisfactory, Moderate, Poor, Very Poor, Severe).'
+    },
+    {
+        q: '"PM2.5" refers to particles that are…',
+        opts: ['2.5 metres wide', '2.5 millimetres wide', '2.5 micrometres wide or smaller', 'made of exactly 2.5 chemicals'],
+        ans: 2,
+        why: 'PM2.5 is fine particulate matter 2.5 microns across or smaller — about 1/30th the width of a human hair. That is small enough to reach deep into the lungs and cross into the bloodstream.'
+    },
+    {
+        q: 'The WHO says annual PM2.5 should stay below…',
+        opts: ['5 µg/m³', '40 µg/m³', '100 µg/m³', 'There is no guideline'],
+        ans: 0,
+        why: 'The WHO 2021 Global Air Quality Guideline for annual PM2.5 is 5 µg/m³. Most Indian cities are many times over it.'
+    },
+    {
+        q: 'India’s own national standard (NAAQS) for annual PM2.5 is…',
+        opts: ['5 µg/m³', '40 µg/m³', '10 µg/m³', 'the same as the WHO limit'],
+        ans: 1,
+        why: 'India’s NAAQS annual PM2.5 limit is 40 µg/m³ — eight times the WHO guideline of 5. So "meets Indian standards" is not the same as "safe".'
+    },
+    {
+        q: 'A city’s AQI is reported as a single number. How is it chosen from all the pollutants?',
+        opts: ['It is the average of every pollutant', 'It is the worst (highest) sub-index among the pollutants', 'It is always the PM2.5 value', 'It is chosen at random each hour'],
+        ans: 1,
+        why: 'The overall AQI is the worst of the individual pollutant sub-indices (CPCB uses up to eight: PM2.5, PM10, NO₂, SO₂, CO, O₃, NH₃, Pb). One bad pollutant sets the headline number.'
+    },
+    {
+        q: 'A lot of India’s PM2.5 is "secondary". What does that mean?',
+        opts: ['It is less harmful', 'It forms in the air from gases, rather than being emitted directly', 'It only appears at night', 'It comes only from vehicles'],
+        ans: 1,
+        why: 'Up to ~42% of India’s PM2.5 is secondary — formed in the atmosphere from gases like SO₂ and NOₓ (e.g. ammonium sulphate). That is why dust-only control misses much of the problem.'
+    },
+    {
+        q: 'On a "Severe" AQI day, the most useful thing to do is…',
+        opts: ['Go for a long outdoor run to build tolerance', 'Limit outdoor exertion; use an N95/FFP2 mask and a purifier indoors', 'Open all windows to let fresh air in', 'Nothing — masks do not help'],
+        ans: 1,
+        why: 'On severe days, cut strenuous outdoor activity, keep windows shut, run a purifier if you have one, and wear a well-fitted N95/FFP2 mask outdoors — these do filter fine particles.'
+    },
+    {
+        q: 'Indoor air, compared with outdoor air, is…',
+        opts: ['Always cleaner', 'Often just as bad or worse — cooking smoke, no filtration', 'Never a concern', 'Only polluted if you smoke'],
+        ans: 1,
+        why: 'Indoor PM2.5 tracks outdoor levels and is often worsened by cooking (especially biomass fuels), incense, and closed rooms. Household air pollution is a major health burden in India.'
+    },
+    {
+        q: 'To compare how polluted two cities are over a whole year, the best number is…',
+        opts: ['One day’s AQI reading', 'The annual-average PM2.5 concentration', 'The hottest day’s temperature', 'The number of monitoring stations'],
+        ans: 1,
+        why: 'A single day’s AQI swings with weather. The fair yardstick is the annual-average PM2.5 (µg/m³) — the basis for rankings like IQAir’s and for the WHO/India standards.'
+    },
+    {
+        q: 'Who is generally most vulnerable to air pollution?',
+        opts: ['Only the elderly', 'Children, pregnant women, the elderly, and people with heart or lung conditions', 'Only outdoor workers', 'Everyone equally, with no differences'],
+        ans: 1,
+        why: 'Children (developing lungs, higher breathing rate), pregnant women, older adults, and people with existing heart or lung disease face the highest risk — though sustained exposure harms everyone.'
+    }
+];
+let aqlitState = { i: 0, score: 0, answered: false };
+function startAqLit() {
+    aqlitState = { i: 0, score: 0, answered: false };
+    var t = document.getElementById('aqlit-q-total');
+    if (t) t.textContent = AQLIT_QUESTIONS.length;
+    renderAqLit();
+}
+function renderAqLit() {
+    var body = document.getElementById('aqlit-card-body');
+    if (!body) return;
+    if (aqlitState.i >= AQLIT_QUESTIONS.length) {
+        var pct = Math.round(aqlitState.score / AQLIT_QUESTIONS.length * 100);
+        var verdict = pct >= 90 ? 'Air-literate. You could teach this.' : pct >= 70 ? 'Strong — you know the essentials.' : pct >= 50 ? 'A useful baseline. Keep exploring the site.' : 'A workshop would help — and that’s exactly what this page is for.';
+        body.innerHTML = '<h3 style="font-family: var(--serif); margin: 0 0 8px;">Self-check complete</h3>' +
+            '<div style="font-size: 1.4rem; font-weight: 700; color: var(--accent); margin-bottom: 6px;">' + aqlitState.score + ' / ' + AQLIT_QUESTIONS.length + '  (' + pct + '%)</div>' +
+            '<div style="font-size: 0.9rem; color: var(--text-2); margin-bottom: 14px;">' + verdict + '</div>' +
+            '<button type="button" class="btn btn-primary" onclick="startAqLit()">Try again</button>';
+        var n = document.getElementById('aqlit-q-num');
+        if (n) n.textContent = AQLIT_QUESTIONS.length;
+        return;
+    }
+    var Q = AQLIT_QUESTIONS[aqlitState.i];
+    var qn = document.getElementById('aqlit-q-num');
+    if (qn) qn.textContent = aqlitState.i + 1;
+    var sc = document.getElementById('aqlit-score');
+    if (sc) sc.textContent = aqlitState.score;
+    aqlitState.answered = false;
+    var html = '<div style="font-family: var(--serif); font-size: 1.15rem; line-height: 1.4; margin-bottom: 14px;">' + Q.q + '</div>';
+    html += '<div style="display: flex; flex-direction: column; gap: 8px;">';
+    Q.opts.forEach(function (opt, i) {
+        html += '<button type="button" class="quiz-opt-btn" onclick="answerAqLit(' + i + ')" data-i="' + i + '" style="text-align: left; padding: 10px 14px; border-radius: 8px; border: 1px solid var(--border); background: var(--bg-section); color: var(--ink); font-size: 0.9rem; cursor: pointer;">' + String.fromCharCode(65 + i) + '. ' + opt + '</button>';
+    });
+    html += '</div><div id="aqlit-feedback" style="margin-top: 14px;"></div>';
+    body.innerHTML = html;
+}
+function answerAqLit(i) {
+    if (aqlitState.answered) return;
+    aqlitState.answered = true;
+    var Q = AQLIT_QUESTIONS[aqlitState.i];
+    var correct = i === Q.ans;
+    if (correct) aqlitState.score += 1;
+    document.querySelectorAll('#aqlit-card-body .quiz-opt-btn').forEach(function (btn) {
+        var idx = parseInt(btn.getAttribute('data-i'));
+        btn.style.cursor = 'default';
+        if (idx === Q.ans) { btn.style.background = '#DCFCE7'; btn.style.borderColor = '#86EFAC'; btn.style.color = '#166534'; btn.style.fontWeight = '700'; }
+        else if (idx === i) { btn.style.background = '#FEE2E2'; btn.style.borderColor = '#FCA5A5'; btn.style.color = '#991B1B'; }
+        else { btn.style.opacity = '0.6'; }
+    });
+    var fb = document.getElementById('aqlit-feedback');
+    if (fb) fb.innerHTML = '<div style="padding: 12px; border-radius: 8px; background: var(--bg-section); border-left: 3px solid ' + (correct ? '#22C55E' : '#EF4444') + ';">' +
+        '<div style="font-weight: 700; margin-bottom: 6px; color: ' + (correct ? '#166534' : '#991B1B') + ';">' + (correct ? 'Correct.' : 'Not quite.') + '</div>' +
+        '<div style="font-size: 0.85rem; color: var(--text-2); line-height: 1.55;">' + Q.why + '</div>' +
+        '<button type="button" class="btn btn-primary mt-2" onclick="nextAqLit()">' + (aqlitState.i + 1 === AQLIT_QUESTIONS.length ? 'See results' : 'Next question') + '</button></div>';
+    var sc = document.getElementById('aqlit-score');
+    if (sc) sc.textContent = aqlitState.score;
+}
+function nextAqLit() { aqlitState.i += 1; renderAqLit(); }

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606104">
+    <link rel="stylesheet" href="/styles.css?v=202606105">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -830,7 +830,7 @@
                                 <span class="hero-cta-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg></span>
                                 <span class="hero-cta-text">
                                     <span class="hero-cta-title">New here? Take the guided tour</span>
-                                    <span class="hero-cta-sub">A 64-slide walkthrough of everything JanVayu tracks &mdash; the data, the health toll, the money, the tools.</span>
+                                    <span class="hero-cta-sub">A guided walkthrough of everything JanVayu tracks &mdash; the data, the health toll, the money, the tools.</span>
                                 </span>
                                 <span class="hero-cta-arrow" aria-hidden="true">&rarr;</span>
                             </a>
@@ -1157,6 +1157,20 @@
             </div>
         </div>
 
+        <!-- STORY OF THE WEEK — a rotating featured blog post -->
+        <div class="container" style="padding-top: 18px;">
+            <div class="dash-section" style="margin-top: 0; border-top: 1px solid var(--border); padding-top: 22px;">
+                <span class="dash-section-eyebrow">From the blog</span>
+                <h2 class="dash-section-title" data-i18n="story_heading">Story of the week</h2>
+            </div>
+            <a class="story-week-card" id="story-of-week" href="/blog/" hidden>
+                <span class="story-week-tag" id="story-week-tag"></span>
+                <span class="story-week-title" id="story-week-title"></span>
+                <span class="story-week-blurb" id="story-week-blurb"></span>
+                <span class="story-week-cta">Read the story <span aria-hidden="true">&rarr;</span></span>
+            </a>
+        </div>
+
         <!-- DID YOU KNOW — surprising, citable, India-specific facts -->
         <div class="container" style="padding-top: 18px;">
             <div class="dash-section" style="margin-top: 0; border-top: 1px solid var(--border); padding-top: 22px;">
@@ -1335,7 +1349,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606104"></script>
+    <script src="/app.js?v=202606105"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -6251,6 +6265,32 @@ window.handleWorkshopSubmit = async function (event, kind) {
             });
         })
         .catch(function() { /* stats.json unavailable — keep existing values */ });
+
+    // Story of the week — deterministic weekly rotation of a featured blog post.
+    (function initStoryOfWeek() {
+        var card = document.getElementById('story-of-week');
+        if (!card) return;
+        fetch('/data/stories.json')
+            .then(function(r) { return r.ok ? r.json() : null; })
+            .then(function(data) {
+                var list = data && data.stories;
+                if (!list || !list.length) return;
+                // ISO-week index so the pick changes weekly without a deploy.
+                var now = new Date();
+                var start = new Date(now.getFullYear(), 0, 1);
+                var week = Math.floor((now - start) / (7 * 24 * 60 * 60 * 1000));
+                var s = list[((week % list.length) + list.length) % list.length];
+                var tag = document.getElementById('story-week-tag');
+                var title = document.getElementById('story-week-title');
+                var blurb = document.getElementById('story-week-blurb');
+                if (tag) tag.textContent = s.tag || 'Blog';
+                if (title) title.textContent = s.title || '';
+                if (blurb) blurb.textContent = s.blurb || '';
+                if (s.url) card.setAttribute('href', s.url);
+                card.hidden = false;
+            })
+            .catch(function() { /* stories.json unavailable — card stays hidden */ });
+    })();
 })();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606105">
+    <link rel="stylesheet" href="/styles.css?v=202606106">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1349,7 +1349,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606105"></script>
+    <script src="/app.js?v=202606106"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -2858,6 +2858,23 @@
             <div class="alert alert-info mt-3"><div data-simple="JanVayu walkthroughs (run by our team) are free. The UrbanEmissions workshop with Dr. Guttikunda is run by him and he sets his own fee — we just pass on your request. We don't share your contact details with anyone except the facilitator.">
                 <strong>Note:</strong> <strong>JanVayu walkthroughs</strong> (run by our team) are free. The <strong>UrbanEmissions workshop</strong> is facilitated independently by Dr. Sarath Guttikunda, who sets his own fee and schedule &mdash; we simply forward your request to him. We don't share your contact details with anyone other than the facilitator. If you'd like to host us at a larger event or sponsor a workshop series, write to us via the <a href="#about" onclick="showPanel('about'); return false;">About page</a>.
             </div></div>
+
+            <!-- ── Air-literacy self-check (companion to the facilitated workshop) ── -->
+            <div class="dash-section" style="margin-top: 2.5rem; border-top: 1px solid var(--border); padding-top: 1.75rem;">
+                <span class="dash-section-eyebrow">Before or after a session</span>
+                <h3 style="font-family: var(--serif); font-size: clamp(1.35rem, 2.5vw, 1.75rem); line-height: 1.25; margin: 0.4rem 0 0.6rem; color: var(--ink);">How air-literate are you?</h3>
+                <p style="font-size: 1rem; line-height: 1.65; color: var(--text-2); max-width: 44rem;" data-simple="A short 10-question quiz to test what you know about air pollution. Every answer explains the science. Great before or after a workshop.">A quick <strong>10-question self-check</strong> on the essentials &mdash; what the AQI actually measures, how India's standards compare, what to do on a bad day. Every answer explains the science, so it teaches as it tests. Handy as a warm-up or a wrap-up for a workshop.</p>
+            </div>
+            <div class="card" style="max-width: 44rem; margin-top: 1rem;">
+                <div class="card-header">
+                    <span class="card-title">Air-Literacy Self-Check</span>
+                    <span style="font-size: 0.72rem; color: var(--text-3);">Question <span id="aqlit-q-num">1</span> / <span id="aqlit-q-total">10</span> &middot; Score <span id="aqlit-score">0</span></span>
+                </div>
+                <div class="card-body" id="aqlit-card-body" style="min-height: 12rem;">
+                    <p style="color: var(--text-2); line-height: 1.6; margin-bottom: 1rem;">Ten questions, no sign-up, instant feedback. Ready?</p>
+                    <button type="button" class="btn btn-primary" onclick="startAqLit()">Start the self-check</button>
+                </div>
+            </div>
 
 </template>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.104",
+  "version": "26.6.105",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.105",
+  "version": "26.6.106",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -2732,3 +2732,11 @@ body {
     .apportion-layout { grid-template-columns: 1fr; gap: 1.25rem; }
     .apportion-ringwrap { max-width: 300px; margin: 0 auto; }
 }
+
+/* ── Story of the week (dashboard) ─────────────────────────────────────── */
+.story-week-card { display: block; text-decoration: none; border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0.7rem; padding: 1.1rem 1.25rem; background: var(--bg-card); transition: box-shadow 0.15s, transform 0.15s; }
+.story-week-card:hover { box-shadow: 0 6px 20px rgba(0,0,0,0.07); transform: translateY(-1px); }
+.story-week-tag { display: inline-block; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--green-700); background: var(--bg-section); padding: 0.15rem 0.5rem; border-radius: 999px; margin-bottom: 0.55rem; }
+.story-week-title { display: block; font-family: var(--serif, Georgia, serif); font-size: 1.2rem; line-height: 1.3; color: var(--ink); margin-bottom: 0.4rem; }
+.story-week-blurb { display: block; font-size: 0.95rem; line-height: 1.6; color: var(--text-2); margin-bottom: 0.6rem; }
+.story-week-cta { display: inline-block; font-size: 0.9rem; font-weight: 600; color: var(--green-700); }

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606105';
+const CACHE_VERSION = 'janvayu-202606106';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606105',
-  '/app.js?v=202606105',
+  '/styles.css?v=202606106',
+  '/app.js?v=202606106',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606104';
+const CACHE_VERSION = 'janvayu-202606105';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606104',
-  '/app.js?v=202606104',
+  '/styles.css?v=202606105',
+  '/app.js?v=202606105',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Two Phase 10 backlog features.

## Story of the week (dashboard)
A "Story of the week" card on the dashboard surfaces one featured blog post, **rotating deterministically by ISO week** so it changes without a deploy. Content lives in `data/stories.json` (8 curated posts, freely editable); the card stays hidden if the data can't load. Also fixed stale hero copy left from the Google-Slides deck ("A 64-slide walkthrough" → "A guided walkthrough").

*Verified via Playwright: card un-hides and renders the week's pick with the correct link, no page errors.*

## Air-literacy self-check (Workshops panel)
A standalone **10-question "How air-literate are you?"** self-check at the bottom of the Workshops panel — a companion to Dr. Guttikunda's facilitated Jeopardy session, framed as a warm-up/wrap-up. Instant per-question feedback that *explains the science*; scored result with a verdict. Questions align with the site's verified figures (WHO annual PM2.5 = 5, India NAAQS = 40, AQI = worst sub-index, ~42% secondary PM2.5).

Implemented in `games.js` (its own `AQLIT_QUESTIONS` + `aqlit-*` handlers, separate from the Games-panel quiz).

*Verified via Playwright: 10 questions, options render, answering shows sourced feedback, no page errors.*

Delivers the Phase 10 **story-of-the-week** and **in-browser AQ-literacy quiz** items. Version **26.6.106**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_