### PR TITLE
Mobile fixes: heading order, responsive table cards, walkthrough deck

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.107"
+version: "26.6.108"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-07-17"
-version: "26.6.108"
+version: "26.6.109"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606108-v108';
+const CACHE_NAME = 'ask-janvayu-202606109-v109';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606107-v107';
+const CACHE_NAME = 'ask-janvayu-202606108-v108';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606108">
+    <link rel="stylesheet" href="/styles.css?v=202606109">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1349,7 +1349,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606108"></script>
+    <script src="/app.js?v=202606109"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/styles.css?v=202606107">
+    <link rel="stylesheet" href="/styles.css?v=202606108">
 </head>
 <body>
     <!-- ═══ ACCESSIBILITY: Skip to content ═══ -->
@@ -1074,73 +1074,73 @@
                 <div class="grid-4 mt-3">
                     <div class="quick-link" onclick="showPanel('health')">
                         <div class="quick-link-icon health"><span class="si si-hospital" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_health_title">Health Calculator</h4><p data-i18n="ql_health_desc">Your personal risk</p></div>
+                        <div><h3 data-i18n="ql_health_title">Health Calculator</h3><p data-i18n="ql_health_desc">Your personal risk</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('economic')">
                         <div class="quick-link-icon economic"><span class="si si-rupee" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_economic_title">Economic Impact</h4><p data-i18n="ql_economic_desc">Productivity loss</p></div>
+                        <div><h3 data-i18n="ql_economic_title">Economic Impact</h3><p data-i18n="ql_economic_desc">Productivity loss</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('aqi-explainer')">
                         <div class="quick-link-icon" style="background: #EFF6FF; color: var(--ink);"><span class="si si-info" style="width:20px;height:20px;"></span></div>
-                        <div><h4>What is AQI?</h4><p>The number explained — all 6 pollutants, two scales, what they hide</p></div>
+                        <div><h3>What is AQI?</h3><p>The number explained — all 6 pollutants, two scales, what they hide</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('source-selector')">
                         <div class="quick-link-icon" style="background: #FEF3C7; color: var(--amber);"><span class="si si-eye" style="width:20px;height:20px;"></span></div>
-                        <div><h4>Trust the Data?</h4><p>Choose your sources — CPCB, WAQI, IQAir, community sensors</p></div>
+                        <div><h3>Trust the Data?</h3><p>Choose your sources — CPCB, WAQI, IQAir, community sensors</p></div>
                     </div>
                 </div>
                 <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('accountability')">
                         <div class="quick-link-icon policy"><span class="si si-shield" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_accountability_t">Accountability</h4><p data-i18n="ql_accountability_d">Mission Tracker & RTI</p></div>
+                        <div><h3 data-i18n="ql_accountability_t">Accountability</h3><p data-i18n="ql_accountability_d">Mission Tracker & RTI</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('voices')">
                         <div class="quick-link-icon tools"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_voices_t">Voices Online</h4><p data-i18n="ql_voices_d">What India is posting about its air &mdash; a curated social-media archive</p></div>
+                        <div><h3 data-i18n="ql_voices_t">Voices Online</h3><p data-i18n="ql_voices_d">What India is posting about its air &mdash; a curated social-media archive</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('testimony')">
                         <div class="quick-link-icon" style="background: #ECFDF5; color: var(--green-600);"><span class="si si-chat" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_testimony_t">Field Testimony</h4><p data-i18n="ql_testimony_d">First-person accounts recorded on the ground &mdash; 100+ people, 13 languages</p></div>
+                        <div><h3 data-i18n="ql_testimony_t">Field Testimony</h3><p data-i18n="ql_testimony_d">First-person accounts recorded on the ground &mdash; 100+ people, 13 languages</p></div>
                     </div>
                     <div class="quick-link" onclick="loadPanel('ward-map')">
                         <div class="quick-link-icon" style="background: #ECFEFF; color: #0891B2;"><span class="si si-pin" style="width:20px;height:20px;"></span></div>
-                        <div><h4>Your Ward</h4><p>How polluted is your ward? Air, heat &amp; green cover</p></div>
+                        <div><h3>Your Ward</h3><p>How polluted is your ward? Air, heat &amp; green cover</p></div>
                     </div>
                 </div>
                 <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('go-outside')">
                         <div class="quick-link-icon" style="background: #EFF6FF; color: var(--ink);"><span class="si si-flare" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_outside_t">Go Outside?</h4><p data-i18n="ql_outside_d">Real-time advice</p></div>
+                        <div><h3 data-i18n="ql_outside_t">Go Outside?</h3><p data-i18n="ql_outside_d">Real-time advice</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('social-feed')">
                         <div class="quick-link-icon" style="background: #FFF7ED; color: #F97316;"><span class="si si-article" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_social_t">Social Feed</h4><p data-i18n="ql_social_d">Live from Reddit &amp; X</p></div>
+                        <div><h3 data-i18n="ql_social_t">Social Feed</h3><p data-i18n="ql_social_d">Live from Reddit &amp; X</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('aqi-alerts')">
                         <div class="quick-link-icon" style="background: #FEF2F2; color: var(--red);"><span class="si si-notifications" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_alerts_t">AQI Alerts</h4><p data-i18n="ql_alerts_d">Get notified</p></div>
+                        <div><h3 data-i18n="ql_alerts_t">AQI Alerts</h3><p data-i18n="ql_alerts_d">Get notified</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('school-closure')">
                         <div class="quick-link-icon" style="background: #F5F3FF; color: var(--purple);"><span class="si si-library" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_school_t">School Status</h4><p data-i18n="ql_school_d">School closure forecast</p></div>
+                        <div><h3 data-i18n="ql_school_t">School Status</h3><p data-i18n="ql_school_d">School closure forecast</p></div>
                     </div>
                 </div>
                 <div class="grid-4 mt-2">
                     <div class="quick-link" onclick="showPanel('games')">
                         <div class="quick-link-icon" style="background: #ECFDF5; color: var(--green-700);"><span class="si si-library" style="width:20px;height:20px;"></span></div>
-                        <div><h4 data-i18n="ql_games_t">Learning Games</h4><p data-i18n="ql_games_d">Seven games: Jeopardy, Vayu Junction &amp; more</p></div>
+                        <div><h3 data-i18n="ql_games_t">Learning Games</h3><p data-i18n="ql_games_d">Seven games: Jeopardy, Vayu Junction &amp; more</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('gallery')">
                         <div class="quick-link-icon" style="background: #ECFEFF; color: #0891B2;"><span class="si si-image" style="width:20px;height:20px;"></span></div>
-                        <div><h4>Photo Gallery <span style="font-size: 0.55rem; padding: 1px 6px; border-radius: 999px; background: var(--accent); color: var(--on-accent); vertical-align: middle; margin-left: 4px;">NEW</span></h4><p>The air, in pictures &mdash; 24 open-licensed photographs</p></div>
+                        <div><h3>Photo Gallery <span style="font-size: 0.55rem; padding: 1px 6px; border-radius: 999px; background: var(--accent); color: var(--on-accent); vertical-align: middle; margin-left: 4px;">NEW</span></h3><p>The air, in pictures &mdash; 24 open-licensed photographs</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('rankings')">
                         <div class="quick-link-icon" style="background: #FEF2F2; color: var(--red);"><span class="si si-bar-chart" style="width:20px;height:20px;"></span></div>
-                        <div><h4>City Rankings</h4><p>Cleanest &amp; most polluted &mdash; live, 7-day, 30-day</p></div>
+                        <div><h3>City Rankings</h3><p>Cleanest &amp; most polluted &mdash; live, 7-day, 30-day</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('resources')">
                         <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-book" style="width:20px;height:20px;"></span></div>
-                        <div><h4>Research &amp; Reading</h4><p>29 India-focused peer-reviewed studies, with citations</p></div>
+                        <div><h3>Research &amp; Reading</h3><p>29 India-focused peer-reviewed studies, with citations</p></div>
                     </div>
                 </div>
             </div>
@@ -1349,7 +1349,7 @@
         </div>
     </footer>
 
-    <script src="/app.js?v=202606107"></script>
+    <script src="/app.js?v=202606108"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -1549,7 +1549,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--red); margin-bottom: 0.5rem;"> Problems with AQI</h4>
+                            <h3 style="font-size: 0.875rem; color: var(--red); margin-bottom: 0.5rem;"> Problems with AQI</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li><strong>Masking effect:</strong> Reports only the worst pollutant — other dangerous levels hidden</li>
                                 <li><strong>Breakpoint misalignment:</strong> India's "satisfactory" (AQI 50-100) allows PM2.5 up to 60 µg/m³ — <em>12× WHO guideline</em></li>
@@ -1558,7 +1558,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--green-600); margin-bottom: 0.5rem;"> Why PM2.5 is the Standard</h4>
+                            <h3 style="font-size: 0.875rem; color: var(--green-600); margin-bottom: 0.5rem;"> Why PM2.5 is the Standard</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li><strong>Primary mortality driver:</strong> GBD 2021 attributes 4.72M global deaths to PM2.5 (7.9% of adult deaths)</li>
                                 <li><strong>Health models calibrated to PM2.5:</strong> GEMM exposure-response functions use µg/m³</li>
@@ -1676,7 +1676,7 @@
                 <div class="card-body">
                     <div class="grid-3">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Pregnancy & Fetal Development</h4>
+                            <h3> Pregnancy & Fetal Development</h3>
                             <p data-simple="Pollution passes from mother to unborn baby through the placenta. It can cause low birth weight, premature birth, and even affect the baby&rsquo;s brain development before they are born.">Air pollution crosses the placenta. Effects on unborn children:</p>
                             <ul>
                                 <li><strong>Low birth weight:</strong> ~20–28% higher risk at high PM2.5 (2024 meta-analysis)</li>
@@ -1690,7 +1690,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Children (0-14 years)</h4>
+                            <h3> Children (0-14 years)</h3>
                             <p>Children are not small adults — they're uniquely vulnerable:</p>
                             <ul>
                                 <li><strong>Breathe 50% more air</strong> per kg body weight</li>
@@ -1703,7 +1703,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Mental Health Impact</h4>
+                            <h3> Mental Health Impact</h3>
                             <p data-simple="Pollution does not just hurt your lungs &mdash; it harms your brain too. It increases depression, anxiety, and memory loss. In children, it can lower IQ and cause behavior problems.">Air pollution affects the brain, not just lungs:</p>
                             <ul>
                                 <li><strong>Depression:</strong> 10% higher risk at high PM2.5</li>
@@ -1719,7 +1719,7 @@
 
                     <div class="grid-2 mt-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--red);"> Elderly (65+)</h4>
+                            <h3 style="color: var(--red);"> Elderly (65+)</h3>
                             <ul>
                                 <li>Weakened immune response</li>
                                 <li>Pre-existing heart/lung conditions</li>
@@ -1728,7 +1728,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Outdoor Workers</h4>
+                            <h3> Outdoor Workers</h3>
                             <ul>
                                 <li>Traffic police, delivery workers, construction</li>
                                 <li>8-12 hours daily exposure</li>
@@ -1757,7 +1757,7 @@
                         <div>
                             <!-- STATE OF GLOBAL AIR 2025 -->
                             <div class="info-box mb-2" style="border-left: 4px solid var(--green-700); background: rgba(27,107,74,0.03);">
-                                <h4 style="color: var(--green-700); margin-bottom: 0.5rem;"> State of Global Air 2025 (HEI, October 2025)</h4>
+                                <h3 style="color: var(--green-700); margin-bottom: 0.5rem;"> State of Global Air 2025 (HEI, October 2025)</h3>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>2 million deaths in India (2023)</strong> — 43% increase since 2000</li>
                                     <li><strong>Death rate disparity:</strong> 186 per 100,000 in India vs 17 in high-income countries (10× gap)</li>
@@ -1770,7 +1770,7 @@
 
                             <!-- LANCET 10-CITY STUDY -->
                             <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(37,99,235,0.03);">
-                                <h4 style="margin-bottom: 0.5rem"> Lancet 10-City Causal Study (Dec 2024)</h4>
+                                <h3 style="margin-bottom: 0.5rem"> Lancet 10-City Causal Study (Dec 2024)</h3>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>33,000 deaths</strong> directly attributable to PM2.5 across 10 Indian cities</li>
                                     <li><strong>7.2% of daily deaths</strong> in Delhi linked to PM2.5 above WHO guideline</li>
@@ -1783,7 +1783,7 @@
                         <div>
                             <!-- HEAT-POLLUTION INTERACTION -->
                             <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
-                                <h4 style="margin-bottom: 0.5rem"> Heat-Pollution Interaction (Karolinska, 2024)</h4>
+                                <h3 style="margin-bottom: 0.5rem"> Heat-Pollution Interaction (Karolinska, 2024)</h3>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>4.6% mortality increase</strong> on days with both high heat AND high PM2.5</li>
                                     <li><strong>Synergistic effect:</strong> Combined risk > sum of individual risks</li>
@@ -1794,7 +1794,7 @@
 
                             <!-- DEMENTIA & COGNITIVE -->
                             <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
-                                <h4 style="margin-bottom: 0.5rem"> PM2.5 and Dementia (SoGA 2025 — New Finding)</h4>
+                                <h3 style="margin-bottom: 0.5rem"> PM2.5 and Dementia (SoGA 2025 — New Finding)</h3>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>54,000 dementia deaths</strong> attributed to PM2.5 in India (first-ever estimate)</li>
                                     <li><strong>Mechanism:</strong> Ultrafine particles cross blood-brain barrier, cause neuroinflammation</li>
@@ -1805,7 +1805,7 @@
 
                             <!-- SOURCE APPORTIONMENT -->
                             <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(22,128,60,0.03);">
-                                <h4 style="color: var(--green-700); margin-bottom: 0.5rem;"> Source Apportionment Update (EGUsphere, 2025)</h4>
+                                <h3 style="color: var(--green-700); margin-bottom: 0.5rem;"> Source Apportionment Update (EGUsphere, 2025)</h3>
                                 <ul style="font-size: 0.875rem; line-height: 1.8;">
                                     <li><strong>Industrial emissions:</strong> Now largest domestic source at 18% (previously underestimated)</li>
                                     <li><strong>Transport:</strong> 12% direct + secondary aerosols</li>
@@ -1831,7 +1831,7 @@
                     <div class="grid-2">
                         <!-- HOUSEHOLD AIR POLLUTION -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(236,72,153,0.03);">
-                            <h4 style="margin-bottom: 0.75rem"> Household Air Pollution — The Invisible Epidemic</h4>
+                            <h3 style="margin-bottom: 0.75rem"> Household Air Pollution — The Invisible Epidemic</h3>
                             <p style="font-size: 0.875rem; margin-bottom: 0.75rem;">
                                 <strong>481,700 deaths/year in India</strong> from household air pollution (HAP) — about 23% of India's air-pollution deaths. Yet NCAP focuses almost exclusively on ambient air.
                             </p>
@@ -1850,7 +1850,7 @@
 
                         <!-- OCCUPATIONAL EXPOSURE -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
-                            <h4 style="margin-bottom: 0.75rem"> Occupational Exposure — Unprotected Workers</h4>
+                            <h3 style="margin-bottom: 0.75rem"> Occupational Exposure — Unprotected Workers</h3>
                             <p style="font-size: 0.875rem; margin-bottom: 0.75rem;">
                                 <strong>~90% of India's workforce is informal</strong> — with no occupational health standards for ambient air exposure. The formal sector gets WFH; workers breathe poison.
                             </p>
@@ -1872,7 +1872,7 @@
                     <div class="grid-2 mt-2">
                         <!-- SPATIAL INJUSTICE -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
-                            <h4 style="margin-bottom: 0.75rem"> Spatial Injustice — Where You Live Matters</h4>
+                            <h3 style="margin-bottom: 0.75rem"> Spatial Injustice — Where You Live Matters</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Industrial proximity:</strong> Low-income housing systematically located near factories, refineries, power plants</li>
                                 <li><strong>Highway adjacency:</strong> Slums built along arterial roads; PM2.5 50% higher within 100m of highways</li>
@@ -1887,7 +1887,7 @@
 
                         <!-- CASTE & CLASS -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(14,165,233,0.03);">
-                            <h4 style="margin-bottom: 0.75rem"> Caste, Class & Environmental Racism</h4>
+                            <h3 style="margin-bottom: 0.75rem"> Caste, Class & Environmental Racism</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Manual scavenging:</strong> Still practiced despite ban; sewer deaths from toxic gases; predominantly Dalit</li>
                                 <li><strong>Sanitation workers:</strong> Burn waste, clear drains; no protective gear; municipality neglect</li>
@@ -1904,7 +1904,7 @@
                     <div class="grid-2 mt-2">
                         <!-- ADAPTATION INEQUALITY -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(22,128,60,0.03);">
-                            <h4 style="color: var(--green-700); margin-bottom: 0.75rem;"> Adaptation Inequality — Protection is a Privilege</h4>
+                            <h3 style="color: var(--green-700); margin-bottom: 0.75rem;"> Adaptation Inequality — Protection is a Privilege</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Air purifiers:</strong> ₹10,000-50,000 + electricity cost; inaccessible to 70%+ households</li>
                                 <li><strong>N95 masks:</strong> ₹50-200 each; informal workers can't afford daily replacement</li>
@@ -1917,7 +1917,7 @@
 
                         <!-- POLICY CRITIQUE -->
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.03);">
-                            <h4 style="color: var(--red); margin-bottom: 0.75rem;"> Policy Blind Spots — Who's Not at the Table?</h4>
+                            <h3 style="color: var(--red); margin-bottom: 0.75rem;"> Policy Blind Spots — Who's Not at the Table?</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>NCAP:</strong> Focuses on ambient PM10/PM2.5; HAP not integrated; no equity metrics</li>
                                 <li><strong>GRAP:</strong> Construction bans hurt workers; no wage compensation; odd-even exempts two-wheelers (used by poor)</li>
@@ -1934,7 +1934,7 @@
 
                     <!-- KEY STATISTICS BOX -->
                     <div class="mt-2" style="background: var(--bg-muted); border-radius: 12px; padding: 1rem;">
-                        <h4 style="color: var(--green-700); margin-bottom: 0.75rem; font-size: 0.9375rem;"> The Numbers That Don't Make Headlines</h4>
+                        <h3 style="color: var(--green-700); margin-bottom: 0.75rem; font-size: 0.9375rem;"> The Numbers That Don't Make Headlines</h3>
                         <div class="grid-4" style="gap: 1rem;">
                             <div style="text-align: center; padding: 0.75rem; background: var(--bg-card); border-radius: 8px;">
                                 <div style="font-size: 1.75rem; font-weight: 700; color: var(--green-700);">481,700</div>
@@ -2075,15 +2075,15 @@
             <div class="card mb-2">
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead><tr><th>Intervention</th><th>Years</th><th>PM2.5 Impact</th><th>Evidence</th><th>Cost-Effectiveness</th></tr></thead>
                             <tbody>
-                                <tr><td><strong>Odd-Even Scheme</strong></td><td>2016, 2019</td><td><span class="badge badge-warning">-2% to -4%</span></td><td><span class="badge badge-warning">Weak</span></td><td>Low</td></tr>
-                                <tr><td><strong>BS-VI Fuel Standards</strong></td><td>2020-</td><td><span class="badge badge-success">-10% to -15%</span></td><td><span class="badge badge-success">Strong</span></td><td>High</td></tr>
-                                <tr><td><strong>GRAP Stage IV</strong></td><td>2024-25</td><td><span class="badge badge-success">-15% to -20%</span></td><td><span class="badge badge-warning">Moderate</span></td><td>Medium</td></tr>
-                                <tr><td><strong>CNG Transition</strong></td><td>2001-</td><td><span class="badge badge-success">-25%</span></td><td><span class="badge badge-success">Strong</span></td><td>Very High</td></tr>
-                                <tr><td><strong>Stubble Burning Bans</strong></td><td>2015-</td><td><span class="badge badge-danger">No change</span></td><td><span class="badge badge-success">Strong</span></td><td>Very Low</td></tr>
-                                <tr><td><strong>Smog Towers</strong></td><td>2021-</td><td><span class="badge badge-danger">Negligible</span></td><td><span class="badge badge-success">Strong</span></td><td>Very Low</td></tr>
+                                <tr><td data-label="Intervention"><strong>Odd-Even Scheme</strong></td><td data-label="Years">2016, 2019</td><td data-label="PM2.5 Impact"><span class="badge badge-warning">-2% to -4%</span></td><td data-label="Evidence"><span class="badge badge-warning">Weak</span></td><td data-label="Cost-Effectiveness">Low</td></tr>
+                                <tr><td data-label="Intervention"><strong>BS-VI Fuel Standards</strong></td><td data-label="Years">2020-</td><td data-label="PM2.5 Impact"><span class="badge badge-success">-10% to -15%</span></td><td data-label="Evidence"><span class="badge badge-success">Strong</span></td><td data-label="Cost-Effectiveness">High</td></tr>
+                                <tr><td data-label="Intervention"><strong>GRAP Stage IV</strong></td><td data-label="Years">2024-25</td><td data-label="PM2.5 Impact"><span class="badge badge-success">-15% to -20%</span></td><td data-label="Evidence"><span class="badge badge-warning">Moderate</span></td><td data-label="Cost-Effectiveness">Medium</td></tr>
+                                <tr><td data-label="Intervention"><strong>CNG Transition</strong></td><td data-label="Years">2001-</td><td data-label="PM2.5 Impact"><span class="badge badge-success">-25%</span></td><td data-label="Evidence"><span class="badge badge-success">Strong</span></td><td data-label="Cost-Effectiveness">Very High</td></tr>
+                                <tr><td data-label="Intervention"><strong>Stubble Burning Bans</strong></td><td data-label="Years">2015-</td><td data-label="PM2.5 Impact"><span class="badge badge-danger">No change</span></td><td data-label="Evidence"><span class="badge badge-success">Strong</span></td><td data-label="Cost-Effectiveness">Very Low</td></tr>
+                                <tr><td data-label="Intervention"><strong>Smog Towers</strong></td><td data-label="Years">2021-</td><td data-label="PM2.5 Impact"><span class="badge badge-danger">Negligible</span></td><td data-label="Evidence"><span class="badge badge-success">Strong</span></td><td data-label="Cost-Effectiveness">Very Low</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -2122,7 +2122,7 @@
                     
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--red);"> 72-Hour Persistence Rule for GRAP</h4>
+                            <h3 style="color: var(--red);"> 72-Hour Persistence Rule for GRAP</h3>
                             <p><strong>Problem:</strong> GRAP stages are currently relaxed as soon as AQI dips below threshold, even briefly. This "yo-yo" effect leads to:</p>
                             <ul>
                                 <li>Premature lifting of restrictions</li>
@@ -2135,7 +2135,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Anticipatory Activation</h4>
+                            <h3> Anticipatory Activation</h3>
                             <p><strong>Problem:</strong> GRAP is reactive — activated only after AQI crosses threshold. By then, damage is done.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2147,7 +2147,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Automatic School Closures</h4>
+                            <h3> Automatic School Closures</h3>
                             <p><strong>Problem:</strong> Schools remain open even during AQI 400-500. Children are most vulnerable.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2160,7 +2160,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-700);"> Stubble — Fix the Economics</h4>
+                            <h3 style="color: var(--green-700);"> Stubble — Fix the Economics</h3>
                             <p><strong>Problem:</strong> Burning is rational for farmers. Bans without alternatives don't work.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2173,7 +2173,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Year-Round Industrial Standards</h4>
+                            <h3> Year-Round Industrial Standards</h3>
                             <p><strong>Problem:</strong> Industrial restrictions only during GRAP. Pollution is year-round problem.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2185,7 +2185,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Congestion Pricing (Not Odd-Even)</h4>
+                            <h3> Congestion Pricing (Not Odd-Even)</h3>
                             <p><strong>Problem:</strong> Odd-even has minimal impact (2-4% reduction) with high compliance cost.</p>
                             <p style="margin-top: 0.5rem;"><strong>Recommendation:</strong></p>
                             <ul>
@@ -2223,7 +2223,7 @@
                     
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Beijing, China</h4>
+                            <h3> Beijing, China</h3>
                             <p><strong>Problem:</strong> 2013 "Airpocalypse" — PM2.5 over 500 for weeks. Called "unlivable."</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
                             <ul>
@@ -2237,7 +2237,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> London, UK</h4>
+                            <h3> London, UK</h3>
                             <p><strong>Problem:</strong> 1952 Great Smog killed 12,000. Chronic pollution through 1990s.</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
                             <ul>
@@ -2251,7 +2251,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Los Angeles, USA</h4>
+                            <h3> Los Angeles, USA</h3>
                             <p><strong>Problem:</strong> 1970s smog so bad children couldn't play outside. "Smog capital."</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
                             <ul>
@@ -2265,7 +2265,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Surat, India</h4>
+                            <h3> Surat, India</h3>
                             <p><strong>Problem:</strong> 1994 plague outbreak linked to poor sanitation and air quality.</p>
                             <p style="margin-top: 0.5rem;"><strong>Solution:</strong></p>
                             <ul>
@@ -2562,19 +2562,19 @@
 
             <div class="grid-2" style="gap:1rem; margin-bottom:1rem;">
                 <div class="info-box" style="background: rgba(234,88,12,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:#C2410C;">Heat cooks ozone</h4>
+                    <h3 style="color:#C2410C;">Heat cooks ozone</h3>
                     <p data-simple="Ground-level ozone is not emitted by anything &mdash; it is formed when vehicle and factory gases react in sunlight, and that reaction runs faster as the air gets hotter. A 50&deg;C street makes more ozone than a 35&deg;C one from the same traffic.">Ground-level ozone isn&rsquo;t emitted &mdash; it&rsquo;s formed when NOx and VOCs react in sunlight, and the reaction runs <strong>faster as temperature rises</strong>. A 50&deg;C street makes more ozone than a 35&deg;C one from the same traffic.<sup>3,4</sup></p>
                 </div>
                 <div class="info-box" style="background: rgba(100,116,139,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:#475569;">Hot days are still days</h4>
+                    <h3 style="color:#475569;">Hot days are still days</h3>
                     <p data-simple="Heatwaves usually arrive with stagnant, high-pressure weather. The same still air that traps heat also fails to blow away smoke, dust and exhaust &mdash; so pollution piles up instead of dispersing.">Heatwaves ride in on stagnant high-pressure systems. The same still air that won&rsquo;t carry heat away <strong>won&rsquo;t disperse smoke, dust and exhaust either</strong> &mdash; so pollution accumulates.<sup>4</sup></p>
                 </div>
                 <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:var(--red);">The cooling spiral</h4>
+                    <h3 style="color:var(--red);">The cooling spiral</h3>
                     <p data-simple="Hotter colonies run more air conditioners. That pulls more electricity from a coal-heavy grid, releasing more PM2.5 and SO2 &mdash; and every AC dumps its waste heat onto the street, making it hotter still. Heat makes pollution makes heat.">Hotter colonies run more ACs &rarr; more power from a coal-heavy grid &rarr; more PM2.5 and SO2 &mdash; and every AC dumps waste heat onto the street. <strong>Heat makes pollution makes heat.</strong><sup>7</sup></p>
                 </div>
                 <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:var(--green-700);">One canopy, two jobs</h4>
+                    <h3 style="color:var(--green-700);">One canopy, two jobs</h3>
                     <p data-simple="Tree cover lowers the temperature and also traps particle pollution on its leaves. Removing the green takes away both the shade and the filter at the same time.">Tree cover lowers temperature <em>and</em> deposits particulate matter on its leaves. Strip the green and you remove <strong>the shade and the filter at once</strong> &mdash; which is why &lsquo;trees cool more than concrete heats&rsquo; is also an air-quality statement.<sup>8</sup></p>
                 </div>
             </div>
@@ -2614,11 +2614,11 @@
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="A study by Artha Global looked at 2,368 homes across all 70 assembly seats of Delhi. It found a clear, measurable link between how a neighbourhood is built and how hot it actually feels.">A white paper by <strong>Artha Global</strong> studied <strong>2,368 households</strong> across all <strong>70 assembly constituencies</strong> of Delhi and found a precise, measurable relationship between urban form and experienced heat.</p>
             <div class="grid-2" style="gap:1rem; margin-bottom:1rem;">
                 <div class="info-box" style="background: rgba(220,38,38,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:var(--red);">Concrete heats</h4>
+                    <h3 style="color:var(--red);">Concrete heats</h3>
                     <p data-simple="When the built-up area of a neighbourhood rises from 25% to 55%, the temperature people actually feel goes up by 0.6&deg;C.">Increasing built-up area from <strong>25% to 55%</strong> raises experienced temperature by <strong>+0.6&deg;C</strong>.</p>
                 </div>
                 <div class="info-box" style="background: rgba(21,128,61,0.06); border-left: 3px solid var(--accent);">
-                    <h4 style="color:var(--green-700);">Trees cool</h4>
+                    <h3 style="color:var(--green-700);">Trees cool</h3>
                     <p data-simple="When tree cover rises from just 3% to 11%, the heat people feel drops by a full 1&deg;C.">Increasing tree cover from just <strong>3% to 11%</strong> lowers experienced heat by <strong>&minus;1&deg;C</strong>.</p>
                 </div>
             </div>
@@ -3008,9 +3008,9 @@
         <div class="card-header"><span class="card-title"><span class="si si-sm si-activity" style="color: var(--accent);"></span> What Actually Works</span></div>
         <div class="card-body">
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>LPG/Induction Transition</h4><p>Ujjwala 2.0 distributed 10+ Cr connections but refill rates remain low (50-60% in some states). Subsidy structure needs reform to ensure sustained use, not one-time distribution.</p></div>
-                <div class="info-box"><h4>DIY Box Fan Filters</h4><p>Research shows a HEPA filter taped to a box fan (Corsi-Rosenthal box) reduces indoor PM2.5 by 40-60% at a cost of Rs 2,000-3,000. No commercial purifier needed. Scalable for schools and offices.</p></div>
-                <div class="info-box"><h4>Ventilation Design</h4><p>Cross-ventilation, stack-effect chimneys, and kitchen separation from living areas reduce indoor PM2.5 by 30-50%. Most effective in new construction. WHO Housing and Health Guidelines (2018) provide design standards.</p></div>
+                <div class="info-box"><h3>LPG/Induction Transition</h3><p>Ujjwala 2.0 distributed 10+ Cr connections but refill rates remain low (50-60% in some states). Subsidy structure needs reform to ensure sustained use, not one-time distribution.</p></div>
+                <div class="info-box"><h3>DIY Box Fan Filters</h3><p>Research shows a HEPA filter taped to a box fan (Corsi-Rosenthal box) reduces indoor PM2.5 by 40-60% at a cost of Rs 2,000-3,000. No commercial purifier needed. Scalable for schools and offices.</p></div>
+                <div class="info-box"><h3>Ventilation Design</h3><p>Cross-ventilation, stack-effect chimneys, and kitchen separation from living areas reduce indoor PM2.5 by 30-50%. Most effective in new construction. WHO Housing and Health Guidelines (2018) provide design standards.</p></div>
             </div>
         </div>
     </div>
@@ -3020,9 +3020,9 @@
         <div class="card-body">
             <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="If you want to measure the air inside your own home, a cheap sensor can help &mdash; but only some are accurate. Here is what to look for so you don&rsquo;t waste money on a gadget that guesses.">Cheap PM sensors put indoor monitoring within reach &mdash; but accuracy varies widely. A 2026 IIT (ISM) Dhanbad evaluation benchmarked affordable PM2.5/PM10 sensors under Indian indoor conditions; use its findings to buy wisely rather than trust the marketing.</p>
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>Insist on a real PM sensor</h4><p>Laser-scattering (optical) modules &mdash; e.g. Plantower PMS-series or Sensirion SPS30 &mdash; measure particles directly. Avoid "air quality" gadgets that only infer PM from VOC/gas readings; they can't see cooking or incense smoke properly.</p></div>
-                <div class="info-box"><h4>Correct for humidity &amp; drift</h4><p>Low-cost sensors read high in humid air and vary by particle type. Co-locating with a reference monitor for a few days lets you apply a correction factor &mdash; the Dhanbad study quantifies this error size-by-size.</p></div>
-                <div class="info-box"><h4>Use it for trends, not verdicts</h4><p>Best for seeing <em>when</em> cooking/incense spikes indoor PM and whether ventilation or a filter helps &mdash; not for a precise absolute number. Expect roughly &plusmn;20&ndash;50% vs regulatory-grade instruments.</p></div>
+                <div class="info-box"><h3>Insist on a real PM sensor</h3><p>Laser-scattering (optical) modules &mdash; e.g. Plantower PMS-series or Sensirion SPS30 &mdash; measure particles directly. Avoid "air quality" gadgets that only infer PM from VOC/gas readings; they can't see cooking or incense smoke properly.</p></div>
+                <div class="info-box"><h3>Correct for humidity &amp; drift</h3><p>Low-cost sensors read high in humid air and vary by particle type. Co-locating with a reference monitor for a few days lets you apply a correction factor &mdash; the Dhanbad study quantifies this error size-by-size.</p></div>
+                <div class="info-box"><h3>Use it for trends, not verdicts</h3><p>Best for seeing <em>when</em> cooking/incense spikes indoor PM and whether ventilation or a filter helps &mdash; not for a precise absolute number. Expect roughly &plusmn;20&ndash;50% vs regulatory-grade instruments.</p></div>
             </div>
             <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 1rem;">Evidence: <a href="https://doi.org/10.1038/s41598-026-61453-2" target="_blank" rel="noopener">Ali et al. (2026), Evaluation of low-cost sensors for size-resolved indoor particle monitoring</a> (<em>Scientific Reports</em>). More in the <a href="#resources" onclick="showPanel('resources'); return false;">Reading List</a>.</p>
         </div>
@@ -3110,7 +3110,7 @@
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Delhi had to close schools many times during winter 2025-26 because the air was too dirty. When pollution gets really bad (AQI above 400), all primary schools must close. But many students in government schools don&rsquo;t have laptops or internet for online classes, so they simply miss out on learning. The next pollution-season closures start October-November 2026.">Delhi schools shifted to online mode multiple times during Winter 2025-26 (the most recent pollution season). Under GRAP Stage III/IV, all primary schools close when AQI exceeds 400. Students in government schools often lack devices for online learning, widening the education equity gap. The next closure window opens with the post-monsoon pollution season &mdash; typically late October 2026.</p>
                 <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
-                    <h4>Winter 2025-26 closures (most recent pollution season)</h4>
+                    <h3>Winter 2025-26 closures (most recent pollution season)</h3>
                     <p>Nov 4-8, Nov 14-18, Nov 22-26, Dec 2-5, Jan 6-10, Jan 16-20. <strong>Total: ~30 days</strong> across Winter 2025-26. An estimated 4+ million school-age children affected in Delhi-NCR alone. Learning loss is cumulative and disproportionately harms first-generation learners.</p>
                 </div>
             </div>
@@ -3130,9 +3130,9 @@
         <div class="card-header"><span class="card-title">What Parents Can Do</span></div>
         <div class="card-body">
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>School Air Quality Audits</h4><p>Parents can request indoor PM2.5 monitoring in classrooms. Low-cost sensors (Rs 3,000-5,000) can be donated to schools. RTE Act mandates safe learning environments.</p></div>
-                <div class="info-box"><h4>N95 for Children</h4><p>Child-sized N95/KN95 masks are available. Proper fit is critical. Mask mandates during GRAP Stage III+ should be enforced in schools that remain open.</p></div>
-                <div class="info-box"><h4>Advocate for Air Purifiers</h4><p>One HEPA purifier (or DIY Corsi-Rosenthal box) per classroom costs Rs 5,000-10,000. Delhi government budgeted for this in 2023 but implementation stalled. File RTI to track status.</p></div>
+                <div class="info-box"><h3>School Air Quality Audits</h3><p>Parents can request indoor PM2.5 monitoring in classrooms. Low-cost sensors (Rs 3,000-5,000) can be donated to schools. RTE Act mandates safe learning environments.</p></div>
+                <div class="info-box"><h3>N95 for Children</h3><p>Child-sized N95/KN95 masks are available. Proper fit is critical. Mask mandates during GRAP Stage III+ should be enforced in schools that remain open.</p></div>
+                <div class="info-box"><h3>Advocate for Air Purifiers</h3><p>One HEPA purifier (or DIY Corsi-Rosenthal box) per classroom costs Rs 5,000-10,000. Delhi government budgeted for this in 2023 but implementation stalled. File RTI to track status.</p></div>
             </div>
         </div>
     </div>
@@ -3183,7 +3183,7 @@
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Cooking with wood, dung, and crop waste exposes women to pollution levels 10 to 40 times higher than outdoor air. The government's Ujjwala scheme gave out 10 crore LPG connections, but many women can't afford refills. They use only about 3.5 cylinders per year instead of the 6-7 needed. Many go back to using firewood because LPG is too expensive.">Solid fuel cooking &mdash; wood, dung, and crop residue &mdash; exposes women to PM2.5 concentrations 10&ndash;40&times; ambient levels. The Pradhan Mantri Ujjwala Yojana (PMUY) distributed over 10 Cr LPG connections since 2016, but sustained use remains a challenge. Refill rates have dropped to approximately 3.5 cylinders per year in many states, far below the 6&ndash;7 cylinders needed for a full cooking fuel transition. Cost remains the primary barrier: many beneficiaries revert to biomass fuels when subsidies are delayed or insufficient.</p>
                 <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid var(--accent);">
-                    <h4>Ujjwala: Connection vs. Transition</h4>
+                    <h3>Ujjwala: Connection vs. Transition</h3>
                     <p>A 2024 CEEW evaluation found that only 38% of Ujjwala beneficiaries use LPG as their primary cooking fuel. The remaining 62% practice fuel stacking &mdash; using LPG for quick meals and biomass for roti-making and extended cooking. The scheme succeeded in access but has not yet achieved a clean cooking transition.</p>
                 </div>
                 <p style="font-size: 0.75rem; color: var(--text-3); margin-top: 0.5rem;"><em>Source: CEEW 2024, PMUY evaluation studies</em></p>
@@ -3195,7 +3195,7 @@
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Women who work in construction, brick kilns, street vending, and farming breathe dirty air all day without protection. About 30% of construction workers are women, but they are rarely given N95 masks or any safety gear.">Women in construction, brick kilns, street vending, and agriculture face sustained outdoor PM2.5 exposure without respiratory protection. Female construction workers comprise approximately 30% of the workforce but are rarely provided N95 masks or occupational health screening. Brick kiln workers &mdash; many of them women from migrant families &mdash; are exposed to PM levels of 500&ndash;1,000 &micro;g/m&sup3; during firing cycles.</p>
                 <div class="info-box" style="background: rgba(59,130,246,0.06); border-left: 3px solid var(--accent);">
-                    <h4>The Informal Sector Gap</h4>
+                    <h3>The Informal Sector Gap</h3>
                     <p>India&rsquo;s Factories Act and Building &amp; Other Construction Workers Act mandate protective equipment, but enforcement in the informal sector &mdash; where most women work &mdash; is nearly non-existent. No national data exists on occupational respiratory disease among female informal workers.</p>
                 </div>
                 <p style="font-size: 0.75rem; color: var(--text-3); margin-top: 0.5rem;"><em>Source: ILO India, 2023</em></p>
@@ -3216,7 +3216,7 @@
             <div class="card-body">
                 <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Most air quality sensors are placed in commercial and industrial areas, not in homes and kitchens where women spend most of their time. India has zero official indoor air monitoring stations. Health studies rarely separate data by gender, so we don't fully know how much worse pollution is for women.">Most air quality monitoring stations (CAAQMS) are sited in commercial, industrial, and traffic zones &mdash; not in residential areas where women spend the majority of their time. CPCB&rsquo;s monitoring network includes zero indoor monitoring stations. Health impact studies rarely disaggregate outcomes by gender, making it impossible to precisely quantify the differential burden on women.</p>
                 <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
-                    <h4>CAG Audit Finding (April 2025)</h4>
+                    <h3>CAG Audit Finding (April 2025)</h3>
                     <p>The Comptroller and Auditor General&rsquo;s April 2025 audit of India&rsquo;s air quality monitoring infrastructure found that station siting criteria systematically excluded residential and peri-urban areas. The audit recommended gender-sensitive monitoring protocols and indoor air quality stations in at least 50 cities by 2028.</p>
                 </div>
                 <p style="font-size: 0.75rem; color: var(--text-3); margin-top: 0.5rem;"><em>Source: CAG Performance Audit, April 2025</em></p>
@@ -3228,12 +3228,12 @@
         <div class="card-header"><span class="card-title">What Needs to Change</span></div>
         <div class="card-body">
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>Complete LPG Transition</h4><p data-simple="Don't just give LPG connections — make refills affordable. Increase the subsidy so families don't go back to burning wood and dung.">Move beyond connection targets to sustained use. Ensure affordable LPG refills through enhanced subsidies, not just one-time connections. Target: every Ujjwala household using 6+ cylinders/year.</p></div>
-                <div class="info-box"><h4>Workplace Exposure Standards</h4><p data-simple="Create rules to protect women working in construction, brick kilns, and street vending. Give them masks and health check-ups.">Mandate respiratory protection and periodic health screening for informal sector workers, especially in construction, brick kilns, and street vending. Enforce existing labour safety laws.</p></div>
-                <div class="info-box"><h4>Gender-Disaggregated Surveillance</h4><p data-simple="When collecting health data, always record whether the patient is male or female. This will help us understand how pollution affects women differently.">All air pollution health surveillance (ICMR, NCDC, state health departments) must record and report outcomes disaggregated by sex. Current systems make women&rsquo;s burden invisible.</p></div>
-                <div class="info-box"><h4>Indoor Monitoring</h4><p data-simple="Put air quality sensors inside homes in at least 50 cities. Focus on kitchens and living areas where women and children spend time.">Deploy indoor air quality monitoring in residential zones across at least 50 NCAP cities. Prioritise kitchens, living areas, and anganwadi centres where women and children congregate.</p></div>
-                <div class="info-box"><h4>Women in NCAP Decision-Making</h4><p data-simple="Include women in clean air planning committees. Right now, almost no women are involved in deciding air pollution policies.">Ensure women&rsquo;s representation in NCAP city-level committees, CAQM working groups, and state pollution control boards. Currently, women constitute less than 5% of CPCB/SPCB board members.</p></div>
-                <div class="info-box"><h4>Research Funding</h4><p data-simple="Fund more studies that look specifically at how air pollution affects women's health, pregnancy, and children.">Direct ICMR and DST funding toward gender-specific air pollution health research: maternal outcomes, occupational exposure in informal sector, and long-term reproductive health impacts.</p></div>
+                <div class="info-box"><h3>Complete LPG Transition</h3><p data-simple="Don't just give LPG connections — make refills affordable. Increase the subsidy so families don't go back to burning wood and dung.">Move beyond connection targets to sustained use. Ensure affordable LPG refills through enhanced subsidies, not just one-time connections. Target: every Ujjwala household using 6+ cylinders/year.</p></div>
+                <div class="info-box"><h3>Workplace Exposure Standards</h3><p data-simple="Create rules to protect women working in construction, brick kilns, and street vending. Give them masks and health check-ups.">Mandate respiratory protection and periodic health screening for informal sector workers, especially in construction, brick kilns, and street vending. Enforce existing labour safety laws.</p></div>
+                <div class="info-box"><h3>Gender-Disaggregated Surveillance</h3><p data-simple="When collecting health data, always record whether the patient is male or female. This will help us understand how pollution affects women differently.">All air pollution health surveillance (ICMR, NCDC, state health departments) must record and report outcomes disaggregated by sex. Current systems make women&rsquo;s burden invisible.</p></div>
+                <div class="info-box"><h3>Indoor Monitoring</h3><p data-simple="Put air quality sensors inside homes in at least 50 cities. Focus on kitchens and living areas where women and children spend time.">Deploy indoor air quality monitoring in residential zones across at least 50 NCAP cities. Prioritise kitchens, living areas, and anganwadi centres where women and children congregate.</p></div>
+                <div class="info-box"><h3>Women in NCAP Decision-Making</h3><p data-simple="Include women in clean air planning committees. Right now, almost no women are involved in deciding air pollution policies.">Ensure women&rsquo;s representation in NCAP city-level committees, CAQM working groups, and state pollution control boards. Currently, women constitute less than 5% of CPCB/SPCB board members.</p></div>
+                <div class="info-box"><h3>Research Funding</h3><p data-simple="Fund more studies that look specifically at how air pollution affects women's health, pregnancy, and children.">Direct ICMR and DST funding toward gender-specific air pollution health research: maternal outcomes, occupational exposure in informal sector, and long-term reproductive health impacts.</p></div>
             </div>
         </div>
     </div>
@@ -3296,9 +3296,9 @@
         <div class="card-header"><span class="card-title">How to Track Industrial Accountability</span></div>
         <div class="card-body">
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>CEMS Data Portal</h4><p>CPCB's <a href="https://ocmms.nic.in/" target="_blank">OCEMS portal</a> publishes real-time stack emission data. Check specific plants by state and category.</p></div>
-                <div class="info-box"><h4>NASA FIRMS</h4><p><a href="https://firms.modaps.eosdis.nasa.gov/" target="_blank">Fire Information for Resource Management</a> detects active burning including industrial and brick kiln fires via satellite. Cross-reference with DPCC consent lists.</p></div>
-                <div class="info-box"><h4>RTI for Consent-to-Operate</h4><p>File RTI with SPCB/DPCC asking for list of CTO holders, inspection reports, and violation notices. Template available in the Accountability panel.</p></div>
+                <div class="info-box"><h3>CEMS Data Portal</h3><p>CPCB's <a href="https://ocmms.nic.in/" target="_blank">OCEMS portal</a> publishes real-time stack emission data. Check specific plants by state and category.</p></div>
+                <div class="info-box"><h3>NASA FIRMS</h3><p><a href="https://firms.modaps.eosdis.nasa.gov/" target="_blank">Fire Information for Resource Management</a> detects active burning including industrial and brick kiln fires via satellite. Cross-reference with DPCC consent lists.</p></div>
+                <div class="info-box"><h3>RTI for Consent-to-Operate</h3><p>File RTI with SPCB/DPCC asking for list of CTO holders, inspection reports, and violation notices. Template available in the Accountability panel.</p></div>
             </div>
         </div>
     </div>
@@ -3329,14 +3329,14 @@
         <div class="card-header"><span class="card-title">Who is most exposed</span></div>
         <div class="card-body">
             <div class="grid-4" style="gap: 1rem;">
-                <div class="info-box"><h4>Street vendors</h4><p>Stationed at busy junctions for the whole working day, directly in traffic exhaust. Documented lung-function loss (see evidence below).</p></div>
-                <div class="info-box"><h4>Traffic police</h4><p>Hours at intersections during peak-flow inversions. Indian cohort studies repeatedly find reduced FEV1/PEFR vs desk-based peers.</p></div>
-                <div class="info-box"><h4>Gig &amp; delivery riders</h4><p>India's fastest-growing outdoor workforce &mdash; long two-wheeler shifts in-plume, breathing hard, no cabin filtration.</p></div>
-                <div class="info-box"><h4>Construction workers</h4><p>Silica and coarse PM on top of ambient pollution; work continues even under GRAP dust curbs at many sites.</p></div>
-                <div class="info-box"><h4>Waste pickers</h4><p>Sorting and open-burning exposure; among the most marginalised and least health-covered workers.</p></div>
-                <div class="info-box"><h4>Auto &amp; e-rickshaw drivers</h4><p>All-day kerbside idling in dense traffic corridors, open cabins.</p></div>
-                <div class="info-box"><h4>Sanitation workers</h4><p>Early-morning street sweeping resuspends road dust into the breathing zone before it settles.</p></div>
-                <div class="info-box"><h4>Roadside mechanics &amp; hawkers</h4><p>Fixed kerbside pitches, often beside idling vehicles, for years at a time.</p></div>
+                <div class="info-box"><h3>Street vendors</h3><p>Stationed at busy junctions for the whole working day, directly in traffic exhaust. Documented lung-function loss (see evidence below).</p></div>
+                <div class="info-box"><h3>Traffic police</h3><p>Hours at intersections during peak-flow inversions. Indian cohort studies repeatedly find reduced FEV1/PEFR vs desk-based peers.</p></div>
+                <div class="info-box"><h3>Gig &amp; delivery riders</h3><p>India's fastest-growing outdoor workforce &mdash; long two-wheeler shifts in-plume, breathing hard, no cabin filtration.</p></div>
+                <div class="info-box"><h3>Construction workers</h3><p>Silica and coarse PM on top of ambient pollution; work continues even under GRAP dust curbs at many sites.</p></div>
+                <div class="info-box"><h3>Waste pickers</h3><p>Sorting and open-burning exposure; among the most marginalised and least health-covered workers.</p></div>
+                <div class="info-box"><h3>Auto &amp; e-rickshaw drivers</h3><p>All-day kerbside idling in dense traffic corridors, open cabins.</p></div>
+                <div class="info-box"><h3>Sanitation workers</h3><p>Early-morning street sweeping resuspends road dust into the breathing zone before it settles.</p></div>
+                <div class="info-box"><h3>Roadside mechanics &amp; hawkers</h3><p>Fixed kerbside pitches, often beside idling vehicles, for years at a time.</p></div>
             </div>
         </div>
     </div>
@@ -3345,7 +3345,7 @@
         <div class="card-header"><span class="card-title">What the evidence shows</span></div>
         <div class="card-body">
             <div class="info-box" style="margin-bottom: 1rem;">
-                <h4><a href="https://doi.org/10.1186/s12889-026-28270-8" target="_blank" rel="noopener">Street vendors, Chennai (2026)</a></h4>
+                <h3><a href="https://doi.org/10.1186/s12889-026-28270-8" target="_blank" rel="noopener">Street vendors, Chennai (2026)</a></h3>
                 <p>A cross-sectional study of <strong>298 urban street vendors</strong> in Chennai found cumulative occupational air-pollution exposure associated with <strong>reduced peak expiratory flow</strong> and a high prevalence of respiratory symptoms &mdash; occupation-specific evidence that the burden lands hardest on low-income informal workers who lack protective infrastructure. <em>Muruganantham et al., BMC Public Health.</em></p>
             </div>
             <p style="font-size: 0.9375rem; color: var(--text-2);" data-simple="Study after study in Indian cities finds that outdoor workers have weaker lungs than people who work indoors. This is a fairness problem: the people who can least afford it are harmed the most.">This is one strand of a consistent Indian literature &mdash; traffic police, drivers and roadside workers repeatedly show lower lung function than indoor-working controls. More peer-reviewed studies are collected in the <a href="#resources" onclick="showPanel('resources'); return false;">Reading List</a>.</p>
@@ -3356,10 +3356,10 @@
         <div class="card-header"><span class="card-title">What would help</span></div>
         <div class="card-body">
             <div class="grid-2" style="gap: 1rem;">
-                <div class="info-box"><h4>Occupational AQ recognition</h4><p>Treat chronic outdoor air exposure as a recognised occupational hazard, with health screening (spirometry) for high-exposure municipal and gig workforces.</p></div>
-                <div class="info-box"><h4>Shelter &amp; shift design</h4><p>Shaded, set-back vending zones away from junctions; rotation of traffic-police postings; pausing non-essential outdoor labour during GRAP Stage III&ndash;IV.</p></div>
-                <div class="info-box"><h4>Protective equipment</h4><p>Properly-fitted N95-class respirators issued and replaced for traffic police, sanitation and construction crews &mdash; not token cloth masks.</p></div>
-                <div class="info-box"><h4>Hold the system accountable</h4><p>File an <a href="#rti-assistant" onclick="showPanel('rti-assistant'); return false;">RTI</a> on whether your city budgets for worker protection or health screening under its Clean Air Plan.</p></div>
+                <div class="info-box"><h3>Occupational AQ recognition</h3><p>Treat chronic outdoor air exposure as a recognised occupational hazard, with health screening (spirometry) for high-exposure municipal and gig workforces.</p></div>
+                <div class="info-box"><h3>Shelter &amp; shift design</h3><p>Shaded, set-back vending zones away from junctions; rotation of traffic-police postings; pausing non-essential outdoor labour during GRAP Stage III&ndash;IV.</p></div>
+                <div class="info-box"><h3>Protective equipment</h3><p>Properly-fitted N95-class respirators issued and replaced for traffic police, sanitation and construction crews &mdash; not token cloth masks.</p></div>
+                <div class="info-box"><h3>Hold the system accountable</h3><p>File an <a href="#rti-assistant" onclick="showPanel('rti-assistant'); return false;">RTI</a> on whether your city budgets for worker protection or health screening under its Clean Air Plan.</p></div>
             </div>
             <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 1rem;">Non-partisan framing: this section documents an exposure-equity gap in the evidence &mdash; it critiques the absence of protective standards, not any party or individual.</p>
         </div>
@@ -3430,15 +3430,15 @@
             <div class="card-header"><span class="card-title">Official Forecast Sources</span></div>
             <div class="card-body">
                 <div class="info-box" style="margin-bottom: 1rem;">
-                    <h4><a href="https://safar.tropmet.res.in/" target="_blank">SAFAR (IITM/MoES)</a></h4>
+                    <h3><a href="https://safar.tropmet.res.in/" target="_blank">SAFAR (IITM/MoES)</a></h3>
                     <p>India's primary AQ forecast system. Covers Delhi, Mumbai, Pune, Ahmedabad. Provides 72-hour PM2.5/PM10/O3 forecasts with emission-based WRF-Chem model. Updated twice daily.</p>
                 </div>
                 <div class="info-box" style="margin-bottom: 1rem;">
-                    <h4><a href="https://app.cpcbccr.com/AQI_India/" target="_blank">CPCB AQI Dashboard</a></h4>
+                    <h3><a href="https://app.cpcbccr.com/AQI_India/" target="_blank">CPCB AQI Dashboard</a></h3>
                     <p>Real-time AQI bulletin with next-day forecast. Covers all CAAQMS stations nationally. Basis for GRAP trigger decisions.</p>
                 </div>
                 <div class="info-box">
-                    <h4><a href="https://aqicn.org/forecast/delhi/" target="_blank">WAQI/AQICN Forecast</a></h4>
+                    <h3><a href="https://aqicn.org/forecast/delhi/" target="_blank">WAQI/AQICN Forecast</a></h3>
                     <p>Independent 5-day forecast using multiple models. Useful for cross-referencing official forecasts.</p>
                 </div>
             </div>
@@ -3462,10 +3462,10 @@
         <div class="card-header"><span class="card-title">Meteorological Factors to Watch</span></div>
         <div class="card-body">
             <div class="grid-4" style="gap: 1rem;">
-                <div class="info-box"><h4>Wind Speed</h4><p>Below 5 km/h = stagnation. Delhi averages 3-4 km/h in winter. Ventilation coefficient below 3,000 m²/s signals multi-day smog episode.</p></div>
-                <div class="info-box"><h4>Mixing Height</h4><p>Below 300m traps pollutants near ground. Delhi winter mixing heights often drop to 100-200m, concentrating emissions in a thin layer.</p></div>
-                <div class="info-box"><h4>Rain Forecast</h4><p>Even 5mm rainfall can cut PM2.5 by 30-50% temporarily. IMD's western disturbance tracking is key for identifying relief windows.</p></div>
-                <div class="info-box"><h4>Farm Fires</h4><p>Peak: Oct 15 - Nov 15. Track via <a href="https://firms.modaps.eosdis.nasa.gov/" target="_blank">NASA FIRMS</a>. Contribution drops below 5% by December, making this a seasonal, not year-round, factor.</p></div>
+                <div class="info-box"><h3>Wind Speed</h3><p>Below 5 km/h = stagnation. Delhi averages 3-4 km/h in winter. Ventilation coefficient below 3,000 m²/s signals multi-day smog episode.</p></div>
+                <div class="info-box"><h3>Mixing Height</h3><p>Below 300m traps pollutants near ground. Delhi winter mixing heights often drop to 100-200m, concentrating emissions in a thin layer.</p></div>
+                <div class="info-box"><h3>Rain Forecast</h3><p>Even 5mm rainfall can cut PM2.5 by 30-50% temporarily. IMD's western disturbance tracking is key for identifying relief windows.</p></div>
+                <div class="info-box"><h3>Farm Fires</h3><p>Peak: Oct 15 - Nov 15. Track via <a href="https://firms.modaps.eosdis.nasa.gov/" target="_blank">NASA FIRMS</a>. Contribution drops below 5% by December, making this a seasonal, not year-round, factor.</p></div>
             </div>
         </div>
     </div>
@@ -3501,19 +3501,19 @@
             <div class="card-header"><span class="card-title">Promise vs. Reality: Key Interventions</span></div>
             <div class="card-body" style="font-size: 0.875rem; color: var(--text-2);">
                 <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
-                    <h4>Anti-Smog Guns (200 deployed, Rs 58 Cr)</h4>
+                    <h3>Anti-Smog Guns (200 deployed, Rs 58 Cr)</h3>
                     <p><strong>Evidence:</strong> Reduce AQI by 5-10 points in immediate vicinity only. No measurable city-level impact. IIT Delhi study: "cosmetic measure."</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
-                    <h4>Road Mechanised Sweeping</h4>
+                    <h3>Road Mechanised Sweeping</h3>
                     <p><strong>Evidence:</strong> Mixed. Reduces resuspended road dust temporarily. 68% of NCAP budget goes here, but road dust is not the primary PM2.5 source (vehicles and biomass are).</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent); margin-bottom: 0.75rem;">
-                    <h4>E-bus Procurement</h4>
+                    <h3>E-bus Procurement</h3>
                     <p><strong>Evidence:</strong> Strong long-term impact. Delhi targets 6,000 buses by Dec 2026 (from 3,600). Each diesel bus replaced = ~25 tonnes CO2/year + significant PM reduction. But procurement pace is slow.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4>Cloud Seeding Experiments</h4>
+                    <h3>Cloud Seeding Experiments</h3>
                     <p><strong>Evidence:</strong> Delhi government conducted trials in late 2025 and early 2026; both claimed success. Independent assessment of both rounds: minimal rainfall produced, no measurable AQI impact. Scientific consensus (CEEW, IIT-Delhi DSS): not scalable as a pollution-control intervention &mdash; addresses symptoms after the fact, not sources.</p>
                 </div>
             </div>
@@ -3524,7 +3524,7 @@
             <div class="card-body" style="font-size: 0.875rem; color: var(--text-2);">
                 <p style="margin-bottom: 1rem;">GRAP (Graded Response Action Plan) triggers emergency measures at AQI thresholds. But does it work?</p>
                 <div class="info-box" style="margin-bottom: 0.75rem;">
-                    <h4>Stage IV (AQI 450+): Winter 2025-26</h4>
+                    <h3>Stage IV (AQI 450+): Winter 2025-26</h3>
                     <p>Invoked 4 times this winter. Measures: truck ban, construction halt, 50% office WFH, school closure. Duration: typically 3-7 days per invocation. AQI improved only when wind speed increased, not as a direct result of GRAP measures. Compliance monitoring found 40% of construction sites continued operations during the ban.</p>
                 </div>
                 <p>The fundamental problem: GRAP is reactive (activated after air quality deteriorates) rather than preventive. It does not address base emission loads from vehicles, industry, and biomass that keep baseline AQI in the 200-300 range even between episodes.</p>
@@ -3584,9 +3584,9 @@
             </div>
 
             <!-- Expenditure table -->
-            <h4 style="margin-top: 1.5rem; margin-bottom: 0.75rem; font-size: 0.9375rem; color: var(--ink);">
+            <h3 style="margin-top: 1.5rem; margin-bottom: 0.75rem; font-size: 0.9375rem; color: var(--ink);">
                 <span class="si si-wallet" style="color: var(--amber);"></span> NCAP Expenditure Tracker
-            </h4>
+            </h3>
             <div class="table-wrap">
                 <table class="table" id="cityPolicyExpTable">
                     <thead>
@@ -3623,60 +3623,60 @@
 
             <!-- Delhi Actions -->
             <div class="city-action-block" data-city-actions="delhi" style="margin-bottom: 1.5rem;">
-                <h4 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
+                <h3 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
                     Delhi &amp; NCR
-                </h4>
+                </h3>
                 <div class="table-wrap">
-                    <table class="table">
+                    <table class="table responsive-cards">
                         <thead><tr><th style="width:110px;">Date</th><th>Action</th><th style="width:130px;">Source</th><th style="width:110px;">Status</th></tr></thead>
                         <tbody>
                             <tr>
-                                <td>19 May 2026</td>
-                                <td>CAQM invokes off-season GRAP Stage-I at AQI 208 &mdash; first-ever summer activation</td>
-                                <td>CAQM order</td>
-                                <td><span class="badge badge-success">Implemented</span></td>
+                                <td data-label="Date">19 May 2026</td>
+                                <td data-label="Action">CAQM invokes off-season GRAP Stage-I at AQI 208 &mdash; first-ever summer activation</td>
+                                <td data-label="Source">CAQM order</td>
+                                <td data-label="Status"><span class="badge badge-success">Implemented</span></td>
                             </tr>
                             <tr>
-                                <td>Apr 2026</td>
-                                <td>NGT directs 6 south-Indian states to file PM reduction roadmaps within 3 months</td>
-                                <td>NGT order</td>
-                                <td><span class="badge badge-warning">Pending</span></td>
+                                <td data-label="Date">Apr 2026</td>
+                                <td data-label="Action">NGT directs 6 south-Indian states to file PM reduction roadmaps within 3 months</td>
+                                <td data-label="Source">NGT order</td>
+                                <td data-label="Status"><span class="badge badge-warning">Pending</span></td>
                             </tr>
                             <tr>
-                                <td>31 Mar 2026</td>
-                                <td>NCAP deadline elapsed &mdash; 23 of 96 cities with sufficient data met the 40% PM10 target (CREA count).</td>
-                                <td>CREA 2026</td>
-                                <td><span class="badge badge-danger">Deadline passed</span></td>
+                                <td data-label="Date">31 Mar 2026</td>
+                                <td data-label="Action">NCAP deadline elapsed &mdash; 23 of 96 cities with sufficient data met the 40% PM10 target (CREA count).</td>
+                                <td data-label="Source">CREA 2026</td>
+                                <td data-label="Status"><span class="badge badge-danger">Deadline passed</span></td>
                             </tr>
                             <tr>
-                                <td>31 Mar 2026</td>
-                                <td>15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) expired. No successor announced.</td>
-                                <td>15th FC report</td>
-                                <td><span class="badge badge-danger">Expired</span></td>
+                                <td data-label="Date">31 Mar 2026</td>
+                                <td data-label="Action">15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) expired. No successor announced.</td>
+                                <td data-label="Source">15th FC report</td>
+                                <td data-label="Status"><span class="badge badge-danger">Expired</span></td>
                             </tr>
                             <tr>
-                                <td>Sep 2025</td>
-                                <td>75% utilisation rule: cities must achieve 75% fund utilisation to access 2025-26 NCAP allocation</td>
-                                <td>MoEFCC notification</td>
-                                <td><span class="badge badge-success">Implemented</span></td>
+                                <td data-label="Date">Sep 2025</td>
+                                <td data-label="Action">75% utilisation rule: cities must achieve 75% fund utilisation to access 2025-26 NCAP allocation</td>
+                                <td data-label="Source">MoEFCC notification</td>
+                                <td data-label="Status"><span class="badge badge-success">Implemented</span></td>
                             </tr>
                             <tr>
-                                <td>Winter 2025-26</td>
-                                <td>GRAP Stage IV invoked 4 times. 40% of construction sites continued operations during ban.</td>
-                                <td>CAQM, media reports</td>
-                                <td><span class="badge badge-warning">Partial</span></td>
+                                <td data-label="Date">Winter 2025-26</td>
+                                <td data-label="Action">GRAP Stage IV invoked 4 times. 40% of construction sites continued operations during ban.</td>
+                                <td data-label="Source">CAQM, media reports</td>
+                                <td data-label="Status"><span class="badge badge-warning">Partial</span></td>
                             </tr>
                             <tr>
-                                <td>Dec 2024</td>
-                                <td>GRAP shifts to predictive activation (3-day IMD/IITM forecast) instead of reactive triggers</td>
-                                <td>CAQM notification</td>
-                                <td><span class="badge badge-success">Implemented</span></td>
+                                <td data-label="Date">Dec 2024</td>
+                                <td data-label="Action">GRAP shifts to predictive activation (3-day IMD/IITM forecast) instead of reactive triggers</td>
+                                <td data-label="Source">CAQM notification</td>
+                                <td data-label="Status"><span class="badge badge-success">Implemented</span></td>
                             </tr>
                             <tr>
-                                <td>2020</td>
-                                <td>BS-VI fuel standards enforced nationally</td>
-                                <td>MoPNG gazette</td>
-                                <td><span class="badge badge-success">Implemented</span></td>
+                                <td data-label="Date">2020</td>
+                                <td data-label="Action">BS-VI fuel standards enforced nationally</td>
+                                <td data-label="Source">MoPNG gazette</td>
+                                <td data-label="Status"><span class="badge badge-success">Implemented</span></td>
                             </tr>
                         </tbody>
                     </table>
@@ -3685,30 +3685,30 @@
 
             <!-- Mumbai Actions -->
             <div class="city-action-block" data-city-actions="mumbai" style="margin-bottom: 1.5rem;">
-                <h4 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
+                <h3 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
                     Mumbai
-                </h4>
+                </h3>
                 <div class="table-wrap">
-                    <table class="table">
+                    <table class="table responsive-cards">
                         <thead><tr><th style="width:110px;">Date</th><th>Action</th><th style="width:130px;">Source</th><th style="width:110px;">Status</th></tr></thead>
                         <tbody>
                             <tr>
-                                <td>2025-26</td>
-                                <td>NCAP allocation &rupee;380 Cr; &rupee;220 Cr utilised (58%). Bulk spent on road sweeping and dust suppression.</td>
-                                <td>CREA NCAP Analysis</td>
-                                <td><span class="badge badge-warning">Moderate</span></td>
+                                <td data-label="Date">2025-26</td>
+                                <td data-label="Action">NCAP allocation &rupee;380 Cr; &rupee;220 Cr utilised (58%). Bulk spent on road sweeping and dust suppression.</td>
+                                <td data-label="Source">CREA NCAP Analysis</td>
+                                <td data-label="Status"><span class="badge badge-warning">Moderate</span></td>
                             </tr>
                             <tr>
-                                <td>2024</td>
-                                <td>PM2.5 increased 38% since 2019 despite NCAP interventions</td>
-                                <td>MPCB annual report</td>
-                                <td><span class="badge badge-danger">Worsening</span></td>
+                                <td data-label="Date">2024</td>
+                                <td data-label="Action">PM2.5 increased 38% since 2019 despite NCAP interventions</td>
+                                <td data-label="Source">MPCB annual report</td>
+                                <td data-label="Status"><span class="badge badge-danger">Worsening</span></td>
                             </tr>
                             <tr>
-                                <td>2023</td>
-                                <td>BEST e-bus fleet expansion to 400 vehicles; target 2,100 by 2026</td>
-                                <td>BEST press release</td>
-                                <td><span class="badge badge-success">On track</span></td>
+                                <td data-label="Date">2023</td>
+                                <td data-label="Action">BEST e-bus fleet expansion to 400 vehicles; target 2,100 by 2026</td>
+                                <td data-label="Source">BEST press release</td>
+                                <td data-label="Status"><span class="badge badge-success">On track</span></td>
                             </tr>
                         </tbody>
                     </table>
@@ -3717,30 +3717,30 @@
 
             <!-- Patna Actions -->
             <div class="city-action-block" data-city-actions="patna" style="margin-bottom: 1.5rem;">
-                <h4 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
+                <h3 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
                     Patna
-                </h4>
+                </h3>
                 <div class="table-wrap">
-                    <table class="table">
+                    <table class="table responsive-cards">
                         <thead><tr><th style="width:110px;">Date</th><th>Action</th><th style="width:130px;">Source</th><th style="width:110px;">Status</th></tr></thead>
                         <tbody>
                             <tr>
-                                <td>2025-26</td>
-                                <td>NCAP allocation &rupee;120 Cr; &rupee;84 Cr utilised (70%). Best utilisation rate among major cities.</td>
-                                <td>CREA NCAP Analysis</td>
-                                <td><span class="badge badge-success">On track</span></td>
+                                <td data-label="Date">2025-26</td>
+                                <td data-label="Action">NCAP allocation &rupee;120 Cr; &rupee;84 Cr utilised (70%). Best utilisation rate among major cities.</td>
+                                <td data-label="Source">CREA NCAP Analysis</td>
+                                <td data-label="Status"><span class="badge badge-success">On track</span></td>
                             </tr>
                             <tr>
-                                <td>2024</td>
-                                <td>3 CAAQMS stations operational; 4 manual stations. PM2.5 annual avg ~96.8 &micro;g/m&sup3; (19&times; WHO).</td>
-                                <td>BSPCB, IQAir 2025</td>
-                                <td><span class="badge badge-danger">Severe</span></td>
+                                <td data-label="Date">2024</td>
+                                <td data-label="Action">3 CAAQMS stations operational; 4 manual stations. PM2.5 annual avg ~96.8 &micro;g/m&sup3; (19&times; WHO).</td>
+                                <td data-label="Source">BSPCB, IQAir 2025</td>
+                                <td data-label="Status"><span class="badge badge-danger">Severe</span></td>
                             </tr>
                             <tr>
-                                <td>2023</td>
-                                <td>Brick kiln conversion programme initiated &mdash; zigzag technology mandate for kilns within 50 km</td>
-                                <td>BSPCB order</td>
-                                <td><span class="badge badge-warning">Partial</span></td>
+                                <td data-label="Date">2023</td>
+                                <td data-label="Action">Brick kiln conversion programme initiated &mdash; zigzag technology mandate for kilns within 50 km</td>
+                                <td data-label="Source">BSPCB order</td>
+                                <td data-label="Status"><span class="badge badge-warning">Partial</span></td>
                             </tr>
                         </tbody>
                     </table>
@@ -3749,36 +3749,36 @@
 
             <!-- Lucknow Actions -->
             <div class="city-action-block" data-city-actions="lucknow">
-                <h4 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
+                <h3 style="font-size: 0.9375rem; color: var(--ink); margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
                     Lucknow
-                </h4>
+                </h3>
                 <div class="table-wrap">
-                    <table class="table">
+                    <table class="table responsive-cards">
                         <thead><tr><th style="width:110px;">Date</th><th>Action</th><th style="width:130px;">Source</th><th style="width:110px;">Status</th></tr></thead>
                         <tbody>
                             <tr>
-                                <td>2025-26</td>
-                                <td>NCAP allocation &rupee;180 Cr; &rupee;72 Cr utilised (40%). Below 75% threshold &mdash; risks losing next-year funding.</td>
-                                <td>CREA NCAP Analysis</td>
-                                <td><span class="badge badge-danger">Below threshold</span></td>
+                                <td data-label="Date">2025-26</td>
+                                <td data-label="Action">NCAP allocation &rupee;180 Cr; &rupee;72 Cr utilised (40%). Below 75% threshold &mdash; risks losing next-year funding.</td>
+                                <td data-label="Source">CREA NCAP Analysis</td>
+                                <td data-label="Status"><span class="badge badge-danger">Below threshold</span></td>
                             </tr>
                             <tr>
-                                <td>2024</td>
-                                <td>PM2.5 annual avg ~76.5 &micro;g/m&sup3; (15&times; WHO). Indo-Gangetic plain trapping.</td>
-                                <td>IQAir 2025</td>
-                                <td><span class="badge badge-danger">Severe</span></td>
+                                <td data-label="Date">2024</td>
+                                <td data-label="Action">PM2.5 annual avg ~76.5 &micro;g/m&sup3; (15&times; WHO). Indo-Gangetic plain trapping.</td>
+                                <td data-label="Source">IQAir 2025</td>
+                                <td data-label="Status"><span class="badge badge-danger">Severe</span></td>
                             </tr>
                             <tr>
-                                <td>2023</td>
-                                <td>Anti-smog gun deployment (12 units) across major intersections</td>
-                                <td>LMC press release</td>
-                                <td><span class="badge badge-warning">Cosmetic</span></td>
+                                <td data-label="Date">2023</td>
+                                <td data-label="Action">Anti-smog gun deployment (12 units) across major intersections</td>
+                                <td data-label="Source">LMC press release</td>
+                                <td data-label="Status"><span class="badge badge-warning">Cosmetic</span></td>
                             </tr>
                             <tr>
-                                <td>2022</td>
-                                <td>Mechanised road sweeping expanded to 200 km of roads daily</td>
-                                <td>UPPCB report</td>
-                                <td><span class="badge badge-success">Implemented</span></td>
+                                <td data-label="Date">2022</td>
+                                <td data-label="Action">Mechanised road sweeping expanded to 200 km of roads daily</td>
+                                <td data-label="Source">UPPCB report</td>
+                                <td data-label="Status"><span class="badge badge-success">Implemented</span></td>
                             </tr>
                         </tbody>
                     </table>
@@ -3836,32 +3836,32 @@
             </p>
             <div class="grid-2" style="gap: 1rem;">
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--red); font-size: 0.875rem;">On spending priorities</h4>
+                    <h3 style="color: var(--red); font-size: 0.875rem;">On spending priorities</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;How much of the NCAP budget was spent on road dust suppression vs actual emission reduction (vehicles, industry, biomass)?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: 68% of NCAP funds nationally went to dust control. Vehicles (38%) and industry (18%) &mdash; the top PM2.5 sources &mdash; received &lt;1% combined.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">On CAQM functioning</h4>
+                    <h3 style="font-size: 0.875rem">On CAQM functioning</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;How many CAQM meetings were held in the past 6 months? What was decided? Are minutes publicly available?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: CAQM is the apex body for NCR air quality. Meeting frequency and decisions should be public. File RTI under CAQM, MoEFCC.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">On monitoring gaps</h4>
+                    <h3 style="font-size: 0.875rem">On monitoring gaps</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;Has your city&rsquo;s monitoring station count increased since NCAP started? Are all stations reporting data continuously?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: Many cities have 2-3 stations for millions of people. Data gaps (&gt;25% downtime) are common. Without measurement, there is no accountability.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">On the funding cliff</h4>
+                    <h3 style="font-size: 0.875rem">On the funding cliff</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;What happened to the 15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) that expired 31 March 2026?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: This bucket was 87% of all NCAP city funding. 16th FC recommendations expected Oct 2026 for FY27 (Apr 2027) &mdash; leaving a potential 12-month gap with no new allocation.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--green-700); font-size: 0.875rem;">On target accountability</h4>
+                    <h3 style="color: var(--green-700); font-size: 0.875rem;">On target accountability</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;NCAP targeted 40% PM10 reduction by March 2026. Only 23 of 96 cities met it. What is the revised plan?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: As of mid-May 2026, no revised NCAP programme has been announced. Guttikunda et al. (2024) found &ldquo;no change in the fraction of cities above 150 &micro;g/m&sup3;&rdquo; for PM10.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">On compliance enforcement</h4>
+                    <h3 style="font-size: 0.875rem">On compliance enforcement</h3>
                     <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;During the last GRAP Stage IV, how many construction sites were inspected? How many penalties were issued?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: Compliance monitoring during winter 2025-26 found 40% of construction sites continued operations during the ban. Enforcement is the weakest link.</p>
                 </div>
@@ -3913,9 +3913,9 @@
         <div class="card-body">
             <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">No comprehensive study exists on air quality-driven internal migration in India. This is a critical research gap. Available indicators:</p>
             <div class="grid-3" style="gap: 1rem;">
-                <div class="info-box"><h4>Real Estate Signal</h4><p>Delhi NCR property prices grew ~4% in 2025 vs. 8-12% in Bangalore, Pune, Hyderabad. Pollution is cited alongside infrastructure as a growth drag.</p></div>
-                <div class="info-box"><h4>Corporate Relocation</h4><p>Several MNCs have expanded Bangalore/Hyderabad offices while freezing Delhi headcount. Employee surveys cite air quality as a top "quality of life" concern, ranking above traffic and safety.</p></div>
-                <div class="info-box"><h4>Brain Drain Risk</h4><p>Delhi's share of India's tech workforce has declined from 18% to 14% over five years. Not all attributable to pollution, but survey data consistently shows it as a contributing factor in relocation decisions.</p></div>
+                <div class="info-box"><h3>Real Estate Signal</h3><p>Delhi NCR property prices grew ~4% in 2025 vs. 8-12% in Bangalore, Pune, Hyderabad. Pollution is cited alongside infrastructure as a growth drag.</p></div>
+                <div class="info-box"><h3>Corporate Relocation</h3><p>Several MNCs have expanded Bangalore/Hyderabad offices while freezing Delhi headcount. Employee surveys cite air quality as a top "quality of life" concern, ranking above traffic and safety.</p></div>
+                <div class="info-box"><h3>Brain Drain Risk</h3><p>Delhi's share of India's tech workforce has declined from 18% to 14% over five years. Not all attributable to pollution, but survey data consistently shows it as a contributing factor in relocation decisions.</p></div>
             </div>
         </div>
     </div>
@@ -4271,13 +4271,13 @@
             <div class="card-header"><span class="card-title">GRAP Stages & School Impact</span></div>
             <div class="card-body">
                 <div class="table-wrap">
-                <table class="data-table" style="font-size: 0.8rem;">
+                <table class="data-table responsive-cards" style="font-size: 0.8rem;">
                     <thead><tr><th>Stage</th><th>AQI Range</th><th>School Action</th><th>Other Measures</th></tr></thead>
                     <tbody>
-                        <tr><td><span class="badge" style="background: #EAB308; color: black;">I</span></td><td>201-300</td><td>No closures, outdoor activity restricted</td><td>Water sprinkling, dust control</td></tr>
-                        <tr><td><span class="badge" style="background: #C2410C; color: white;">II</span></td><td>301-400</td><td>No outdoor sports/activities</td><td>Ban on diesel generators, coal/biomass</td></tr>
-                        <tr><td><span class="badge" style="background: #B91C1C; color: white;">III</span></td><td>401-450</td><td>Primary schools closed (up to Class 5)</td><td>Ban on construction, BS-III petrol vehicles</td></tr>
-                        <tr><td><span class="badge" style="background: #6D28D9; color: white;">IV</span></td><td>450+</td><td>All schools closed, online classes mandatory</td><td>Truck ban, 50% WFH for offices</td></tr>
+                        <tr><td data-label="Stage"><span class="badge" style="background: #EAB308; color: black;">I</span></td><td data-label="AQI Range">201-300</td><td data-label="School Action">No closures, outdoor activity restricted</td><td data-label="Other Measures">Water sprinkling, dust control</td></tr>
+                        <tr><td data-label="Stage"><span class="badge" style="background: #C2410C; color: white;">II</span></td><td data-label="AQI Range">301-400</td><td data-label="School Action">No outdoor sports/activities</td><td data-label="Other Measures">Ban on diesel generators, coal/biomass</td></tr>
+                        <tr><td data-label="Stage"><span class="badge" style="background: #B91C1C; color: white;">III</span></td><td data-label="AQI Range">401-450</td><td data-label="School Action">Primary schools closed (up to Class 5)</td><td data-label="Other Measures">Ban on construction, BS-III petrol vehicles</td></tr>
+                        <tr><td data-label="Stage"><span class="badge" style="background: #6D28D9; color: white;">IV</span></td><td data-label="AQI Range">450+</td><td data-label="School Action">All schools closed, online classes mandatory</td><td data-label="Other Measures">Truck ban, 50% WFH for offices</td></tr>
                     </tbody>
                 </table>
                 </div>
@@ -4821,7 +4821,7 @@
 
             <!-- EXAMPLE QUESTION CHIPS — surface what the bot can do -->
             <div class="info-box" style="background: rgba(27,107,74,0.04); border-left: 3px solid var(--accent); margin-bottom: 1.25rem; padding: 1rem;">
-                <h4 style="margin: 0 0 0.5rem; color: var(--accent); font-size: 0.875rem; font-weight: 700;">Try one of these &mdash; tap a chip to load the question</h4>
+                <h3 style="margin: 0 0 0.5rem; color: var(--accent); font-size: 0.875rem; font-weight: 700;">Try one of these &mdash; tap a chip to load the question</h3>
                 <div style="display: flex; flex-wrap: wrap; gap: 6px;">
                     <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Should I go jogging today?')">Should I go jogging today?</button>
                     <button class="ask-chip" style="padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text-2); font-size: 0.78rem; cursor: pointer;" onclick="loadAskChip('Top 5 worst Indian cities right now')">Top 5 worst Indian cities right now</button>
@@ -4925,7 +4925,7 @@
             </div>
 
             <div class="info-box">
-                <h4>What this bot can do</h4>
+                <h3>What this bot can do</h3>
                 <p style="margin-bottom: 0.75rem;">JanVayu's Ask system runs <strong>four internal data fetches</strong> for the city you pick (live WAQI, intra-city WAQI bounds-network, Sensor.Community community sensors, IQAir 2025 cached annual baseline), then layers <strong>seven deterministic calculators</strong> (cigarette equivalence per Berkeley Earth, mortality risk per Jaganathan et al. 2024, life-expectancy loss per AQLI 2025, migration delta, transport exposure, purifier CADR sizing, school-closure forecast) and <strong>six RTI templates</strong> (station data, NCAP funds, industry compliance, GRAP enforcement, school closure, health burden) onto an open model (OpenAI gpt-oss-120B) served via Groq.</p>
                 <p style="margin-bottom: 0.75rem;"><strong>Every answer cites the primary source</strong> for any number it gives &mdash; CPCB Annual Report, IQAir World Air Quality Report 2025, Lancet Countdown 2025, AQLI 2025, CREA, Sensor.Community, CAG audits, NGT orders. If a source is missing, the bot has failed (its own instruction).</p>
                 <p>For national/topical questions (BS-VI, e-buses, NCAP, monitoring network), the bot frames India-wide and does NOT default to Delhi context. All AI calls go through JanVayu's server; your question never leaves our infrastructure. <strong>Full chat history + PWA install</strong> available at <a href="/ask/" style="color: var(--accent);">/ask/ &rarr;</a></p>
@@ -5778,7 +5778,7 @@ function showRoleDashboard(role) {
         <div class="role-action-card" onclick="showPanel('${a.panel}')">
             <div class="role-action-card-icon">${a.icon}</div>
             <div>
-                <h4>${a.title}</h4>
+                <h3>${a.title}</h3>
                 <p>${a.desc}</p>
                 <span class="action-cta">${a.cta}</span>
             </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.108",
+  "version": "26.6.109",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.107",
+  "version": "26.6.108",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/accountability.html
+++ b/panels/accountability.html
@@ -9,22 +9,22 @@
                 <div class="card-header"><span class="card-title"> Promises vs Reality</span></div>
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead><tr><th>Statement/Promise</th><th>By Whom</th><th>Date</th><th>Status</th></tr></thead>
                             <tbody>
-                                <tr style="background: rgba(239,68,68,0.08);"><td>"No conclusive data on pollution deaths"</td><td>Union Environment Ministry</td><td>July 2024</td><td><span class="badge badge-danger">Contradicts ICMR-Lancet Studies</span></td></tr>
-                                <tr><td>"Delhi's air will be clean within 3 years"</td><td>Delhi CM</td><td>2020</td><td><span class="badge badge-danger">Failed</span></td></tr>
-                                <tr><td>"40% PM2.5 reduction by 2026"</td><td>MoEFCC (NCAP)</td><td>2019</td><td><span class="badge badge-danger">Only 23/100 Cities Met 40% PM10 Target (CREA 2026)</span></td></tr>
-                                <tr><td>"Stubble burning will end this year"</td><td>Punjab CM</td><td>2021, 2022, 2023, 2024</td><td><span class="badge badge-danger">Repeated Every Year</span></td></tr>
-                                <tr><td>"Smog towers will solve pollution"</td><td>DPCC/IIT</td><td>2021</td><td><span class="badge badge-danger">₹20Cr Wasted</span></td></tr>
-                                <tr><td>"1000 electric buses by 2023"</td><td>Delhi Transport</td><td>2021</td><td><span class="badge badge-success">1,000 Target Met by 2024; ~4,538 by Apr 2026</span></td></tr>
-                                <tr><td>"All brick kilns will use zigzag tech"</td><td>CPCB</td><td>2019</td><td><span class="badge badge-danger">30% Compliance</span></td></tr>
-                                <tr><td>"Real-time source apportionment"</td><td>MoEFCC</td><td>2022</td><td><span class="badge badge-warning">90/130 Studies Done (CREA 2026)</span></td></tr>
-                                <tr><td>"Odd-even will reduce pollution 15%"</td><td>Delhi Govt</td><td>2016</td><td><span class="badge badge-warning">~13% During Scheme Hours, Jan 2016 (EPIC)</span></td></tr>
-                                <tr style="background: rgba(234,179,8,0.08);"><td>"NCAP funds fully utilized"</td><td>MoEFCC/States</td><td>2019-25</td><td><span class="badge badge-warning">Delhi: 17% (RTI 2025)</span></td></tr>
-                                <tr style="background: rgba(27,107,74,0.08);"><td>"NCAP 40% reduction in 100 cities"</td><td>MoEFCC (NCAP)</td><td>2019</td><td><span class="badge badge-danger">Only 23/100 Met Target (CREA 2026)</span></td></tr>
-                                <tr style="background: rgba(27,107,74,0.08);"><td>"Comprehensive monitoring in NCAP cities"</td><td>CPCB</td><td>2019</td><td><span class="badge badge-danger">28/130 Cities Still No CAAQMS (2026)</span></td></tr>
-                                <tr style="background: rgba(27,107,74,0.08);"><td>"Action on CAQM recommendations"</td><td>Delhi/NCR States</td><td>Jan 2026</td><td><span class="badge badge-warning">SC: 4-Week Deadline (Jan 21)</span></td></tr>
+                                <tr style="background: rgba(239,68,68,0.08);"><td data-label="Statement/Promise">"No conclusive data on pollution deaths"</td><td data-label="By Whom">Union Environment Ministry</td><td data-label="Date">July 2024</td><td data-label="Status"><span class="badge badge-danger">Contradicts ICMR-Lancet Studies</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Delhi's air will be clean within 3 years"</td><td data-label="By Whom">Delhi CM</td><td data-label="Date">2020</td><td data-label="Status"><span class="badge badge-danger">Failed</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"40% PM2.5 reduction by 2026"</td><td data-label="By Whom">MoEFCC (NCAP)</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">Only 23/100 Cities Met 40% PM10 Target (CREA 2026)</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Stubble burning will end this year"</td><td data-label="By Whom">Punjab CM</td><td data-label="Date">2021, 2022, 2023, 2024</td><td data-label="Status"><span class="badge badge-danger">Repeated Every Year</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Smog towers will solve pollution"</td><td data-label="By Whom">DPCC/IIT</td><td data-label="Date">2021</td><td data-label="Status"><span class="badge badge-danger">₹20Cr Wasted</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"1000 electric buses by 2023"</td><td data-label="By Whom">Delhi Transport</td><td data-label="Date">2021</td><td data-label="Status"><span class="badge badge-success">1,000 Target Met by 2024; ~4,538 by Apr 2026</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"All brick kilns will use zigzag tech"</td><td data-label="By Whom">CPCB</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">30% Compliance</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Real-time source apportionment"</td><td data-label="By Whom">MoEFCC</td><td data-label="Date">2022</td><td data-label="Status"><span class="badge badge-warning">90/130 Studies Done (CREA 2026)</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Odd-even will reduce pollution 15%"</td><td data-label="By Whom">Delhi Govt</td><td data-label="Date">2016</td><td data-label="Status"><span class="badge badge-warning">~13% During Scheme Hours, Jan 2016 (EPIC)</span></td></tr>
+                                <tr style="background: rgba(234,179,8,0.08);"><td data-label="Statement/Promise">"NCAP funds fully utilized"</td><td data-label="By Whom">MoEFCC/States</td><td data-label="Date">2019-25</td><td data-label="Status"><span class="badge badge-warning">Delhi: 17% (RTI 2025)</span></td></tr>
+                                <tr style="background: rgba(27,107,74,0.08);"><td data-label="Statement/Promise">"NCAP 40% reduction in 100 cities"</td><td data-label="By Whom">MoEFCC (NCAP)</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">Only 23/100 Met Target (CREA 2026)</span></td></tr>
+                                <tr style="background: rgba(27,107,74,0.08);"><td data-label="Statement/Promise">"Comprehensive monitoring in NCAP cities"</td><td data-label="By Whom">CPCB</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">28/130 Cities Still No CAAQMS (2026)</span></td></tr>
+                                <tr style="background: rgba(27,107,74,0.08);"><td data-label="Statement/Promise">"Action on CAQM recommendations"</td><td data-label="By Whom">Delhi/NCR States</td><td data-label="Date">Jan 2026</td><td data-label="Status"><span class="badge badge-warning">SC: 4-Week Deadline (Jan 21)</span></td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -43,7 +43,7 @@
                 <div class="card-body">
                     <div class="grid-2" style="gap: 1.5rem;">
                         <div>
-                            <h4 style="color: var(--green-700); font-size: 0.875rem; margin-bottom: 0.75rem;"> NCAP Target Failures</h4>
+                            <h3 style="color: var(--green-700); font-size: 0.875rem; margin-bottom: 0.75rem;"> NCAP Target Failures</h3>
                             <div class="grid-2" style="gap: 0.75rem; margin-bottom: 1rem;">
                                 <div style="text-align: center; padding: 0.75rem; background: rgba(27,107,74,0.08); border-radius: 8px;">
                                     <div style="font-size: 1.75rem; font-weight: 700; color: var(--green-700);">23/100</div>
@@ -60,7 +60,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem; margin-bottom: 0.75rem"> Fund Misallocation</h4>
+                            <h3 style="font-size: 0.875rem; margin-bottom: 0.75rem"> Fund Misallocation</h3>
                             <div style="background: var(--bg); padding: 0.75rem; border-radius: 8px; font-size: 0.875rem;">
                                 <div style="display: flex; justify-content: space-between; margin-bottom: 0.5rem;">
                                     <span>Road dust control</span><strong style="color: var(--green-700);">68%</strong>
@@ -103,7 +103,7 @@
                 <div class="card-body">
                     <div class="grid-2" style="gap: 1.5rem;">
                         <div>
-                            <h4 style="color: var(--red); font-size: 0.875rem; margin-bottom: 0.75rem;">CREA Analysis: Oct 2025 – Feb 2026</h4>
+                            <h3 style="color: var(--red); font-size: 0.875rem; margin-bottom: 0.75rem;">CREA Analysis: Oct 2025 – Feb 2026</h3>
                             <div class="grid-2" style="gap: 0.75rem; margin-bottom: 1rem;">
                                 <div style="text-align: center; padding: 0.75rem; background: rgba(220,38,38,0.08); border-radius: 8px;">
                                     <div style="font-size: 1.75rem; font-weight: 700; color: var(--red);">204/238</div>
@@ -121,7 +121,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem; margin-bottom: 0.75rem">GRAP & Monitoring Gaps</h4>
+                            <h3 style="font-size: 0.875rem; margin-bottom: 0.75rem">GRAP & Monitoring Gaps</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>GRAP triggers:</strong> Invoked repeatedly through the winter, with prolonged Stage III/IV spells (per CAQM invocation orders; no official aggregate published)</li>
                                 <li><strong>Monitor discrepancy:</strong> Newslaundry found AQI 400+ at street level vs 249 at nearest CPCB station (Safdarjung, Mar 12)</li>
@@ -209,7 +209,7 @@
 
                     <!-- EVIDENCE GRADING LEGEND -->
                     <div class="info-box mb-2">
-                        <h4 style="margin-bottom: 0.75rem"> Evidence Grading Scale (E1-E5)</h4>
+                        <h3 style="margin-bottom: 0.75rem"> Evidence Grading Scale (E1-E5)</h3>
                         <div class="grid-5" style="gap: 0.5rem; font-size: 0.8125rem;">
                             <div style="padding: 0.5rem; background: rgba(27,107,74,0.08); border-radius: 6px; text-align: center;">
                                 <strong style="color: var(--green-700);">E1</strong><br>
@@ -236,7 +236,7 @@
 
                     <!-- INTERVENTION TRACKING TABLE -->
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr>
                                     <th>Intervention</th>
@@ -249,96 +249,96 @@
                             <tbody>
                                 <!-- TRANSPORT -->
                                 <tr style="background: rgba(22,128,60,0.05);">
-                                    <td><strong>BS-VI Fuel Standards</strong></td>
-                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
-                                    <td>2020</td>
-                                    <td><span class="badge badge-success">E4</span></td>
-                                    <td>Operational nationwide. Cut fuel sulphur 80% (50->10 ppm) from Apr 2020, enabling DPF/SCR after-treatment (PIB).</td>
+                                    <td data-label="Intervention"><strong>BS-VI Fuel Standards</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
+                                    <td data-label="Announced">2020</td>
+                                    <td data-label="Grade"><span class="badge badge-success">E4</span></td>
+                                    <td data-label="Verification Source">Operational nationwide. Cut fuel sulphur 80% (50->10 ppm) from Apr 2020, enabling DPF/SCR after-treatment (PIB).</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Delhi Metro Expansion (Phase 4)</strong></td>
-                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
-                                    <td>2019</td>
-                                    <td><span class="badge badge-warning">E3</span></td>
-                                    <td>~25 km of ~112 km sanctioned operational (first sections opened Jan-Mar 2026); remainder under construction (DMRC). Ridership impact on emissions unquantified.</td>
+                                    <td data-label="Intervention"><strong>Delhi Metro Expansion (Phase 4)</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
+                                    <td data-label="Announced">2019</td>
+                                    <td data-label="Grade"><span class="badge badge-warning">E3</span></td>
+                                    <td data-label="Verification Source">~25 km of ~112 km sanctioned operational (first sections opened Jan-Mar 2026); remainder under construction (DMRC). Ridership impact on emissions unquantified.</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Electric Bus Fleet (1000 buses)</strong></td>
-                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
-                                    <td>2021</td>
-                                    <td><span class="badge badge-success">E4</span></td>
-                                    <td>2023 deadline missed, but 1,000-bus target met by 2024; ~4,538 e-buses operational by Apr 2026 — India's largest e-bus fleet (DTC).</td>
+                                    <td data-label="Intervention"><strong>Electric Bus Fleet (1000 buses)</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
+                                    <td data-label="Announced">2021</td>
+                                    <td data-label="Grade"><span class="badge badge-success">E4</span></td>
+                                    <td data-label="Verification Source">2023 deadline missed, but 1,000-bus target met by 2024; ~4,538 e-buses operational by Apr 2026 — India's largest e-bus fleet (DTC).</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Odd-Even Scheme</strong></td>
-                                    <td><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
-                                    <td>2016</td>
-                                    <td><span class="badge badge-danger">E1</span></td>
-                                    <td>EPIC/UChicago: ~13% PM2.5 drop during 8am-8pm in Jan 2016; no effect at night or in the Apr 2016 round. Exemptions and seasonal-only deployment limit impact.</td>
+                                    <td data-label="Intervention"><strong>Odd-Even Scheme</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
+                                    <td data-label="Announced">2016</td>
+                                    <td data-label="Grade"><span class="badge badge-danger">E1</span></td>
+                                    <td data-label="Verification Source">EPIC/UChicago: ~13% PM2.5 drop during 8am-8pm in Jan 2016; no effect at night or in the Apr 2016 round. Exemptions and seasonal-only deployment limit impact.</td>
                                 </tr>
 
                                 <!-- INDUSTRIAL -->
                                 <tr style="background: rgba(124,58,237,0.05);">
-                                    <td><strong>Brick Kiln Zigzag Technology</strong></td>
-                                    <td><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
-                                    <td>2019</td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
-                                    <td>Zigzag adoption uneven — ~45% of kilns in UP, ~71% in Haryana-NCR (CPCB/SPCB inspections). Enforcement weak; seasonal operation continues.</td>
+                                    <td data-label="Intervention"><strong>Brick Kiln Zigzag Technology</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
+                                    <td data-label="Announced">2019</td>
+                                    <td data-label="Grade"><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
+                                    <td data-label="Verification Source">Zigzag adoption uneven — ~45% of kilns in UP, ~71% in Haryana-NCR (CPCB/SPCB inspections). Enforcement weak; seasonal operation continues.</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Industrial Emission Standards (FGD)</strong></td>
-                                    <td><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
-                                    <td>2015</td>
-                                    <td><span class="badge badge-warning">E3</span></td>
-                                    <td>FGD installed at only ~8% of coal units (~57 units, Aug 2025). July 2025 MoEFCC notification exempted ~78% of plants (Category C) from FGD entirely; ~11% (Category A) must comply by Dec 2027.</td>
+                                    <td data-label="Intervention"><strong>Industrial Emission Standards (FGD)</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
+                                    <td data-label="Announced">2015</td>
+                                    <td data-label="Grade"><span class="badge badge-warning">E3</span></td>
+                                    <td data-label="Verification Source">FGD installed at only ~8% of coal units (~57 units, Aug 2025). July 2025 MoEFCC notification exempted ~78% of plants (Category C) from FGD entirely; ~11% (Category A) must comply by Dec 2027.</td>
                                 </tr>
 
                                 <!-- AGRICULTURAL -->
                                 <tr style="background: rgba(34,197,94,0.05);">
-                                    <td><strong>Stubble Management Subsidies</strong></td>
-                                    <td><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
-                                    <td>2018</td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
-                                    <td>₹3,062 Cr allocated (2018-24). NASA FIRMS counts show Punjab fires well below the 2021 peak, though researchers note some burning shifted outside satellite overpass times, complicating year-on-year comparisons.</td>
+                                    <td data-label="Intervention"><strong>Stubble Management Subsidies</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
+                                    <td data-label="Announced">2018</td>
+                                    <td data-label="Grade"><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
+                                    <td data-label="Verification Source">₹3,062 Cr allocated (2018-24). NASA FIRMS counts show Punjab fires well below the 2021 peak, though researchers note some burning shifted outside satellite overpass times, complicating year-on-year comparisons.</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>PUSA Bio-Decomposer</strong></td>
-                                    <td><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
-                                    <td>2020</td>
-                                    <td><span class="badge badge-warning">E3</span></td>
-                                    <td>Free distribution in Delhi. Efficacy disputed. Adoption rate low outside Delhi.</td>
+                                    <td data-label="Intervention"><strong>PUSA Bio-Decomposer</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
+                                    <td data-label="Announced">2020</td>
+                                    <td data-label="Grade"><span class="badge badge-warning">E3</span></td>
+                                    <td data-label="Verification Source">Free distribution in Delhi. Efficacy disputed. Adoption rate low outside Delhi.</td>
                                 </tr>
 
                                 <!-- DUST CONTROL -->
                                 <tr style="background: rgba(249,115,22,0.05);">
-                                    <td><strong>Mechanical Road Sweeping</strong></td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
-                                    <td>2019</td>
-                                    <td><span class="badge badge-warning">E3</span></td>
-                                    <td>64% of NCAP funds spent on dust control (CSE). Impact on PM2.5 not quantified.</td>
+                                    <td data-label="Intervention"><strong>Mechanical Road Sweeping</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
+                                    <td data-label="Announced">2019</td>
+                                    <td data-label="Grade"><span class="badge badge-warning">E3</span></td>
+                                    <td data-label="Verification Source">64% of NCAP funds spent on dust control (CSE). Impact on PM2.5 not quantified.</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Smog Towers</strong></td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
-                                    <td>2021</td>
-                                    <td><span class="badge badge-danger">E1</span></td>
-                                    <td>₹20 Cr spent. IIT-Bombay: "Negligible impact beyond 50m radius." Photo-op policy.</td>
+                                    <td data-label="Intervention"><strong>Smog Towers</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
+                                    <td data-label="Announced">2021</td>
+                                    <td data-label="Grade"><span class="badge badge-danger">E1</span></td>
+                                    <td data-label="Verification Source">₹20 Cr spent. IIT-Bombay: "Negligible impact beyond 50m radius." Photo-op policy.</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Construction Site Dust Screens</strong></td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
-                                    <td>2017</td>
-                                    <td><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
-                                    <td>NGT mandate. Compliance uneven and poorly documented in public inspection data. No impact measurement.</td>
+                                    <td data-label="Intervention"><strong>Construction Site Dust Screens</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #C2410C; color: white;">Dust</span></td>
+                                    <td data-label="Announced">2017</td>
+                                    <td data-label="Grade"><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
+                                    <td data-label="Verification Source">NGT mandate. Compliance uneven and poorly documented in public inspection data. No impact measurement.</td>
                                 </tr>
 
                                 <!-- WASTE -->
                                 <tr style="background: rgba(239,68,68,0.05);">
-                                    <td><strong>Waste Burning Ban Enforcement</strong></td>
-                                    <td><span class="badge" style="background: #B91C1C; color: white;">Waste</span></td>
-                                    <td>2015</td>
-                                    <td><span class="badge badge-danger">E1</span></td>
-                                    <td>Open burning continues. Fines rarely collected. Landfill fires persist at Ghazipur, Bhalswa.</td>
+                                    <td data-label="Intervention"><strong>Waste Burning Ban Enforcement</strong></td>
+                                    <td data-label="Category"><span class="badge" style="background: #B91C1C; color: white;">Waste</span></td>
+                                    <td data-label="Announced">2015</td>
+                                    <td data-label="Grade"><span class="badge badge-danger">E1</span></td>
+                                    <td data-label="Verification Source">Open burning continues. Fines rarely collected. Landfill fires persist at Ghazipur, Bhalswa.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -346,13 +346,13 @@
 
                     <!-- FOUR I'S FRAMEWORK -->
                     <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--border);">
-                        <h4 style="margin-bottom: 0.75rem"> World Bank "Four I's" Framework Assessment</h4>
+                        <h3 style="margin-bottom: 0.75rem"> World Bank "Four I's" Framework Assessment</h3>
                         <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">
                             The World Bank's December 2025 report identifies four pillars essential for clean air progress. We assess India's NCAP against this framework:
                         </p>
                         <div class="grid-4" style="gap: 0.75rem;">
                             <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                                <h5 style="font-size: 0.875rem"> Information</h5>
+                                <h4 style="font-size: 0.875rem"> Information</h4>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Accessible, reliable data for planning and accountability"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> CPCB CAAQMS coverage expanding but gaps remain. Source apportionment studies completed in only 90/130 cities (CREA 2026). JanVayu fills citizen data gap.
@@ -360,7 +360,7 @@
                                 <span class="badge badge-warning mt-1" style="font-size: 0.8125rem;">PARTIAL</span>
                             </div>
                             <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                                <h5 style="color: var(--green-600); font-size: 0.875rem;"> Incentives</h5>
+                                <h4 style="color: var(--green-600); font-size: 0.875rem;"> Incentives</h4>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Encourage behavioral and investment shift"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> EV subsidies exist but reach limited. Stubble incentive weak: Punjab's proposed ₹2,500/acre cash scheme stalled after the Centre declined to fund its share (2024); support limited to CRM machinery subsidy. Ujjwala refill subsidy insufficient.
@@ -368,7 +368,7 @@
                                 <span class="badge badge-warning mt-1" style="font-size: 0.8125rem;">WEAK</span>
                             </div>
                             <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                                <h5 style="font-size: 0.875rem"> Institutions</h5>
+                                <h4 style="font-size: 0.875rem"> Institutions</h4>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Coordinate action, ensure compliance"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> CAQM created 2021 but limited enforcement. Inter-state coordination remains blame-game. NCAP city action plans inconsistent.
@@ -376,7 +376,7 @@
                                 <span class="badge badge-danger mt-1" style="font-size: 0.8125rem;">WEAK</span>
                             </div>
                             <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                                <h5 style="font-size: 0.875rem"> Infrastructure</h5>
+                                <h4 style="font-size: 0.875rem"> Infrastructure</h4>
                                 <p style="font-size: 0.8125rem; margin: 0.5rem 0;"><em>"Enable clean energy, transport, waste systems"</em></p>
                                 <div style="font-size: 0.875rem; color: var(--text-2);">
                                     <strong>India Status:</strong> Metro expansion ongoing. EV charging patchy. Waste management infrastructure decades behind need. Industrial modernization slow.
@@ -399,44 +399,44 @@
                 <div class="card-header"><span class="card-title"> Court Orders Tracker</span></div>
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead><tr><th>Order</th><th>Court</th><th>Date</th><th>Compliance</th></tr></thead>
                             <tbody>
                                 <tr>
-                                    <td>"Ban on firecrackers in Delhi-NCR"</td>
-                                    <td>Supreme Court</td>
-                                    <td>2018, 2020, 2021...</td>
-                                    <td><span class="badge badge-danger">Violated Every Diwali</span></td>
+                                    <td data-label="Order">"Ban on firecrackers in Delhi-NCR"</td>
+                                    <td data-label="Court">Supreme Court</td>
+                                    <td data-label="Date">2018, 2020, 2021...</td>
+                                    <td data-label="Compliance"><span class="badge badge-danger">Violated Every Diwali</span></td>
                                 </tr>
                                 <tr>
-                                    <td>"Stop stubble burning immediately"</td>
-                                    <td>NGT</td>
-                                    <td>Multiple orders</td>
-                                    <td><span class="badge badge-danger">Ignored</span></td>
+                                    <td data-label="Order">"Stop stubble burning immediately"</td>
+                                    <td data-label="Court">NGT</td>
+                                    <td data-label="Date">Multiple orders</td>
+                                    <td data-label="Compliance"><span class="badge badge-danger">Ignored</span></td>
                                 </tr>
                                 <tr>
-                                    <td>"Implement GRAP without delay"</td>
-                                    <td>Supreme Court</td>
-                                    <td>Nov 2024</td>
-                                    <td><span class="badge badge-warning">Partial</span></td>
+                                    <td data-label="Order">"Implement GRAP without delay"</td>
+                                    <td data-label="Court">Supreme Court</td>
+                                    <td data-label="Date">Nov 2024</td>
+                                    <td data-label="Compliance"><span class="badge badge-warning">Partial</span></td>
                                 </tr>
                                 <tr>
-                                    <td>"Compensate farmers for not burning"</td>
-                                    <td>NGT</td>
-                                    <td>2021</td>
-                                    <td><span class="badge badge-warning">Inadequate</span></td>
+                                    <td data-label="Order">"Compensate farmers for not burning"</td>
+                                    <td data-label="Court">NGT</td>
+                                    <td data-label="Date">2021</td>
+                                    <td data-label="Compliance"><span class="badge badge-warning">Inadequate</span></td>
                                 </tr>
                                 <tr>
-                                    <td>"Install smog guns at all construction"</td>
-                                    <td>NGT</td>
-                                    <td>2019</td>
-                                    <td><span class="badge badge-danger">~40% Sites Only</span></td>
+                                    <td data-label="Order">"Install smog guns at all construction"</td>
+                                    <td data-label="Court">NGT</td>
+                                    <td data-label="Date">2019</td>
+                                    <td data-label="Compliance"><span class="badge badge-danger">~40% Sites Only</span></td>
                                 </tr>
                                 <tr>
-                                    <td>"Phase out 15-year-old diesel vehicles"</td>
-                                    <td>NGT</td>
-                                    <td>2015</td>
-                                    <td><span class="badge badge-warning">Ongoing</span></td>
+                                    <td data-label="Order">"Phase out 15-year-old diesel vehicles"</td>
+                                    <td data-label="Court">NGT</td>
+                                    <td data-label="Date">2015</td>
+                                    <td data-label="Compliance"><span class="badge badge-warning">Ongoing</span></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -453,7 +453,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--red);">NCAP Funds (2019-2025)</h4>
+                            <h3 style="color: var(--red);">NCAP Funds (2019-2025)</h3>
                             <ul>
                                 <li><strong>Released:</strong> ₹13,415 crore to 130 cities — CREA 2026</li>
                                 <li><strong>Utilized:</strong> ~₹9,929 crore (74%) — CREA 2026</li>
@@ -465,7 +465,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>State Budgets for Air Quality</h4>
+                            <h3>State Budgets for Air Quality</h3>
                             <ul>
                                 <li><strong>Delhi (2024-25):</strong> ₹500 Cr (0.6% of budget)</li>
                                 <li><strong>Punjab stubble:</strong> ₹300 Cr (mostly unspent)</li>
@@ -484,7 +484,7 @@
                 <div class="card-body">
                     <div class="grid-3">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Delhi Government</h4>
+                            <h3>Delhi Government</h3>
                             <ul>
                                 <li>Local transport (buses, autos)</li>
                                 <li>Municipal waste burning</li>
@@ -496,7 +496,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Punjab/Haryana</h4>
+                            <h3>Punjab/Haryana</h3>
                             <ul>
                                 <li>Stubble burning (Oct-Nov)</li>
                                 <li>Brick kilns</li>
@@ -507,7 +507,7 @@
                         </div>
 
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Central Government</h4>
+                            <h3>Central Government</h3>
                             <ul>
                                 <li>Vehicle emission standards</li>
                                 <li>Fuel quality (BS-VI)</li>
@@ -531,12 +531,12 @@
                     <div class="card-header"><span class="card-title">RTI Filing Guide</span></div>
                     <div class="card-body">
                         <div class="info-box">
-                            <h4>What is RTI?</h4>
+                            <h3>What is RTI?</h3>
                             <p>The Right to Information Act 2005 gives every Indian citizen the right to request information from government bodies. Use it to demand air quality data, fund utilization details, and action reports.</p>
                         </div>
                         
                         <div class="info-box">
-                            <h4>Where to File</h4>
+                            <h3>Where to File</h3>
                             <ul>
                                 <li><strong>CPCB</strong> (Central Pollution Control Board) — National air quality data, NCAP funds</li>
                                 <li><strong>DPCC</strong> (Delhi Pollution Control Committee) — Delhi-specific data</li>
@@ -547,7 +547,7 @@
                         </div>
 
                         <div class="info-box">
-                            <h4>How to File</h4>
+                            <h3>How to File</h3>
                             <ul>
                                 <li><strong>Online:</strong> <a href="https://rtionline.gov.in" target="_blank" style="color: var(--green-700);">rtionline.gov.in</a> (Rs 10 fee)</li>
                                 <li><strong>By Post:</strong> Send to CPIO of relevant department with Rs 10 postal order</li>
@@ -557,7 +557,7 @@
                         </div>
 
                         <div class="info-box">
-                            <h4>Key Addresses</h4>
+                            <h3>Key Addresses</h3>
                             <p style="margin-bottom: 0.5rem;"><strong>CPCB:</strong> Parivesh Bhawan, East Arjun Nagar, Delhi-110032</p>
                             <p style="margin-bottom: 0.5rem;"><strong>DPCC:</strong> 4th Floor, ISBT Building, Kashmere Gate, Delhi-110006</p>
                             <p><strong>MoEFCC:</strong> Indira Paryavaran Bhawan, Jor Bagh Road, New Delhi-110003</p>

--- a/panels/actions.html
+++ b/panels/actions.html
@@ -24,7 +24,7 @@
                 <div class="card-body">
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Just like the city has emergency pollution rules (GRAP), you can make your own family plan. When pollution gets worse, you take more steps to protect yourself.">Just like the city has GRAP stages, create your own household response plan based on AQI levels.</p>
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr>
                                     <th>AQI Level</th>
@@ -35,40 +35,40 @@
                             </thead>
                             <tbody>
                                 <tr style="background: rgba(34,197,94,0.1);">
-                                    <td><strong style="color: var(--green-600);">0-50 Good</strong></td>
-                                    <td>Normal activities. Open windows for ventilation.</td>
-                                    <td>All activities normal</td>
-                                    <td> All outdoor activities</td>
+                                    <td data-label="AQI Level"><strong style="color: var(--green-600);">0-50 Good</strong></td>
+                                    <td data-label="Your Home Response">Normal activities. Open windows for ventilation.</td>
+                                    <td data-label="Kids & Elderly">All activities normal</td>
+                                    <td data-label="Outdoor Activity"> All outdoor activities</td>
                                 </tr>
                                 <tr style="background: rgba(234,179,8,0.1);">
-                                    <td><strong style="color: #EAB308;">51-100 Satisfactory</strong></td>
-                                    <td>Sensitive individuals limit prolonged outdoor exertion</td>
-                                    <td>Reduce intense outdoor play</td>
-                                    <td> Limit strenuous exercise</td>
+                                    <td data-label="AQI Level"><strong style="color: #EAB308;">51-100 Satisfactory</strong></td>
+                                    <td data-label="Your Home Response">Sensitive individuals limit prolonged outdoor exertion</td>
+                                    <td data-label="Kids & Elderly">Reduce intense outdoor play</td>
+                                    <td data-label="Outdoor Activity"> Limit strenuous exercise</td>
                                 </tr>
                                 <tr style="background: rgba(249,115,22,0.1);">
-                                    <td><strong style="color: #F97316;">101-200 Moderate</strong></td>
-                                    <td>Keep windows closed. Run air purifier if available.</td>
-                                    <td>Indoor play preferred</td>
-                                    <td> No jogging/cycling outdoors</td>
+                                    <td data-label="AQI Level"><strong style="color: #F97316;">101-200 Moderate</strong></td>
+                                    <td data-label="Your Home Response">Keep windows closed. Run air purifier if available.</td>
+                                    <td data-label="Kids & Elderly">Indoor play preferred</td>
+                                    <td data-label="Outdoor Activity"> No jogging/cycling outdoors</td>
                                 </tr>
                                 <tr style="background: rgba(27,107,74,0.08);">
-                                    <td><strong style="color: var(--red);">201-300 Poor</strong></td>
-                                    <td>Seal windows. Wet mop floors. N95 if going out.</td>
-                                    <td>Stay indoors. No school commute if possible.</td>
-                                    <td> Essential trips only with N95</td>
+                                    <td data-label="AQI Level"><strong style="color: var(--red);">201-300 Poor</strong></td>
+                                    <td data-label="Your Home Response">Seal windows. Wet mop floors. N95 if going out.</td>
+                                    <td data-label="Kids & Elderly">Stay indoors. No school commute if possible.</td>
+                                    <td data-label="Outdoor Activity"> Essential trips only with N95</td>
                                 </tr>
                                 <tr style="background: rgba(127,29,29,0.15);">
-                                    <td><strong style="color: #991B1B;">301-400 Very Poor</strong></td>
-                                    <td>DIY air filter running. Damp towels on gaps. Mask indoors if no purifier.</td>
-                                    <td>Consider staying with relatives in cleaner area</td>
-                                    <td> Stay home. Work from home if possible.</td>
+                                    <td data-label="AQI Level"><strong style="color: #991B1B;">301-400 Very Poor</strong></td>
+                                    <td data-label="Your Home Response">DIY air filter running. Damp towels on gaps. Mask indoors if no purifier.</td>
+                                    <td data-label="Kids & Elderly">Consider staying with relatives in cleaner area</td>
+                                    <td data-label="Outdoor Activity"> Stay home. Work from home if possible.</td>
                                 </tr>
                                 <tr style="background: rgba(127,29,29,0.25);">
-                                    <td><strong style="color: #7F1D1D;">401-500 Severe</strong></td>
-                                    <td>Emergency mode. Multiple purifiers. Consider temporary relocation.</td>
-                                    <td>Relocate if child/elderly has respiratory condition</td>
-                                    <td> Complete lockdown. Emergency only.</td>
+                                    <td data-label="AQI Level"><strong style="color: #7F1D1D;">401-500 Severe</strong></td>
+                                    <td data-label="Your Home Response">Emergency mode. Multiple purifiers. Consider temporary relocation.</td>
+                                    <td data-label="Kids & Elderly">Relocate if child/elderly has respiratory condition</td>
+                                    <td data-label="Outdoor Activity"> Complete lockdown. Emergency only.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -83,7 +83,7 @@
                     <div class="grid-3">
                         <!-- ZERO COST -->
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-600);">₹0 — Zero Cost Actions</h4>
+                            <h3 style="color: var(--green-600);">₹0 — Zero Cost Actions</h3>
                             <p data-simple="Things you can do right now that cost nothing: wet mop your floors, seal window gaps with wet towels, don&rsquo;t burn incense on bad air days, and rinse your nose with salt water after going outside."></p>
                             <ul>
                                 <li><strong>Wet mopping</strong> — Mop floors 2x daily to trap settled PM2.5</li>
@@ -100,7 +100,7 @@
 
                         <!-- LOW COST -->
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>₹500-2000 — Low Cost</h4>
+                            <h3>₹500-2000 — Low Cost</h3>
                             <p data-simple="For a small budget: buy N95 masks (₹50-150), make a DIY air purifier with a box fan and filter for ₹1200, or get indoor plants like money plant and snake plant."></p>
                             <ul>
                                 <li><strong>N95/N99 masks</strong> — ₹50-150 each. Only N95+ blocks PM2.5. Cloth masks don't work.</li>
@@ -116,7 +116,7 @@
 
                         <!-- INVESTMENT -->
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>₹5000+ — Investment Solutions</h4>
+                            <h3>₹5000+ — Investment Solutions</h3>
                             <p data-simple="If you can spend more: get a HEPA air purifier (₹8,000+), buy an air quality monitor (₹3,000+), upgrade your car&rsquo;s cabin filter, or get your windows professionally sealed."></p>
                             <ul>
                                 <li><strong>HEPA air purifier</strong> — ₹8,000-50,000. Get CADR rating for your room size. Run 24/7 during bad days.</li>
@@ -140,7 +140,7 @@
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;">When AQI >200, outdoor play is harmful. Children breathe faster and inhale more pollutants per kg body weight. Here are energy-burning indoor alternatives:</p>
                     <div class="grid-4">
                         <div class="info-box">
-                            <h4> Physical Activity</h4>
+                            <h3> Physical Activity</h3>
                             <ul>
                                 <li>Indoor obstacle course</li>
                                 <li>Dance/Zumba videos</li>
@@ -151,7 +151,7 @@
                             </ul>
                         </div>
                         <div class="info-box">
-                            <h4> Creative Play</h4>
+                            <h3> Creative Play</h3>
                             <ul>
                                 <li>Arts & crafts</li>
                                 <li>Building blocks/Lego</li>
@@ -162,7 +162,7 @@
                             </ul>
                         </div>
                         <div class="info-box">
-                            <h4> Learning Games</h4>
+                            <h3> Learning Games</h3>
                             <ul>
                                 <li>Board games</li>
                                 <li>Puzzles</li>
@@ -173,7 +173,7 @@
                             </ul>
                         </div>
                         <div class="info-box">
-                            <h4> Timing Tips</h4>
+                            <h3> Timing Tips</h3>
                             <ul>
                                 <li>Best outdoor window: 12-4 PM (usually lowest AQI)</li>
                                 <li>Avoid: 6-10 AM, 6-10 PM (peak hours)</li>
@@ -192,14 +192,14 @@
                     <div class="grid-2">
                         <div>
                             <div class="table-wrap">
-                                <table class="table">
+                                <table class="table responsive-cards">
                                     <thead><tr><th>Mask Type</th><th>PM2.5 Filtration</th><th>Cost</th><th>Verdict</th></tr></thead>
                                     <tbody>
-                                        <tr><td>Cloth/Cotton</td><td>10-30%</td><td>₹20-50</td><td style="color: var(--red);"> Useless for PM2.5</td></tr>
-                                        <tr><td>Surgical mask</td><td>30-50%</td><td>₹5-10</td><td style="color: var(--amber);"> Better than nothing</td></tr>
-                                        <tr><td>N95 (no valve)</td><td>95%</td><td>₹50-150</td><td style="color: var(--green-600);"> Recommended</td></tr>
-                                        <tr><td>N99</td><td>99%</td><td>₹150-300</td><td style="color: var(--green-600);"> Best protection</td></tr>
-                                        <tr><td>N95 with valve</td><td>95% (inhale only)</td><td>₹100-200</td><td style="color: var(--ink);"> Easier breathing</td></tr>
+                                        <tr><td data-label="Mask Type">Cloth/Cotton</td><td data-label="PM2.5 Filtration">10-30%</td><td data-label="Cost">₹20-50</td><td style="color: var(--red);" data-label="Verdict"> Useless for PM2.5</td></tr>
+                                        <tr><td data-label="Mask Type">Surgical mask</td><td data-label="PM2.5 Filtration">30-50%</td><td data-label="Cost">₹5-10</td><td style="color: var(--amber);" data-label="Verdict"> Better than nothing</td></tr>
+                                        <tr><td data-label="Mask Type">N95 (no valve)</td><td data-label="PM2.5 Filtration">95%</td><td data-label="Cost">₹50-150</td><td style="color: var(--green-600);" data-label="Verdict"> Recommended</td></tr>
+                                        <tr><td data-label="Mask Type">N99</td><td data-label="PM2.5 Filtration">99%</td><td data-label="Cost">₹150-300</td><td style="color: var(--green-600);" data-label="Verdict"> Best protection</td></tr>
+                                        <tr><td data-label="Mask Type">N95 with valve</td><td data-label="PM2.5 Filtration">95% (inhale only)</td><td data-label="Cost">₹100-200</td><td style="color: var(--ink);" data-label="Verdict"> Easier breathing</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -208,7 +208,7 @@
                             </div>
                         </div>
                         <div class="info-box">
-                            <h4>Proper Mask Usage</h4>
+                            <h3>Proper Mask Usage</h3>
                             <ul>
                                 <li><strong>Fit test:</strong> No gaps around nose/chin. Glasses fogging = bad seal.</li>
                                 <li><strong>Replace:</strong> Every 3-5 days of regular use, or when breathing becomes difficult</li>
@@ -228,7 +228,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>What Schools Should Do</h4>
+                            <h3>What Schools Should Do</h3>
                             <ul>
                                 <li><strong>AQI-based schedule</strong> — No outdoor PT/games when AQI >200</li>
                                 <li><strong>Indoor assembly</strong> — Shift morning assembly indoors during bad days</li>
@@ -241,7 +241,7 @@
                             <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Reference: CPCB School Guidelines 2023</div>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-600);">What Parents Can Demand (Legal Basis)</h4>
+                            <h3 style="color: var(--green-600);">What Parents Can Demand (Legal Basis)</h3>
                             <ul>
                                 <li><strong>CAQM Direction 2024:</strong> Schools must suspend outdoor activities when AQI >400</li>
                                 <li><strong>Right to Education:</strong> Schools must provide safe environment</li>
@@ -262,7 +262,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--red);">Clinical Preparedness</h4>
+                            <h3 style="color: var(--red);">Clinical Preparedness</h3>
                             <ul>
                                 <li><strong>Stock up:</strong> Nebulizers, bronchodilators, steroids for Nov-Dec surge</li>
                                 <li><strong>Triage protocol:</strong> Respiratory distress fast-track during severe AQI days</li>
@@ -273,7 +273,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Infrastructure</h4>
+                            <h3>Infrastructure</h3>
                             <ul>
                                 <li><strong>HEPA in ICU/NICU:</strong> Critical care units need filtered air</li>
                                 <li><strong>Positive pressure:</strong> OTs should have positive pressure ventilation</li>
@@ -293,7 +293,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Immediate Actions</h4>
+                            <h3>Immediate Actions</h3>
                             <ul>
                                 <li><strong>Ban leaf burning:</strong> Compost pit instead. Fine violators.</li>
                                 <li><strong>No open waste burning:</strong> Report to MCD if staff burns</li>
@@ -305,7 +305,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-700);">Legal Powers & Long-term</h4>
+                            <h3 style="color: var(--green-700);">Legal Powers & Long-term</h3>
                             <ul>
                                 <li><strong>MC Act:</strong> RWAs can frame bylaws on burning, DG use</li>
                                 <li><strong>Green cover:</strong> Plant pollution-resistant trees (Neem, Peepal, Ashoka)</li>
@@ -326,7 +326,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-600);"> Rural Areas</h4>
+                            <h3 style="color: var(--green-600);"> Rural Areas</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Main sources:</strong> Crop burning, biomass cooking, dust roads, brick kilns</p>
                             <ul>
                                 <li><strong>Stubble alternatives:</strong>
@@ -344,7 +344,7 @@
                             <div style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Subsidy: Contact District Agriculture Officer for Happy Seeder</div>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4> Urban Areas</h4>
+                            <h3> Urban Areas</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;"><strong>Main sources:</strong> Vehicles, construction, industry, road dust, waste burning</p>
                             <ul>
                                 <li><strong>Transport:</strong>
@@ -373,7 +373,7 @@
                 <div class="card-body">
                     <div class="grid-3">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--red);">Report Violations</h4>
+                            <h3 style="color: var(--red);">Report Violations</h3>
                             <ul>
                                 <li><strong>Sameer App</strong> — CPCB app to report pollution sources</li>
                                 <li><strong>Green Delhi App</strong> — For Delhi-specific complaints</li>
@@ -383,7 +383,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4>Demand Action</h4>
+                            <h3>Demand Action</h3>
                             <ul>
                                 <li><strong>File RTI</strong> — Templates in RTI tab</li>
                                 <li><strong>Write to MLA/MP</strong> — Elected representatives respond to volume</li>
@@ -393,7 +393,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--green-600);">Community Building</h4>
+                            <h3 style="color: var(--green-600);">Community Building</h3>
                             <ul>
                                 <li><strong>WhatsApp groups</strong> — Coordinate local clean air initiatives</li>
                                 <li><strong>Tree plantation</strong> — Organize drives with RWA/school</li>

--- a/panels/aqi-explainer.html
+++ b/panels/aqi-explainer.html
@@ -11,7 +11,7 @@
         <div class="card-body">
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="AQI is like a report card for air. It checks up to 8 pollutants, gives each a score, and reports the worst score as the final AQI. The pollutant with the worst score is called the 'dominant pollutant'.">AQI is a <strong>composite index</strong>. Monitoring stations measure up to 8 pollutants (PM2.5, PM10, NO2, SO2, O3, CO, NH3, Pb). Each pollutant concentration is converted into a sub-index on a 0&ndash;500 scale using breakpoint tables. The <strong>final AQI = maximum of all sub-indices</strong>. The pollutant with the highest sub-index is called the <em>dominant pollutant</em>.</p>
             <div class="info-box" style="background: rgba(99,102,241,0.06); border-left: 3px solid var(--accent); margin-bottom: 1rem;">
-                <h4>Why this matters</h4>
+                <h3>Why this matters</h3>
                 <p data-simple="An AQI of 200 from PM2.5 and an AQI of 200 from NO2 need different responses. PM2.5 means wear a mask. NO2 means avoid traffic areas. Same number, different action.">An AQI of 200 could be driven by PM2.5 alone OR by NO2 alone &mdash; the health response should differ. PM2.5-driven AQI calls for N95 masks and air purifiers. NO2-driven AQI calls for avoiding traffic corridors and idling vehicles. <strong>Same number, different action.</strong></p>
             </div>
 
@@ -132,24 +132,24 @@
             <p style="font-size: 0.9375rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="Most people think air pollution means PM2.5. But other pollutants cause serious harm too, and they need different solutions. Dust dominates in Rajasthan. NO2 is rising in big cities from diesel vehicles. Ozone surges in summer but nobody talks about it.">India&rsquo;s air pollution conversation is dominated by PM2.5 &mdash; understandably, since it is the deadliest. But focusing exclusively on one pollutant creates dangerous blind spots:</p>
             <div class="grid-2" style="gap: 1rem; margin-bottom: 1rem;">
                 <div class="info-box" style="background: rgba(217,119,6,0.06); border-left: 3px solid var(--accent);">
-                    <h4>Different AQI, different response</h4>
+                    <h3>Different AQI, different response</h3>
                     <p data-simple="AQI 150 from PM2.5 means tiny particles in the air — wear a mask and use a purifier. AQI 150 from ozone means avoid being outdoors in the afternoon sun. Same AQI number, but different actions needed.">A city with AQI 150 from PM2.5 vs AQI 150 from O3 requires completely different responses. PM2.5 calls for masks and purifiers; O3 calls for staying indoors during peak sunlight hours. Masks do <strong>not</strong> filter ozone.</p>
                 </div>
                 <div class="info-box" style="background: rgba(234,179,8,0.06); border-left: 3px solid var(--accent);">
-                    <h4>PM10: the forgotten pollutant</h4>
+                    <h3>PM10: the forgotten pollutant</h3>
                     <p data-simple="In cities like Jaipur, Jodhpur, and Ahmedabad, PM10 (dust) often makes the AQI worse than PM2.5. But media and policy focus almost entirely on PM2.5, so dust-driven pollution gets ignored.">PM10 dominates AQI in Rajasthan, Gujarat, and western India due to desert dust and road dust resuspension &mdash; but gets a fraction of the media coverage PM2.5 receives. Dust-driven AQI crises are real health events.</p>
                 </div>
                 <div class="info-box" style="background: rgba(124,58,237,0.06); border-left: 3px solid var(--accent);">
-                    <h4>NO2: the silent crisis</h4>
+                    <h3>NO2: the silent crisis</h3>
                     <p data-simple="NO2 from diesel vehicles is rising fast in Delhi, Mumbai, Bengaluru, and Chennai. It inflames airways and helps create ozone. But because PM2.5 gets all the attention, NO2 rises unchecked.">NO2 is rising rapidly in metro cities due to growing diesel vehicle fleets. It is a direct health hazard <em>and</em> a precursor to ozone formation. The dual threat makes NO2 reduction one of the highest-impact interventions.</p>
                 </div>
                 <div class="info-box" style="background: rgba(34,197,94,0.06); border-left: 3px solid var(--accent);">
-                    <h4>O3: surging in summer</h4>
+                    <h3>O3: surging in summer</h3>
                     <p data-simple="Ozone pollution is worst in hot, sunny months — exactly when PM2.5 drops and people think the air is clean. In many Indian cities, ozone is rising year over year, but almost nobody talks about it.">Ozone is the pollutant most people have never heard of but is surging in Indian summers. It peaks precisely when PM2.5 drops &mdash; creating a false sense of &ldquo;clean air&rdquo; in months when ozone may be dangerously high.</p>
                 </div>
             </div>
             <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent);">
-                <h4>India&rsquo;s NAAQS vs WHO guidelines</h4>
+                <h3>India&rsquo;s NAAQS vs WHO guidelines</h3>
                 <p data-simple="India says PM2.5 up to 40 is safe for a year. WHO says anything above 5 is unsafe. That's an 8 times difference. What India calls 'Moderate' air, the WHO calls 'Unhealthy'. Always look at the actual pollution numbers, not just the AQI label.">India&rsquo;s National Ambient Air Quality Standard for PM2.5 is <strong>40 &micro;g/m&sup3;</strong> (annual average). The WHO 2021 guideline is <strong>5 &micro;g/m&sup3;</strong> &mdash; an <strong>8&times; gap</strong>. What CPCB labels &ldquo;Moderate&rdquo; would be classified &ldquo;Unhealthy&rdquo; by global standards. <strong>Always look at raw &micro;g/m&sup3; values, not just the AQI label.</strong></p>
             </div>
         </div>
@@ -204,7 +204,7 @@
                 </table>
             </div>
             <div class="info-box" style="background: rgba(239,68,68,0.06); border-left: 3px solid var(--accent); margin-top: 1rem;">
-                <h4>Key insight</h4>
+                <h3>Key insight</h3>
                 <p data-simple="At 60 micrograms of PM2.5, CPCB calls the air 'Satisfactory' (AQI 100) while the US EPA calls it 'Unhealthy' (AQI 154). At the pollution levels common in Indian cities, the Indian scale sounds milder. At very high levels the two scales cross over. The lesson: don't trust the label, look at the actual PM2.5 number.">At 60 &micro;g/m&sup3; PM2.5, CPCB reports AQI 100 (&ldquo;Satisfactory&rdquo;) while the US EPA reports 154 (&ldquo;Unhealthy&rdquo;) &mdash; at the concentrations common in Indian cities, the CPCB scale sounds milder. At very high concentrations the ordering reverses: at 100 &micro;g/m&sup3; CPCB&rsquo;s sub-index of ~232 (&ldquo;Poor&rdquo;) exceeds the EPA&rsquo;s ~182. <strong>Always look at the raw &micro;g/m&sup3; concentration, not just the AQI number or colour code.</strong></p>
             </div>
         </div>

--- a/panels/budget.html
+++ b/panels/budget.html
@@ -49,7 +49,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <h4 style="color: var(--green-700); font-size: 0.9375rem; margin-bottom: 0.75rem;">Annual Economic Cost of Air Pollution</h4>
+                            <h3 style="color: var(--green-700); font-size: 0.9375rem; margin-bottom: 0.75rem;">Annual Economic Cost of Air Pollution</h3>
                             <div style="font-size: 2.5rem; font-weight: 700; color: var(--green-700);">$36.8 Billion</div>
                             <div style="font-size: 0.875rem; color: var(--text-2);">1.36% of GDP (Lancet 2021) / $339 Billion at 9.5% GDP (Lancet Countdown 2025)</div>
                             <ul style="font-size: 0.875rem; margin-top: 1rem; line-height: 1.8;">
@@ -59,7 +59,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="color: var(--green-700); font-size: 0.9375rem; margin-bottom: 0.75rem;">Annual Clean Air Spending (All Schemes)</h4>
+                            <h3 style="color: var(--green-700); font-size: 0.9375rem; margin-bottom: 0.75rem;">Annual Clean Air Spending (All Schemes)</h3>
                             <div style="font-size: 2.5rem; font-weight: 700; color: var(--green-700);">~₹15,000 Cr</div>
                             <div style="font-size: 0.875rem; color: var(--text-2);">Approximately $1.8 Billion across all schemes</div>
                             <div style="margin-top: 1rem; padding: 0.75rem; background: rgba(27,107,74,0.08); border-radius: 6px; border-left: 3px solid var(--green-700);">
@@ -126,7 +126,7 @@
                 </div>
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr>
                                     <th>City</th>
@@ -138,25 +138,25 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><strong>Delhi</strong></td>
-                                    <td>81.36</td>
-                                    <td>14.10</td>
-                                    <td><span class="badge badge-danger">17%</span></td>
-                                    <td style="color: var(--green-700);">Critical underutilization</td>
+                                    <td data-label="City"><strong>Delhi</strong></td>
+                                    <td data-label="Allocated (₹ Cr)">81.36</td>
+                                    <td data-label="Utilized (₹ Cr)">14.10</td>
+                                    <td data-label="Utilization %"><span class="badge badge-danger">17%</span></td>
+                                    <td style="color: var(--green-700);" data-label="Status">Critical underutilization</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Noida</strong></td>
-                                    <td>55.70</td>
-                                    <td>7.07</td>
-                                    <td><span class="badge badge-danger">13%</span></td>
-                                    <td style="color: var(--green-700);">Critical underutilization</td>
+                                    <td data-label="City"><strong>Noida</strong></td>
+                                    <td data-label="Allocated (₹ Cr)">55.70</td>
+                                    <td data-label="Utilized (₹ Cr)">7.07</td>
+                                    <td data-label="Utilization %"><span class="badge badge-danger">13%</span></td>
+                                    <td style="color: var(--green-700);" data-label="Status">Critical underutilization</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Ghaziabad</strong></td>
-                                    <td>48.50</td>
-                                    <td>&gt;39</td>
-                                    <td><span class="badge badge-success">&gt;80%</span></td>
-                                    <td style="color: var(--green-700);">High performer (CREA 2026)</td>
+                                    <td data-label="City"><strong>Ghaziabad</strong></td>
+                                    <td data-label="Allocated (₹ Cr)">48.50</td>
+                                    <td data-label="Utilized (₹ Cr)">&gt;39</td>
+                                    <td data-label="Utilization %"><span class="badge badge-success">&gt;80%</span></td>
+                                    <td style="color: var(--green-700);" data-label="Status">High performer (CREA 2026)</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -244,7 +244,7 @@
                 </div>
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr>
                                     <th>Scheme</th>
@@ -256,25 +256,25 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><strong>FAME I</strong></td>
-                                    <td>2015-2019</td>
-                                    <td>895</td>
-                                    <td>Hybrid & EV adoption</td>
-                                    <td><span class="badge badge-success">Completed</span></td>
+                                    <td data-label="Scheme"><strong>FAME I</strong></td>
+                                    <td data-label="Period">2015-2019</td>
+                                    <td data-label="Outlay (₹ Cr)">895</td>
+                                    <td data-label="Key Focus">Hybrid & EV adoption</td>
+                                    <td data-label="Status"><span class="badge badge-success">Completed</span></td>
                                 </tr>
                                 <tr>
-                                    <td><strong>FAME II</strong></td>
-                                    <td>2019-2024</td>
-                                    <td>11,500</td>
-                                    <td>E-2W, E-3W, E-buses, Charging</td>
-                                    <td><span class="badge badge-success">Completed</span></td>
+                                    <td data-label="Scheme"><strong>FAME II</strong></td>
+                                    <td data-label="Period">2019-2024</td>
+                                    <td data-label="Outlay (₹ Cr)">11,500</td>
+                                    <td data-label="Key Focus">E-2W, E-3W, E-buses, Charging</td>
+                                    <td data-label="Status"><span class="badge badge-success">Completed</span></td>
                                 </tr>
                                 <tr>
-                                    <td><strong>PM E-DRIVE</strong></td>
-                                    <td>2024-2026</td>
-                                    <td>10,900</td>
-                                    <td>Mass mobility, 72,300 chargers</td>
-                                    <td><span class="badge badge-info">Active</span></td>
+                                    <td data-label="Scheme"><strong>PM E-DRIVE</strong></td>
+                                    <td data-label="Period">2024-2026</td>
+                                    <td data-label="Outlay (₹ Cr)">10,900</td>
+                                    <td data-label="Key Focus">Mass mobility, 72,300 chargers</td>
+                                    <td data-label="Status"><span class="badge badge-info">Active</span></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -328,7 +328,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <h4 style="color: var(--green-700); font-size: 0.875rem; margin-bottom: 0.5rem;">Structural Issues</h4>
+                            <h3 style="color: var(--green-700); font-size: 0.875rem; margin-bottom: 0.5rem;">Structural Issues</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>No legally binding targets:</strong> NCAP targets are aspirational with no penalties</li>
                                 <li><strong>XV-FC cliff:</strong> ₹16,539 Cr <strong>expired 31 Mar 2026</strong>; no dedicated successor to the air-quality grant announced as of mid-May 2026 &mdash; 16th Finance Commission report was submitted 17 Nov 2025 (award period 2026-31)</li>
@@ -338,7 +338,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">Hidden Funds</h4>
+                            <h3 style="font-size: 0.875rem; margin-bottom: 0.5rem">Hidden Funds</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.8;">
                                 <li><strong>Environmental Cess:</strong> ₹45.8 Cr collected over 8 years, &lt;1% spent on pollution control (RTI)</li>
                                 <li><strong>CAMPA Funds:</strong> only ₹26,002 Cr utilized (2019-24), a fraction of the accumulated afforestation corpus (CAG 2024)</li>

--- a/panels/citizen-action.html
+++ b/panels/citizen-action.html
@@ -54,7 +54,7 @@
                 <div class="card-body">
                     <div class="grid-2">
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--green-700); margin-bottom: 0.75rem;">Delhi's Internal Sources (Winter Months)</h4>
+                            <h3 style="font-size: 0.875rem; color: var(--green-700); margin-bottom: 0.75rem;">Delhi's Internal Sources (Winter Months)</h3>
                             <p style="font-size: 0.875rem; margin-bottom: 1rem;">Even when external sources (stubble burning) are at peak, <strong>half of PM2.5 comes from within Delhi itself</strong>.</p>
                             
                             <div style="margin-bottom: 0.75rem;">
@@ -121,7 +121,7 @@
                             </div>
                             
                             <div class="info-box mt-2" style="border-left: 3px solid var(--accent);">
-                                <h4 style="margin-bottom: 0.5rem"> The Stubble Burning Myth</h4>
+                                <h3 style="margin-bottom: 0.5rem"> The Stubble Burning Myth</h3>
                                 <p style="font-size: 0.875rem;">Even at its peak (Oct 15 - Nov 15), stubble burning contributes 15-35% of PM2.5. Even with <strong>zero stubble burning</strong>, Delhi's AQI would still be "Very Poor" (>300). Blaming Punjab is a red herring.</p>
                             </div>
                             
@@ -148,7 +148,7 @@
 
                     <!-- TRANSPORT -->
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(59,130,246,0.03);">
-                        <h4 style="margin-bottom: 0.5rem"> Transport Measures</h4>
+                        <h3 style="margin-bottom: 0.5rem"> Transport Measures</h3>
                         <ul style="font-size: 0.875rem; line-height: 1.7; columns: 2; column-gap: 2rem;">
                             <li><strong>Car-Pooling:</strong> Min 3 occupants; dedicated carpool lanes with heavy fines</li>
                             <li><strong>Odd-Even:</strong> Include two-wheelers; no exemptions</li>
@@ -161,7 +161,7 @@
 
                     <!-- CONSTRUCTION -->
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(245,158,11,0.03);">
-                        <h4 style="margin-bottom: 0.5rem"> Construction & Industry</h4>
+                        <h3 style="margin-bottom: 0.5rem"> Construction & Industry</h3>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>Construction Holiday:</strong> Shutdown non-essential construction Oct-Feb</li>
                             <li><strong>Industrial Compliance:</strong> Immediate shutdown of violators—no compromises</li>
@@ -172,7 +172,7 @@
 
                     <!-- BURNING -->
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.03);">
-                        <h4 style="color: var(--red); margin-bottom: 0.5rem;"> Open & Waste Burning</h4>
+                        <h3 style="color: var(--red); margin-bottom: 0.5rem;"> Open & Waste Burning</h3>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>Zero Tolerance:</strong> No wood/coal/waste burning, including Lohri</li>
                             <li><strong>Fireworks:</strong> Nationwide ban (weddings/Diwali); heavy purchase tax</li>
@@ -182,7 +182,7 @@
 
                     <!-- GOVERNANCE -->
                     <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.03);">
-                        <h4 style="margin-bottom: 0.5rem"> Enforcement & Governance</h4>
+                        <h3 style="margin-bottom: 0.5rem"> Enforcement & Governance</h3>
                         <ul style="font-size: 0.875rem; line-height: 1.7;">
                             <li><strong>High-Level Oversight:</strong> Monthly PM-CM-Chief Secretary reviews with public dashboards</li>
                             <li><strong>PUC Compliance:</strong> Quarterly mandatory; deny fuel to dirty vehicles</li>
@@ -208,7 +208,7 @@
                     </div>
                     <div class="grid-2" style="gap: 1rem;">
                         <div>
-                            <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;"> Why Flyovers Fail</h4>
+                            <h3 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;"> Why Flyovers Fail</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li>Shift congestion downstream</li>
                                 <li>Encourage longer car trips (induced demand)</li>
@@ -217,7 +217,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="color: var(--green-600); margin-bottom: 0.5rem; font-size: 0.875rem;"> What Works</h4>
+                            <h3 style="color: var(--green-600); margin-bottom: 0.5rem; font-size: 0.875rem;"> What Works</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li>Rail-first: Metro + suburban rail + bus integration</li>
                                 <li>Walking infrastructure: Continuous footpaths</li>
@@ -243,7 +243,7 @@
                     <p style="font-size: 0.875rem; margin-bottom: 1rem;">A New York Times analysis tracked real-time PM2.5 exposure for two Delhi children on the same day.</p>
                     <div class="grid-2" style="gap: 1rem;">
                         <div class="info-box" style="border-left: 4px solid var(--green-700); background: rgba(27,107,74,0.03);">
-                            <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;"> Monu — Poor (Trans-Yamuna)</h4>
+                            <h3 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;"> Monu — Poor (Trans-Yamuna)</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.6;">
                                 <li>Peak exposure: <strong>~180 µg/m³</strong></li>
                                 <li>No air purifier, limited ability to stay indoors</li>
@@ -251,7 +251,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(34,197,94,0.03);">
-                            <h4 style="color: var(--green-600); margin-bottom: 0.5rem; font-size: 0.875rem;"> Aamya — Affluent (Greater Kailash)</h4>
+                            <h3 style="color: var(--green-600); margin-bottom: 0.5rem; font-size: 0.875rem;"> Aamya — Affluent (Greater Kailash)</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.6;">
                                 <li>Peak exposure: <strong>~80 µg/m³</strong></li>
                                 <li>Air purifier, AC, can limit outdoor time</li>

--- a/panels/legal.html
+++ b/panels/legal.html
@@ -14,21 +14,21 @@
                     <div class="grid-2" style="gap: 1rem;">
                         <div>
                             <div class="info-box mb-2" style="border-left: 4px solid var(--green-700);">
-                                <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Article 21: Right to Life = Right to Clean Air</h4>
+                                <h3 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Article 21: Right to Life = Right to Clean Air</h3>
                                 <p style="font-size: 0.875rem;"><strong>Subhash Kumar v. State of Bihar (1991):</strong> Supreme Court declared that the right to life encompasses the right to enjoy pollution-free water and air.</p>
                             </div>
                             <div class="info-box" style="border-left: 4px solid var(--accent);">
-                                <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Right Against Climate Degradation (2024)</h4>
+                                <h3 style="margin-bottom: 0.5rem; font-size: 0.875rem">Right Against Climate Degradation (2024)</h3>
                                 <p style="font-size: 0.875rem;"><strong>M.K. Ranjitsinh v. Union of India (2024):</strong> Fundamental right against climate degradation — frames air pollution as constitutional rights defense.</p>
                             </div>
                         </div>
                         <div>
                             <div class="info-box mb-2" style="border-left: 4px solid var(--accent);">
-                                <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Polluter Pays Principle</h4>
+                                <h3 style="margin-bottom: 0.5rem; font-size: 0.875rem">Polluter Pays Principle</h3>
                                 <p style="font-size: 0.875rem;"><strong>Vellore Citizens v. UOI (1996):</strong> Integrated Precautionary and Polluter Pays Principles. Justifies pollution cess, fines on violators.</p>
                             </div>
                             <div class="info-box" style="border-left: 4px solid var(--accent);">
-                                <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Absolute Liability</h4>
+                                <h3 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">Absolute Liability</h3>
                                 <p style="font-size: 0.875rem;"><strong>M.C. Mehta v. UOI (1987):</strong> Industries in hazardous activities are strictly liable regardless of negligence.</p>
                             </div>
                         </div>
@@ -43,35 +43,35 @@
                 </div>
                 <div class="card-body">
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr><th>Act/Body</th><th>Key Provision</th><th>Power Granted</th></tr>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><strong>EPA, 1986</strong></td>
-                                    <td>Section 3 & 5</td>
-                                    <td>Closure of any industry; stoppage of electricity/water</td>
+                                    <td data-label="Act/Body"><strong>EPA, 1986</strong></td>
+                                    <td data-label="Key Provision">Section 3 & 5</td>
+                                    <td data-label="Power Granted">Closure of any industry; stoppage of electricity/water</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>CAQM Act, 2021</strong></td>
-                                    <td>Section 14, 15</td>
-                                    <td>Prevails over state orders; fines up to ₹1 crore; 5 years imprisonment</td>
+                                    <td data-label="Act/Body"><strong>CAQM Act, 2021</strong></td>
+                                    <td data-label="Key Provision">Section 14, 15</td>
+                                    <td data-label="Power Granted">Prevails over state orders; fines up to ₹1 crore; 5 years imprisonment</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Air Act, 1981</strong></td>
-                                    <td>Section 31(A)</td>
-                                    <td>Binding orders on specific pollution sources</td>
+                                    <td data-label="Act/Body"><strong>Air Act, 1981</strong></td>
+                                    <td data-label="Key Provision">Section 31(A)</td>
+                                    <td data-label="Power Granted">Binding orders on specific pollution sources</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>MV Act, 1988</strong></td>
-                                    <td>Section 190(2)</td>
-                                    <td>Mandatory PUC; fines up to ₹10,000; fuel denial</td>
+                                    <td data-label="Act/Body"><strong>MV Act, 1988</strong></td>
+                                    <td data-label="Key Provision">Section 190(2)</td>
+                                    <td data-label="Power Granted">Mandatory PUC; fines up to ₹10,000; fuel denial</td>
                                 </tr>
                                 <tr>
-                                    <td><strong>SWM Rules, 2016</strong></td>
-                                    <td>Multiple</td>
-                                    <td>Prohibits open burning; NGT imposed ₹900 Cr on Delhi</td>
+                                    <td data-label="Act/Body"><strong>SWM Rules, 2016</strong></td>
+                                    <td data-label="Key Provision">Multiple</td>
+                                    <td data-label="Power Granted">Prohibits open burning; NGT imposed ₹900 Cr on Delhi</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -87,30 +87,30 @@
                 <div class="card-body">
                     <p style="font-size: 0.875rem; margin-bottom: 1rem;">GRAP is a <strong>judicially approved mandate</strong>, approved by Supreme Court in 2016 in M.C. Mehta v. UOI (WP 13029/1985). CAQM implements it across NCR since 2021.</p>
                     <div class="table-wrap">
-                        <table class="table">
+                        <table class="table responsive-cards">
                             <thead>
                                 <tr><th>Stage</th><th>AQI</th><th>Key Measures</th></tr>
                             </thead>
                             <tbody>
                                 <tr style="background: rgba(245,158,11,0.05);">
-                                    <td><span class="badge badge-warning">I</span></td>
-                                    <td>201-300</td>
-                                    <td>Water sprinkling; dust control; PUC checks</td>
+                                    <td data-label="Stage"><span class="badge badge-warning">I</span></td>
+                                    <td data-label="AQI">201-300</td>
+                                    <td data-label="Key Measures">Water sprinkling; dust control; PUC checks</td>
                                 </tr>
                                 <tr style="background: rgba(249,115,22,0.05);">
-                                    <td><span class="badge" style="background: #C2410C; color: white;">II</span></td>
-                                    <td>301-400</td>
-                                    <td>Enhanced parking fees; increased public transport</td>
+                                    <td data-label="Stage"><span class="badge" style="background: #C2410C; color: white;">II</span></td>
+                                    <td data-label="AQI">301-400</td>
+                                    <td data-label="Key Measures">Enhanced parking fees; increased public transport</td>
                                 </tr>
                                 <tr style="background: rgba(239,68,68,0.05);">
-                                    <td><span class="badge badge-danger">III</span></td>
-                                    <td>401-450</td>
-                                    <td>Construction restrictions; 50% WFH; hybrid schools</td>
+                                    <td data-label="Stage"><span class="badge badge-danger">III</span></td>
+                                    <td data-label="AQI">401-450</td>
+                                    <td data-label="Key Measures">Construction restrictions; 50% WFH; hybrid schools</td>
                                 </tr>
                                 <tr style="background: rgba(127,29,29,0.1);">
-                                    <td><span class="badge" style="background: #7F1D1D; color: white;">IV</span></td>
-                                    <td>&gt;450</td>
-                                    <td>Complete C&D ban; truck ban; 50% office capacity</td>
+                                    <td data-label="Stage"><span class="badge" style="background: #7F1D1D; color: white;">IV</span></td>
+                                    <td data-label="AQI">&gt;450</td>
+                                    <td data-label="Key Measures">Complete C&D ban; truck ban; 50% office capacity</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -130,19 +130,19 @@
                 <div class="card-body">
                     <div class="grid-2" style="gap: 1rem;">
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">NGT &mdash; South-India PM Roadmap Order</h4>
+                            <h3 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">NGT &mdash; South-India PM Roadmap Order</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>April 2026.</strong> National Green Tribunal (Principal Bench) directs <strong>six south-Indian states</strong> &mdash; TN, KL, KA, AP, TS, PY &mdash; to file sector-wise PM10/PM2.5 reduction roadmaps tied to state budgets. First NGT order shifting the policy frame beyond the Indo-Gangetic Plain. <a href="https://www.downtoearth.org.in/environment/daily-court-digest-major-environment-orders-april-10-2026" target="_blank" rel="noopener">DTE Daily Court Digest</a>.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">NGT &mdash; Diesel-Generator Retrofit Notices</h4>
+                            <h3 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">NGT &mdash; Diesel-Generator Retrofit Notices</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>9 April 2026.</strong> NGT issues notices to <strong>every State Pollution Control Board</strong> and Pollution Control Committee for failing to enforce CPCB/CAQM directions on DG-set emissions retrofit. Establishes nationwide accountability beyond NCR. Next hearing 21 July 2026.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">CAQM &mdash; First Off-Season GRAP Stage-I</h4>
+                            <h3 style="font-size: 0.875rem; margin-bottom: 0.5rem">CAQM &mdash; First Off-Season GRAP Stage-I</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>19 May 2026.</strong> Commission for Air Quality Management invokes GRAP Stage-I in Delhi-NCR at AQI 208 &mdash; the <strong>first-ever off-season activation</strong>. Revoked 4 May, re-invoked 15 days later. Signals year-round enforcement, not just October&ndash;March. <a href="https://caqm.nic.in/index1.aspx?lsid=4168&amp;lev=2&amp;lid=4171&amp;langid=1" target="_blank" rel="noopener">CAQM order index</a>.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.875rem; margin-bottom: 0.5rem">NCAP Deadline Elapsed</h4>
+                            <h3 style="font-size: 0.875rem; margin-bottom: 0.5rem">NCAP Deadline Elapsed</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>31 March 2026.</strong> NCAP's original 40% PM10 reduction target deadline passed. 23/100 cities with sufficient data met the target (CREA). <strong>No revised programme announced</strong> as of mid-May 2026. 15th Finance Commission grants expired the same day.</p>
                         </div>
                     </div>
@@ -157,7 +157,7 @@
                 <div class="card-body">
                     <div class="grid-2" style="gap: 1rem;">
                         <div class="info-box" style="border-left: 3px solid var(--green-700);">
-                            <h4 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">10/15 Year Ban Rule</h4>
+                            <h3 style="color: var(--green-700); margin-bottom: 0.5rem; font-size: 0.875rem;">10/15 Year Ban Rule</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.6;">
                                 <li><strong>NGT (2014-15):</strong> Diesel >10 years, petrol >15 years banned</li>
                                 <li><strong>SC (Oct 2018):</strong> Confirmed; directed impounding</li>
@@ -165,7 +165,7 @@
                             </ul>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="margin-bottom: 0.5rem; font-size: 0.875rem">Proposed ICE Sales Ban (2026)</h4>
+                            <h3 style="margin-bottom: 0.5rem; font-size: 0.875rem">Proposed ICE Sales Ban (2026)</h3>
                             <p style="font-size: 0.875rem;">Legally defensible under EPA Section 3 & 5, given vehicles are the largest single local source of Delhi&rsquo;s PM2.5 (~39%, TERI&ndash;ARAI 2018). Article 21 (Right to Life) overrides Article 19(1)(g) (Right to Trade).</p>
                         </div>
                     </div>
@@ -189,7 +189,7 @@
                     </div>
                     <div class="grid-2" style="gap: 1rem;">
                         <div>
-                            <h4 style="font-size: 0.875rem; color: var(--green-700); margin-bottom: 0.5rem;">Key Findings</h4>
+                            <h3 style="font-size: 0.875rem; color: var(--green-700); margin-bottom: 0.5rem;">Key Findings</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li><strong>10 of 12</strong> coal TPPs within 300km never had full stack monitoring</li>
                                 <li>Only 2 plants partially monitored — results still awaited</li>
@@ -197,7 +197,7 @@
                             </ul>
                         </div>
                         <div>
-                            <h4 style="font-size: 0.875rem;  margin-bottom: 0.5rem">Impact</h4>
+                            <h3 style="font-size: 0.875rem;  margin-bottom: 0.5rem">Impact</h3>
                             <ul style="font-size: 0.875rem; line-height: 1.7;">
                                 <li><strong>281 kilo-tonnes SO₂</strong> released annually (CREA)</li>
                                 <li>FGD systems could cut to 93 kilo-tonnes (67% reduction)</li>
@@ -231,152 +231,152 @@
 
                     <!-- Delhi-NCR -->
                     <div id="legal-state-delhi-ncr" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Delhi-NCR</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Delhi-NCR</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Supreme Court: Clean Air as Fundamental Right</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Supreme Court: Clean Air as Fundamental Right</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court said breathing clean air is your basic right under the Constitution."><strong>MC Mehta v Union of India (1986&ndash;ongoing):</strong> Clean air is a fundamental right under Article 21. This landmark WP (No. 13029/1985) has generated dozens of follow-up orders, including the basis for GRAP.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: 24/7 CAAQMS Operation</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: 24/7 CAAQMS Operation</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal ordered that all government air monitors must run 24 hours a day, 7 days a week."><strong>2024:</strong> Directed CPCB to ensure 24/7 operation of all Continuous Ambient Air Quality Monitoring Stations. Many stations were running at &lt;70% data availability.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">CAQM: First Off-Season GRAP Stage-I</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">CAQM: First Off-Season GRAP Stage-I</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="For the first time, Delhi's emergency pollution rules were turned on in summer, not just winter."><strong>19 May 2026:</strong> First-ever off-season GRAP Stage-I activation at AQI 208. Signals year-round enforcement, breaking the October&ndash;March-only pattern.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Four-Week Deadline on Stubble Burning</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Four-Week Deadline on Stubble Burning</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court told state governments they have 4 weeks to make a plan to stop farmers burning crop waste."><strong>2025:</strong> Supreme Court directed Punjab, Haryana, UP, and Rajasthan to submit stubble-burning action plans within four weeks. Linked non-compliance to contempt proceedings.</p>
                         </div>
                     </div>
 
                     <!-- South India -->
                     <div id="legal-state-south" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">South India (TN / KL / KA / AP / TS / PY)</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">South India (TN / KL / KA / AP / TS / PY)</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Sector-wise PM Reduction Roadmaps</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Sector-wise PM Reduction Roadmaps</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told all 6 southern states to make a plan showing exactly how they will reduce dust and soot pollution, with money set aside for it."><strong>April 2026:</strong> NGT Principal Bench directed all six south-Indian states to file sector-wise PM10/PM2.5 reduction roadmaps tied to state budgets. First order shifting the policy frame beyond the Indo-Gangetic Plain.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Madras HC: Industrial Emissions in Ennore-Manali Belt</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Madras HC: Industrial Emissions in Ennore-Manali Belt</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Madras High Court ordered a check on factories in Chennai's heavily polluted Ennore-Manali area."><strong>2024:</strong> Directed TNPCB to conduct comprehensive stack-emission audits of all industries in the Ennore-Manali industrial belt and report within 90 days.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Karnataka SPCB: Bengaluru Construction Dust Norms</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Karnataka SPCB: Bengaluru Construction Dust Norms</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="Bengaluru's pollution board now requires big construction projects to use water sprinklers and cover sites to control dust."><strong>2025:</strong> Mandatory dust-suppression measures for all construction sites &gt;500 sq.m. following NGT direction. Penalties up to ₹5 lakh for non-compliance.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Kerala HC: Waste-Burning Ban Enforcement</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Kerala HC: Waste-Burning Ban Enforcement</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed all local bodies in Kerala to strictly enforce the open-burning ban under SWM Rules 2016. Fines for non-compliant panchayats.</p>
                         </div>
                     </div>
 
                     <!-- Bihar -->
                     <div id="legal-state-bihar" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Bihar (Patna)</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Bihar (Patna)</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: 10 Additional CAAQMS</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: 10 Additional CAAQMS</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told Bihar to install 10 more air quality monitors by December 2026 because the state has too few."><strong>2025:</strong> Directed Bihar SPCB to install 10 additional Continuous Ambient Air Quality Monitoring Stations by December 2026. Patna had only 2 CAAQMS for a city of 2.5 million.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Patna HC: Brick Kiln Compliance Audit</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Patna HC: Brick Kiln Compliance Audit</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Patna High Court ordered a check on all brick kilns within 60 days to see if they follow pollution rules."><strong>2025:</strong> Ordered Bihar SPCB to complete a compliance audit of all brick kilns in Patna, Gaya, and Muzaffarpur districts within 60 days. Kilns not converted to zigzag technology to be shut.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Patna Waste-Burning Penalty</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Patna Waste-Burning Penalty</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Imposed environmental compensation of ₹25 lakh on Patna Municipal Corporation for failing to prevent open waste burning along the Ganga ghats despite repeated directions.</p>
                         </div>
                     </div>
 
                     <!-- Maharashtra -->
                     <div id="legal-state-maharashtra" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Maharashtra (Mumbai / Pune)</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Maharashtra (Mumbai / Pune)</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Bombay HC: BMC Air Quality Action Plan</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Bombay HC: BMC Air Quality Action Plan</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Bombay High Court told Mumbai's corporation to make a proper plan to reduce air pollution."><strong>2025:</strong> Directed BMC to submit a comprehensive air quality action plan within 12 weeks, covering construction dust, vehicular emissions, and industrial pollution in the Mumbai Metropolitan Region.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Construction Dust Norms for Mumbai Metro</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Construction Dust Norms for Mumbai Metro</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal set strict dust-control rules for Mumbai Metro construction sites after local complaints."><strong>2024:</strong> Directed Mumbai Metro Rail Corporation to install anti-smog guns, wheel-washing systems, and wind barriers at all active construction sites. Environmental compensation of ₹10 lakh imposed for previous violations.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MPCB: Pune Industrial Zone Crackdown</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MPCB: Pune Industrial Zone Crackdown</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Maharashtra Pollution Control Board issued closure notices to 14 units in Chakan-Ranjangaon industrial belt for exceeding PM emission norms. Follow-up to NGT direction.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">NGT: Navi Mumbai Waste Burning</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">NGT: Navi Mumbai Waste Burning</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Imposed ₹15 lakh penalty on Navi Mumbai Municipal Corporation for persistent open-waste burning in Turbhe and Airoli zones despite SWM Rules.</p>
                         </div>
                     </div>
 
                     <!-- Uttar Pradesh -->
                     <div id="legal-state-up" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Uttar Pradesh (Lucknow / Kanpur / Varanasi)</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Uttar Pradesh (Lucknow / Kanpur / Varanasi)</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Allahabad HC: Revive Manual Monitoring Stations</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Allahabad HC: Revive Manual Monitoring Stations</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Allahabad High Court told UP's pollution board to restart manual air monitoring stations that had stopped working."><strong>2025:</strong> Directed UPPCB to revive all non-functional manual air-monitoring stations across the state within 6 months. Out of 72 stations, 28 were found non-operational.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Brick Kiln Compliance for UP Cluster</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Brick Kiln Compliance for UP Cluster</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal set a deadline for brick kilns in UP to switch to cleaner technology or shut down."><strong>2024:</strong> Set a hard deadline for all brick kilns in the Lucknow-Kanpur-Agra cluster to convert to zigzag or vertical shaft technology. Estimated 4,000+ kilns affected.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Varanasi Ghat Cremation Emissions</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Varanasi Ghat Cremation Emissions</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed Varanasi Municipal Corporation and UPPCB to submit a plan for reducing emissions from traditional cremation at Manikarnika and Harishchandra ghats, including promotion of electric cremation facilities.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Kanpur Tannery Pollution</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">SC: Kanpur Tannery Pollution</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>Ongoing:</strong> Follow-up orders on MC Mehta v Union of India (tanneries case). Kanpur tanneries directed to install CETP upgrades. Impacts both water and air (VOC/H₂S emissions).</p>
                         </div>
                     </div>
 
                     <!-- West Bengal -->
                     <div id="legal-state-wb" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">West Bengal (Kolkata / Howrah)</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">West Bengal (Kolkata / Howrah)</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Calcutta HC: Vehicular Emission Checks</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">Calcutta HC: Vehicular Emission Checks</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Calcutta High Court ordered stricter vehicle pollution checks in Kolkata."><strong>2025:</strong> Directed Transport Department to set up 50 additional PUC-checking stations across Kolkata and strengthen impounding of vehicles without valid PUC certificates.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: East Kolkata Industrial Emissions</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: East Kolkata Industrial Emissions</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed WBPCB to conduct emission audits of all industries in the East Kolkata industrial belt (Bantala-Kasba) and submit compliance reports within 90 days.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Howrah Foundry Cluster</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Howrah Foundry Cluster</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Imposed ₹50 lakh environmental compensation on the Howrah foundry cluster for PM10 exceedances. Directed conversion to induction furnaces within 18 months.</p>
                         </div>
                     </div>
 
                     <!-- Punjab & Haryana -->
                     <div id="legal-state-punjab" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Punjab &amp; Haryana</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Punjab &amp; Haryana</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">SC: Stubble-Burning Contempt Warning</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">SC: Stubble-Burning Contempt Warning</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Supreme Court warned Punjab and Haryana that they could face contempt charges if they don't stop farmers from burning crop stubble."><strong>2025:</strong> Supreme Court warned Punjab and Haryana of contempt proceedings for failing to curb paddy-stubble burning. Directed ₹2,500/acre incentive for in-situ management be disbursed before kharif season.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Ludhiana Industrial Cluster</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Ludhiana Industrial Cluster</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2024:</strong> Directed PPCB to submit comprehensive action plan for Ludhiana's dyeing and electroplating units. Over 3,000 small-scale units contributing to both air and water pollution.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Punjab &amp; Haryana HC: Crop Residue Management</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Punjab &amp; Haryana HC: Crop Residue Management</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed state governments to ensure CRM machinery (Happy Seeders, Super SMS) reaches small and marginal farmers. Observed that machines were concentrated with large landholders.</p>
                         </div>
                     </div>
 
                     <!-- MP & Chhattisgarh -->
                     <div id="legal-state-mp" class="legal-state-block" style="display:none;">
-                        <h4 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Madhya Pradesh &amp; Chhattisgarh</h4>
+                        <h3 style="font-size: 0.9375rem; color: var(--green-700); margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Madhya Pradesh &amp; Chhattisgarh</h3>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Singrauli Super-Thermal Power Cluster</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--accent); margin-bottom: 0.25rem;">NGT: Singrauli Super-Thermal Power Cluster</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The Green Tribunal told power plants in Singrauli to install pollution-control equipment and pay fines for the damage they've already caused."><strong>2024:</strong> Directed all thermal power plants in the Singrauli-Sonbhadra cluster to comply with revised emission norms (SO₂, NOx, PM) by March 2026. Cumulative capacity &gt;20 GW makes this one of India's most polluted zones.</p>
                         </div>
                         <div class="info-box mb-2" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MP HC: Bhopal Construction-Dust Controls</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">MP HC: Bhopal Construction-Dust Controls</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed Bhopal Municipal Corporation and MPPCB to enforce mandatory dust-suppression measures at all construction sites &gt;500 sq.m, following a citizens' PIL.</p>
                         </div>
                         <div class="info-box" style="border-left: 3px solid var(--accent);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Korba Industrial Pollution</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">NGT: Korba Industrial Pollution</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);"><strong>2025:</strong> Directed Chhattisgarh SPCB to conduct health-impact assessment around the Korba coal-mining and thermal-power cluster. Residents reported PM10 levels 4&ndash;5&times; NAAQS during winter months.</p>
                         </div>
                     </div>
@@ -392,23 +392,23 @@
                     <p style="font-size: 0.875rem; color: var(--text-2); margin-bottom: 1rem;" data-simple="You have at least five strong laws protecting your right to clean air. Here they are.">Five pillars of law that protect your right to breathe clean air. Know them &mdash; cite them in your complaints.</p>
                     <div class="grid-2" style="gap: 0.75rem;">
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(27,107,74,0.04);">
-                            <h4 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Article 21 &mdash; Constitution of India</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--green-700); margin-bottom: 0.25rem;">Article 21 &mdash; Constitution of India</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="The right to life includes the right to breathe clean air. The Supreme Court has said so repeatedly.">Right to life includes the right to clean air. <em>MC Mehta v UoI (1986), Subhash Kumar v State of Bihar (1991).</em></p>
                         </div>
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(59,130,246,0.04);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Air (Prevention &amp; Control of Pollution) Act, 1981</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Air (Prevention &amp; Control of Pollution) Act, 1981</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="This law created CPCB and state pollution boards. Their job is to prevent and control air pollution.">Established CPCB and State Pollution Control Boards (SPCBs). Mandates them to prevent, control, and abate air pollution. <em>Section 31A:</em> binding closure/direction orders.</p>
                         </div>
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(124,58,237,0.04);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Environment (Protection) Act, 1986</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">Environment (Protection) Act, 1986</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="This law lets the central government shut down any polluting factory and set rules for emissions.">Umbrella legislation. Central government can take measures for environmental protection, set emission standards, and order closure of polluting units. <em>Sections 3 &amp; 5.</em></p>
                         </div>
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(217,119,6,0.04);">
-                            <h4 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">National Green Tribunal Act, 2010</h4>
+                            <h3 style="font-size: 0.8125rem;  margin-bottom: 0.25rem">National Green Tribunal Act, 2010</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="India has a special environmental court (NGT) where any person can file a case. No lawyer needed for individual applications. Filing fee is just 1,000 rupees.">Created a dedicated tribunal for environmental disputes. Any person can file an application. Filing fee: ₹1,000 (waived for BPL). No lawyer required for individual applications.</p>
                         </div>
                         <div class="info-box" style="border-left: 4px solid var(--accent); background: rgba(239,68,68,0.04);">
-                            <h4 style="font-size: 0.8125rem; color: var(--red); margin-bottom: 0.25rem;">Right to Information Act, 2005</h4>
+                            <h3 style="font-size: 0.8125rem; color: var(--red); margin-bottom: 0.25rem;">Right to Information Act, 2005</h3>
                             <p style="font-size: 0.8125rem; color: var(--text-2);" data-simple="You have the right to ask the government for any information about pollution data, funds spent, and enforcement actions &mdash; and they must reply within 30 days.">Right to access government data on pollution monitoring, NCAP funds, enforcement actions. Free for BPL; ₹10 otherwise. 30-day response mandate. <a href="#" onclick="showPanel('rti-assistant'); return false;" style="color: var(--red); font-weight: 600;">Use the RTI Assistant &rarr;</a></p>
                         </div>
                     </div>
@@ -427,7 +427,7 @@
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #15803D; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 1</span>
-                            <h4 style="font-size: 0.9375rem; color: #166534; margin: 0;">File an RTI &mdash; Free, 30-day response guaranteed</h4>
+                            <h3 style="font-size: 0.9375rem; color: #166534; margin: 0;">File an RTI &mdash; Free, 30-day response guaranteed</h3>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Send a letter asking for information. It's free for BPL families, ₹10 for others. The government MUST reply within 30 days.">The simplest and most powerful tool. Any citizen can demand pollution data, budget utilisation details, or enforcement records.</p>
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">
@@ -454,7 +454,7 @@
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #1D4ED8; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 2</span>
-                            <h4 style="font-size: 0.9375rem; color: #1E40AF; margin: 0;">File a Complaint with CPCB</h4>
+                            <h3 style="font-size: 0.9375rem; color: #1E40AF; margin: 0;">File a Complaint with CPCB</h3>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="If you see a factory polluting, waste being burned, or construction dust everywhere, you can complain to CPCB online. Include photos if you can.">Report specific violations &mdash; illegal burning, industrial emissions, construction dust &mdash; directly to CPCB online.</p>
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">
@@ -473,7 +473,7 @@
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #B45309; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 3</span>
-                            <h4 style="font-size: 0.9375rem; color: #92400E; margin: 0;">Write to Your MP / MLA</h4>
+                            <h3 style="font-size: 0.9375rem; color: #92400E; margin: 0;">Write to Your MP / MLA</h3>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Write a letter to your local elected representative. Elected officials care about complaints from voters. Use the template below.">Elected representatives respond to constituent pressure. A well-written letter citing local data is surprisingly effective.</p>
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">
@@ -501,7 +501,7 @@ Yours faithfully,
                     <div class="info-box mb-2" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #6D28D9; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 4</span>
-                            <h4 style="font-size: 0.9375rem; color: #5B21B6; margin: 0;">Approach the National Green Tribunal (NGT)</h4>
+                            <h3 style="font-size: 0.9375rem; color: #5B21B6; margin: 0;">Approach the National Green Tribunal (NGT)</h3>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="Any person can go to the NGT &mdash; India's special environment court. No lawyer needed. It costs just 1,000 rupees (free if you're BPL).">The NGT is a dedicated environmental court. Any individual can file an application &mdash; no lawyer is needed for individual applications.</p>
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">
@@ -521,7 +521,7 @@ Yours faithfully,
                     <div class="info-box" style="border-left: 4px solid var(--accent); padding: 1rem;">
                         <div style="display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem;">
                             <span style="background: #B91C1C; color: white; font-weight: 700; font-size: 0.75rem; padding: 2px 8px; border-radius: 999px;">STEP 5</span>
-                            <h4 style="font-size: 0.9375rem; color: #991B1B; margin: 0;">File a PIL (Public Interest Litigation)</h4>
+                            <h3 style="font-size: 0.9375rem; color: #991B1B; margin: 0;">File a PIL (Public Interest Litigation)</h3>
                         </div>
                         <p style="font-size: 0.8125rem; color: var(--text-2); margin-bottom: 0.5rem;" data-simple="If the problem is big and affects your whole community, you can file a Public Interest Litigation in the High Court or Supreme Court. Any citizen can file one.">For systemic failures affecting a community. Filed in the High Court or Supreme Court. Any citizen can file &mdash; no special locus standi required.</p>
                         <div style="background: var(--bg-section); padding: 0.75rem; border-radius: 8px; font-size: 0.8125rem; margin-bottom: 0.5rem;">

--- a/panels/progress.html
+++ b/panels/progress.html
@@ -34,19 +34,19 @@
 
             <div class="grid-3" style="gap: 1rem; margin-bottom: 1.5rem;">
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--accent); font-size: 0.875rem;">Varanasi</h4>
+                    <h3 style="color: var(--accent); font-size: 0.875rem;">Varanasi</h3>
                     <div style="font-size: 1.5rem; font-weight: 700; color: var(--accent);">76.4%</div>
                     <div style="font-size: 0.75rem; color: var(--text-3);">PM10 reduction (NCAP top performer)</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">84% of particulate pollution here is dust. Massive road paving, mechanised sweeping, and construction site controls have worked. Caveat: PM2.5 from combustion sources remains stubbornly high.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--accent); font-size: 0.875rem;">Bareilly</h4>
+                    <h3 style="color: var(--accent); font-size: 0.875rem;">Bareilly</h3>
                     <div style="font-size: 1.5rem; font-weight: 700; color: var(--accent);">70%+</div>
                     <div style="font-size: 0.75rem; color: var(--text-3);">PM10 reduction (predicted, Lancet SEA 2024)</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">Prophet model forecasting confirms trajectory. Among the strongest performers in UP's non-attainment cities, alongside Raebareli (58%).</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--accent); font-size: 0.875rem;">Moradabad</h4>
+                    <h3 style="color: var(--accent); font-size: 0.875rem;">Moradabad</h3>
                     <div style="font-size: 1.5rem; font-weight: 700; color: var(--accent);">58%</div>
                     <div style="font-size: 0.75rem; color: var(--text-3);">PM10 reduction</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">Brass industry hub that has made real progress. Industrial fuel switching and road improvements contributed. Kanpur (51.2%) and Kolkata (21.5%) also improving.</p>
@@ -54,7 +54,7 @@
             </div>
 
             <div class="info-box" style="background: rgba(27,107,74,0.06); border: 1px solid rgba(27,107,74,0.15); padding: 1rem;">
-                <h4 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">Honest caveat</h4>
+                <h3 style="color: var(--accent); font-size: 0.875rem; margin-bottom: 0.5rem;">Honest caveat</h3>
                 <p style="font-size: 0.8125rem; color: var(--text-2); line-height: 1.7;" data-simple="Be careful with these numbers. The government measures bigger dust particles (PM10), not the tiny ones that really harm your lungs (PM2.5). Reducing dust is easier than reducing smoke from vehicles and factories. Some cities won clean-air awards even though their monitoring machines were broken. Progress is real in some places, but overall India still has a long way to go.">NCAP measures PM10, not PM2.5. The deadlier fine particles from combustion (vehicles, industry, cooking) are harder to reduce than coarse dust. Guttikunda et al.'s 2024 analysis of 2019&ndash;2023 data documented "no change in fraction of cities above 150 µg/m³" for PM10 nationally, and TROPOMI satellite data through the same window showed SO2 and NO2 actually increased. The Plank reported in 2025 that cities like Surat won national clean-air awards while their monitoring stations were non-functional. Progress is real in some places, but the national picture remains mixed.</p>
             </div>
         </div>
@@ -68,7 +68,7 @@
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.25rem;">
                 <div>
-                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Delhi: Largest E-Bus Fleet in India</h4>
+                    <h3 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Delhi: Largest E-Bus Fleet in India</h3>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         <p><strong>4,845 e-buses</strong> operational (latest count, 9 Jul 2026, after 300 more were added &mdash; <a href="https://www.electrive.com/2026/07/09/india-delhi-adds-300-electric-buses-to-its-public-transport-fleet/" target="_blank" rel="noopener">electrive</a>); India's largest fleet, having overtaken Maharashtra's 4,001 in Feb 2026, when CM Rekha Gupta flagged off 500 new buses at Ramlila Maidan.</p>
                         <p style="margin-top: 0.5rem;"><strong>Targets:</strong> 7,500 by end 2026, 14,000 by 2028. Delhi-Panipat interstate e-bus route launched. <em>Mid-year (Q2/Q3 2026) public count expected.</em></p>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
                 <div>
-                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">National E-Bus Landscape</h4>
+                    <h3 style="font-size: 0.9375rem; margin-bottom: 0.75rem">National E-Bus Landscape</h3>
                     <div style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         <p><strong>PM-eBus Sewa:</strong> $2.4 billion scheme for 10,000 e-buses across 169 cities by 2026 (WRI India). Half of eligible cities currently lack any organised bus transport.</p>
                         <p style="margin-top: 0.5rem;"><strong>State leaderboard:</strong> Delhi (4,845, Jul 2026), Maharashtra (4,001), Karnataka (1,989), Gujarat (1,041), Telangana (875), UP (874).</p>
@@ -88,7 +88,7 @@
             </div>
 
             <div class="info-box" style="border-left: 3px solid var(--accent);">
-                <h4 style="font-size: 0.8125rem">Citizen-led "Double the Bus" campaigns</h4>
+                <h3 style="font-size: 0.8125rem">Citizen-led "Double the Bus" campaigns</h3>
                 <p style="font-size: 0.8125rem; color: var(--text-2);">In Mumbai, Pune, and Nagpur, citizen groups have pressured municipal budgets to prioritise bus fleet expansion over new flyovers. Policy Circle documented the campaign in September 2025: an example of how informed citizens can redirect infrastructure spending toward public health outcomes.</p>
             </div>
         </div>
@@ -101,7 +101,7 @@
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.5rem;">
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">CAQM 27th Full Commission Meeting</h4>
+                    <h3 style="font-size: 0.875rem">CAQM 27th Full Commission Meeting</h3>
                     <div style="font-size: 0.75rem; color: var(--text-3);">Feb 20, 2026 (PIB)</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         33 domain experts submitted a meta-analysis of source apportionment studies (2015-2025) to the Supreme Court. Key finding: PM2.5 identified as the dominant pollutant in Delhi's AQI, with secondary particulates (27%), transport (23%), and biomass burning (20%) as top contributors. This is significant because it shifts official focus from PM10 (easier to show improvement) toward PM2.5 (what actually kills people).
@@ -112,7 +112,7 @@
                 </div>
 
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="font-size: 0.875rem">Year-Round Action Plans (2026)</h4>
+                    <h3 style="font-size: 0.875rem">Year-Round Action Plans (2026)</h3>
                     <div style="font-size: 0.75rem; color: var(--text-3);">CAQM / DPCC, Feb 2026</div>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         For the first time, CAQM and DPCC have shifted from winter-emergency-only response to a year-round pollution mitigation framework. Twelve NCR cities submitted detailed action plans in Feb 2026. Delhi targets a 15% AQI reduction and PM2.5 reduction from 99 to 96 µg/m³.
@@ -125,14 +125,14 @@
 
             <div class="grid-2" style="gap: 1.25rem; margin-bottom: 1.5rem;">
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--accent); font-size: 0.875rem;">Public Participation Precedent</h4>
+                    <h3 style="color: var(--accent); font-size: 0.875rem;">Public Participation Precedent</h3>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         A 2023 study published in PMC analysed CAQM's Supreme Court-mandated open public comment process and documented that it actually influenced policy. 115 public and expert comments were compiled via RTI. Recurring themes (green transport, cycling, alternative fuels, crop burning) were incorporated into CAQM policy. This sets a precedent: democratic, stakeholder-driven air quality governance works when mandated.
                     </p>
                 </div>
 
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
-                    <h4 style="color: var(--accent); font-size: 0.875rem;">Industrial Compliance Wins</h4>
+                    <h3 style="color: var(--accent); font-size: 0.875rem;">Industrial Compliance Wins</h3>
                     <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                         Gujarat's common boiler policy and Odisha's investment in Continuous Emission Monitoring Systems (CEMS) are cited by CSE as models for state-level industrial emission control. Indore achieved zero-landfill status. Pune integrated informal waste workers into collection systems. Hyderabad's decentralised C&amp;D waste management through PPP plants is being studied for replication.
                     </p>
@@ -140,7 +140,7 @@
             </div>
 
             <div class="info-box" style="border-left: 3px solid var(--accent);">
-                <h4 style="color: var(--accent); font-size: 0.875rem;">BS-VI: The Quiet Revolution</h4>
+                <h3 style="color: var(--accent); font-size: 0.875rem;">BS-VI: The Quiet Revolution</h3>
                 <p style="font-size: 0.8125rem; color: var(--text-2); margin-top: 0.5rem;">
                     India skipped BS-V and leapfrogged directly to BS-VI emission standards in April 2020, equivalent to Euro 6. This was one of the most ambitious vehicle emission standard upgrades globally. Combined with Delhi's "No PUC, No Fuel" policy (PUC issuance jumped 46% in a single day when real-time checks began) and fuel denial for diesel vehicles over 10 years and petrol vehicles over 15 years (from July 2025), transport emissions per vehicle are declining even as the fleet grows.
                 </p>
@@ -154,13 +154,13 @@
         <div class="card-body">
             <div class="grid-2" style="gap: 1.25rem;">
                 <div>
-                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Warrior Moms / Clean Air Fund</h4>
+                    <h3 style="font-size: 0.9375rem; margin-bottom: 0.75rem">Warrior Moms / Clean Air Fund</h3>
                     <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         The "Mera Planet Mera Ghar" campaign trained 1,600 children in Delhi to voice environmental concerns, reaching 6 million citizens. Warrior Moms has become one of India's most effective air quality advocacy networks, successfully pushing for school air purifier commitments in Delhi and air quality audits in schools.
                     </p>
                 </div>
                 <div>
-                    <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">RTI as Accountability Tool</h4>
+                    <h3 style="font-size: 0.9375rem; margin-bottom: 0.75rem">RTI as Accountability Tool</h3>
                     <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                         Citizen RTI applications have forced disclosure of NCAP fund utilisation data, CAQM inspection records, and public comment responses. The PMC study confirming CAQM incorporated public feedback was itself enabled by an RTI application. This right is arguably the single most powerful tool citizens have for clean air accountability.
                     </p>
@@ -168,7 +168,7 @@
             </div>
 
             <div style="margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid var(--border);">
-                <h4 style="font-size: 0.9375rem; margin-bottom: 0.75rem">COVID Lockdown: The Accidental Proof</h4>
+                <h3 style="font-size: 0.9375rem; margin-bottom: 0.75rem">COVID Lockdown: The Accidental Proof</h3>
                 <p style="font-size: 0.875rem; line-height: 1.8; color: var(--text-2);">
                     April 2020 remains the most powerful data point in India's clean air story. PM2.5 dropped by over 50%. Blue skies were visible in Delhi for weeks. The Himalayas became visible from Punjab plains for the first time in decades. This was not a policy achievement, but it proved something essential: India's air pollution is entirely man-made and entirely reversible. That knowledge fuels every citizen campaign, every RTI filing, every "Double the Bus" rally. The question was never whether clean air is possible. It is whether there is political will.
                 </p>
@@ -185,15 +185,15 @@
             </p>
             <div class="grid-3" style="gap: 1rem;">
                 <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                    <h5 style="color: var(--accent); font-size: 0.8125rem;">For advocacy</h5>
+                    <h4 style="color: var(--accent); font-size: 0.8125rem;">For advocacy</h4>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Use Varanasi and Bareilly as proof that NCAP targets are achievable. Ask your city why it hasn't matched them.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                    <h5 style="font-size: 0.8125rem">For policy</h5>
+                    <h4 style="font-size: 0.8125rem">For policy</h4>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Cite the CAQM public participation precedent in your submissions. File RTIs on your city's NCAP fund utilisation.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent); padding: 0.75rem;">
-                    <h5 style="font-size: 0.8125rem">For journalism</h5>
+                    <h4 style="font-size: 0.8125rem">For journalism</h4>
                     <p style="font-size: 0.75rem; color: var(--text-2);">Compare e-bus deployment pace across states. Ask why some cities achieve 70% reductions while others worsen.</p>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -2287,7 +2287,7 @@ html.reveal-on [data-reveal].is-in { opacity: 1; transform: none; }
 [data-theme="dark"] .role-action-card-icon {
     background: rgba(22, 163, 74, 0.12);
 }
-.role-action-card h4 {
+.role-action-card h3, .role-action-card h4 {
     font-family: var(--sans); font-size: 0.9rem; font-weight: 600;
     color: var(--text); margin-bottom: 0.25rem;
 }
@@ -2766,3 +2766,26 @@ body {
 .city-combo-opt:hover, .city-combo-opt.active { background: var(--bg-section); }
 .city-combo-opt.active { outline: 1px solid var(--accent); }
 .city-combo-empty { padding: 7px 10px; font-size: 0.85rem; color: var(--text-3); }
+
+/* ── Responsive tables → stacked labeled cards on small screens ─────────── */
+@media (max-width: 640px) {
+    .responsive-cards, .responsive-cards tbody, .responsive-cards tr, .responsive-cards td {
+        display: block; width: 100%; box-sizing: border-box;
+    }
+    .responsive-cards { min-width: 0 !important; }
+    /* Keep the header row in the DOM for assistive tech, hidden visually. */
+    .responsive-cards thead { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+    .responsive-cards tr { margin-bottom: 0.75rem; border: 1px solid var(--border); border-radius: 8px; padding: 0.5rem 0.85rem; background: var(--bg-card); }
+    /* Label above value, each on its own line — wraps naturally, never overflows. */
+    .responsive-cards td {
+        text-align: left; padding: 0.4rem 0; border: none; border-bottom: 1px solid var(--border);
+        font-size: 0.85rem; overflow-wrap: anywhere;
+    }
+    .responsive-cards td:last-child { border-bottom: none; }
+    .responsive-cards td::before {
+        content: attr(data-label); display: block;
+        font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+        color: var(--text-3); margin-bottom: 0.15rem;
+    }
+    .responsive-cards td[data-label=""]::before { content: ""; margin: 0; }
+}

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606107';
+const CACHE_VERSION = 'janvayu-202606108';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606107',
-  '/app.js?v=202606107',
+  '/styles.css?v=202606108',
+  '/app.js?v=202606108',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606108';
+const CACHE_VERSION = 'janvayu-202606109';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606108',
-  '/app.js?v=202606108',
+  '/styles.css?v=202606109',
+  '/app.js?v=202606109',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/walkthrough/deck.html
+++ b/walkthrough/deck.html
@@ -35,6 +35,33 @@
   .slide.prev { transform:translateX(-40px) scale(.98); }
   @media (prefers-reduced-motion: reduce){ .slide{ transition:opacity .2s; transform:none;} .slide.prev{transform:none;} }
 
+  /* ── Mobile / portrait: drop the fixed 16:9 box; let the active slide fill
+       the width and flow vertically so nothing overlaps. One slide at a time. */
+  @media (max-width: 820px), (orientation: portrait) {
+    html, body { overflow-y: auto; }
+    .stage { position: static; display: block; min-height: 100vh; padding: 54px 12px 96px; }
+    .slide {
+      position: relative; width: 100%; max-width: 640px; margin: 0 auto;
+      aspect-ratio: auto; min-height: calc(100vh - 170px);
+      padding: 26px 22px; overflow: visible;
+      opacity: 0; transform: none; pointer-events: none; display: none;
+    }
+    .slide.active { display: flex; opacity: 1; pointer-events: auto; }
+    .slide.prev { transform: none; }
+    h1.title { font-size: clamp(2rem, 9vw, 3rem); }
+    h2.head { font-size: clamp(1.55rem, 6.6vw, 2.1rem); }
+    .sub { font-size: 1.05rem; max-width: none; }
+    .body, .figrow { flex-direction: column; align-items: stretch; gap: 18px; flex: none; margin-top: 1em; }
+    .col { flex: none; min-width: 0; }
+    ul.points li { font-size: 1rem; }
+    .stats { grid-template-columns: 1fr; gap: 16px; flex: none; }
+    .stat { text-align: left; }
+    .stat .n { font-size: 2.4rem; }
+    .dgm { min-height: 0; }
+    .dgm svg { width: 100%; height: auto; max-height: 52vh; }
+    .slide-note { position: static; margin-top: 18px; }
+  }
+
   /* Slide interior */
   .eyebrow { font-size:clamp(.7rem,1.1vw,.85rem); font-weight:700; letter-spacing:.12em; text-transform:uppercase; color:var(--accent); display:flex; align-items:center; gap:10px; }
   .eyebrow::before { content:''; width:26px; height:3px; background:var(--accent); border-radius:2px; }


### PR DESCRIPTION
Three accessibility / mobile fixes.

## 1. Walkthrough deck — broken portrait layout (fix)
On a portrait phone the slide's `min(96vw, 96vh·16/9)` sizing collapsed each 16:9 slide into a **~375×210px box** far too small for its content, so the title, bullets and second column **overflowed and overlapped** — unreadable (you spotted this). Added a mobile/portrait media query that drops the fixed aspect ratio: the active slide now **fills the width and flows vertically** (two-column `.body` stacks, stats go single-column, diagrams scale to fit), one slide at a time, page scrolls if a slide is tall.
*Verified at 390×844: slides fill the width, no overlap, no horizontal overflow, nav intact.*

## 2. Heading-order sweep
Panels jumped `h2` → `h4` (skipping `h3`). Shifted headings up one level across the 7 affected panels + homepage blocks + role-dashboard cards (appearance preserved via inline `font-size`). **0 heading-order skips site-wide** (was ~30).

## 3. Mobile tables → cards (issue #33)
15 data tables stack into **labeled cards below 640px** (`data-label` pattern; `<thead>` kept for assistive tech; desktop keeps real tables). Label-above-value layout, no horizontal overflow. Two complex tables left as scroll.

## Verification (Playwright)
- Deck 390×844: no overlap/overflow ✓
- Tables 390px: labeled cards, no overflow ✓; 1280px: real tables ✓
- 0 heading skips (static scan) ✓ · 0 page errors ✓

Version **26.6.109**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)