### PR TITLE
Searchable city combobox for the hero selector

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.106"
+version: "26.6.107"

--- a/app.js
+++ b/app.js
@@ -2856,8 +2856,106 @@
     }
 
     // ── Init ──
+    // ── Searchable city combobox ──
+    // Wraps a native <select> in a type-to-filter combobox WITHOUT removing the
+    // select: the select keeps holding the value and firing 'change', so every
+    // downstream handler (updateHeroCity, generateAQICard, …) keeps working. The
+    // combobox is a WAI-ARIA listbox pattern (role=combobox + role=listbox).
+    window.enhanceCityCombobox = function enhanceCityCombobox(select) {
+        if (!select || select.dataset.comboEnhanced) return;
+        select.dataset.comboEnhanced = '1';
+        const opts = Array.from(select.querySelectorAll('option'))
+            .map(o => ({ value: o.value, label: (o.textContent || '').trim() }))
+            .filter(o => o.value);
+        const wrap = document.createElement('div');
+        wrap.className = 'city-combo';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'city-combo-input';
+        input.setAttribute('role', 'combobox');
+        input.setAttribute('aria-autocomplete', 'list');
+        input.setAttribute('aria-expanded', 'false');
+        input.setAttribute('autocomplete', 'off');
+        input.setAttribute('placeholder', 'Search city…');
+        const lbl = select.getAttribute('aria-label');
+        if (lbl) input.setAttribute('aria-label', lbl);
+        const listId = 'combo-list-' + (select.id || ('c' + Math.floor(opts.length * 997)));
+        const list = document.createElement('ul');
+        list.className = 'city-combo-list';
+        list.id = listId;
+        list.setAttribute('role', 'listbox');
+        list.hidden = true;
+        input.setAttribute('aria-controls', listId);
+        const cur = opts.find(o => o.value === select.value);
+        if (cur) input.value = cur.label;
+        select.parentNode.insertBefore(wrap, select);
+        wrap.appendChild(input);
+        wrap.appendChild(list);
+        wrap.appendChild(select);
+        select.style.display = 'none';
+        select.setAttribute('tabindex', '-1');
+        select.setAttribute('aria-hidden', 'true');
+        let active = -1;
+        let filtered = opts.slice();
+        function renderList(items) {
+            list.innerHTML = items.map((o, i) =>
+                '<li role="option" class="city-combo-opt" id="' + listId + '-opt-' + i + '" data-value="' + o.value + '">' + o.label + '</li>'
+            ).join('') || '<li class="city-combo-empty" aria-disabled="true">No match</li>';
+        }
+        function openList() { list.hidden = false; input.setAttribute('aria-expanded', 'true'); }
+        function closeList() { list.hidden = true; input.setAttribute('aria-expanded', 'false'); active = -1; input.removeAttribute('aria-activedescendant'); }
+        function doFilter(q) {
+            q = (q || '').trim().toLowerCase();
+            filtered = q ? opts.filter(o => o.label.toLowerCase().indexOf(q) !== -1) : opts.slice();
+            renderList(filtered);
+        }
+        function highlight() {
+            Array.from(list.querySelectorAll('.city-combo-opt')).forEach((li, i) => {
+                const on = i === active;
+                li.classList.toggle('active', on);
+                if (on) { input.setAttribute('aria-activedescendant', li.id); li.scrollIntoView({ block: 'nearest' }); }
+            });
+        }
+        function choose(o) {
+            if (!o) return;
+            select.value = o.value;
+            input.value = o.label;
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            closeList();
+        }
+        input.addEventListener('focus', () => { doFilter(''); openList(); input.select(); });
+        input.addEventListener('input', () => { doFilter(input.value); openList(); active = -1; });
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown') { e.preventDefault(); if (list.hidden) { doFilter(''); openList(); } active = Math.min(active + 1, filtered.length - 1); highlight(); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); active = Math.max(active - 1, 0); highlight(); }
+            else if (e.key === 'Enter') { if (!list.hidden && active >= 0 && filtered[active]) { e.preventDefault(); choose(filtered[active]); } }
+            else if (e.key === 'Escape') { closeList(); }
+        });
+        input.addEventListener('blur', () => {
+            // If they typed a full match, accept it; otherwise restore the current selection.
+            setTimeout(() => {
+                if (list.hidden) return;
+                const typed = input.value.trim().toLowerCase();
+                const exact = opts.find(o => o.label.toLowerCase() === typed);
+                if (exact) choose(exact);
+                else { const c = opts.find(o => o.value === select.value); if (c) input.value = c.label; closeList(); }
+            }, 120);
+        });
+        list.addEventListener('mousedown', (e) => {
+            const li = e.target.closest('.city-combo-opt');
+            if (li) { e.preventDefault(); choose(opts.find(o => o.value === li.getAttribute('data-value'))); }
+        });
+        document.addEventListener('click', (e) => { if (!wrap.contains(e.target)) closeList(); });
+        // Keep the input label in sync if the value is changed elsewhere in code.
+        select.addEventListener('change', () => {
+            const c = opts.find(o => o.value === select.value);
+            if (c && document.activeElement !== input) input.value = c.label;
+        });
+    };
+
     document.addEventListener('DOMContentLoaded', async () => {
         console.log('[JanVayu] Initializing redesigned version...');
+        try { window.enhanceCityCombobox(document.getElementById('hero-city-select')); } catch (e) { console.warn('city combobox:', e); }
 
         // ── PWA: register service worker for offline shell + last-known AQI cache ──
         if ('serviceWorker' in navigator) {

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606106-v106';
+const CACHE_NAME = 'ask-janvayu-202606107-v107';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606106">
+    <link rel="stylesheet" href="/styles.css?v=202606107">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1349,7 +1349,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606106"></script>
+    <script src="/app.js?v=202606107"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.106",
+  "version": "26.6.107",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/styles.css
+++ b/styles.css
@@ -2740,3 +2740,29 @@ body {
 .story-week-title { display: block; font-family: var(--serif, Georgia, serif); font-size: 1.2rem; line-height: 1.3; color: var(--ink); margin-bottom: 0.4rem; }
 .story-week-blurb { display: block; font-size: 0.95rem; line-height: 1.6; color: var(--text-2); margin-bottom: 0.6rem; }
 .story-week-cta { display: inline-block; font-size: 0.9rem; font-weight: 600; color: var(--green-700); }
+
+/* ── Searchable city combobox ───────────────────────────────────────────── */
+.city-combo { position: relative; flex: 1; min-width: 0; }
+.city-combo-input {
+    width: 100%; box-sizing: border-box;
+    font-family: var(--sans); font-size: 0.72rem; font-weight: 600;
+    background: var(--bg-section); color: var(--ink);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 5px 8px; cursor: text;
+}
+.city-combo-input::placeholder { color: var(--text-3); font-weight: 500; text-transform: none; letter-spacing: 0; }
+.city-combo-input:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+.city-combo-list {
+    position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 60;
+    margin: 0; padding: 4px; list-style: none;
+    max-height: 15rem; overflow-y: auto;
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.14);
+}
+.city-combo-input { text-align: left; }
+.city-combo-opt {
+    padding: 7px 10px; border-radius: 6px; font-size: 0.85rem; color: var(--ink); cursor: pointer; text-align: left;
+}
+.city-combo-opt:hover, .city-combo-opt.active { background: var(--bg-section); }
+.city-combo-opt.active { outline: 1px solid var(--accent); }
+.city-combo-empty { padding: 7px 10px; font-size: 0.85rem; color: var(--text-3); }

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606106';
+const CACHE_VERSION = 'janvayu-202606107';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606106',
-  '/app.js?v=202606106',
+  '/styles.css?v=202606107',
+  '/app.js?v=202606107',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Replaces the long grouped hero city dropdown with a **type-to-filter combobox** (Phase 6 / issue #2 item).

## Design
It **wraps** the native `<select>` rather than replacing it: the select stays in the DOM (hidden) holding the value and firing `change`, so every downstream handler — `updateHeroCity`, `generateAQICard`, `shareOnWhatsApp` — keeps working untouched. Zero changes to the rest of the dashboard's wiring.

- WAI-ARIA listbox pattern: `role="combobox"` + `role="listbox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`.
- Full keyboard support: ↑/↓ to move, Enter to select, Esc to close; click-outside and blur handled (blur accepts an exact typed match or restores the current selection).
- Exposed as `window.enhanceCityCombobox(select)` so the other city selectors can adopt it later without duplication.

## Verification (Playwright)
- Native select hidden ✓
- Type "mum" → filters to Mumbai ✓
- Click Mumbai → `select.value = "mumbai"`, input shows "Mumbai", `change` fires ✓
- Keyboard: "kol" + ↓ + Enter → `select.value = "kolkata"` ✓
- No page errors ✓

Version **26.6.107**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_