### PR TITLE
Weekly fact-check (20 Jul 2026): stats.json display bugs + stale-figure sync

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ keywords:
   - health
   - open-data
 
-date-released: "2026-07-18"
-version: "26.6.122"
+date-released: "2026-07-20"
+version: "26.6.123"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This is not a campaign. It is a record.
 | Annual PM2.5 Deaths | 1.72 million | Lancet Countdown 2025 |
 | Economic Cost | $339.4 billion (9.5% GDP) | Lancet Countdown 2025 |
 | India's Global Share | World's largest national PM2.5 death toll (~a quarter of the global total) | Lancet Countdown 2025 |
-| Most Polluted Capital | New Delhi (91.6 µg/m³) | IQAir 2025 |
+| Most Polluted Capital | New Delhi (82.2 µg/m³, 8th straight year worst) | IQAir 2025 |
 | Most Polluted City | Loni, India (112.5 µg/m³) | IQAir 2025 |
 | Cities Meeting WHO Guideline | Only 14% globally | IQAir 2025 |
 | India Average PM2.5 | 48.9 µg/m³ (~10× WHO limit) | IQAir 2025 |

--- a/app.js
+++ b/app.js
@@ -2201,7 +2201,7 @@
 
             const ncapCtx = document.getElementById('ncapChart');
             if (ncapCtx) {
-                charts.ncap = new Chart(ncapCtx, { type: 'bar', data: { labels: ['Delhi', 'Mumbai', 'Noida', 'Ghaziabad', 'Lucknow', 'Patna'], datasets: [{ label: 'Allocated (₹ Cr)', data: [81, 380, 56, 49, 180, 120], backgroundColor: '#3B82F6' }, { label: 'Utilized (₹ Cr)', data: [14, 220, 7, 13, 72, 84], backgroundColor: '#22C55E' }] }, options: { responsive: true, maintainAspectRatio: false, plugins: { title: { display: true, text: 'NCAP Fund Utilization (CREA Jan 2026)', font: { size: 11 } } }, scales: { y: { grid: { color: gridColor } } } } });
+                charts.ncap = new Chart(ncapCtx, { type: 'bar', data: { labels: ['Delhi', 'Noida', 'Ghaziabad'], datasets: [{ label: 'Allocated (₹ Cr)', data: [81.36, 127, 48.5], backgroundColor: '#3B82F6' }, { label: 'Utilized (₹ Cr)', data: [14.1, 30, 39], backgroundColor: '#22C55E' }] }, options: { responsive: true, maintainAspectRatio: false, plugins: { title: { display: true, text: 'NCAP Fund Utilization (city-level, 2025-26)', font: { size: 11 } } }, scales: { y: { grid: { color: gridColor } } } } });
             }
 
             // BUDGET TRACKER CHARTS

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606122-v122';
+const CACHE_NAME = 'ask-janvayu-202606123-v123';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/docs/fact-check-2026-07-20.md
+++ b/docs/fact-check-2026-07-20.md
@@ -1,0 +1,107 @@
+# Weekly fact-check — 20 July 2026
+
+**Method:** Multi-agent sweep. Scope this run: `scripts/stats.json` (never previously audited — flagged CRITICAL, since its values override HTML `[data-stat]` elements at runtime), the README "Key Statistics" table (never previously audited), and every file newly added or substantially rewritten since the last round (`docs/fact-check-2026-07c.md`, 17 Jul 2026): `index.html`'s new accountability content, `panels/accountability.html` (rewritten — new promises tracker + interventions table), `panels/budget.html` (NCAP city rows + CRM figures), `netlify/functions/lib/calc.mjs`, and five new blog posts. `panels/economic.html`, `panels/aqi-explainer.html` (heading-level a11y fix only) and `panels/source-selector.html` were unchanged since the 17 Jul round and were not re-audited. 8 parallel research agents web-verified the extracted claims against current primary sources (IQAir, CREA, ResGov, PIB, EPIC, CAQM, Lancet Planetary Health).
+
+## Summary
+
+**~45 statistics/claims checked. ~20 confirmed current. 17 corrected. 2 rows removed (no credible source). 4 flagged, unresolved.**
+
+The most consequential finding: a **live display bug** in `scripts/stats.json` — the exact failure mode this routine exists to catch, since JSON values silently override the HTML at runtime. Also found: a Chart.js dataset in `app.js` still serving five stale/fabricated per-city NCAP figures that had already been corrected in the `budget.html` panel weeks ago but never synced to the chart, and the same gap in the live Ask JanVayu system prompt (`netlify/functions/air-query.mjs`), which is even higher-blast-radius than a static page since every chatbot answer citing station counts was serving a stale figure.
+
+## Corrected (applied, with source)
+
+### scripts/stats.json — display bugs (CRITICAL scope)
+
+- **`most_polluted_city` schema mismatch broke the homepage card.** The JSON had `{"value": "Loni", "pm25": "112.5", ...}`, but the injector script only reads `entry.value` + `entry.unit` — it ignores `pm25`. At runtime this overwrote the "Did You Know" card's `112.5 µg/m³` (the actual number the label needs) with the bare word `"Loni"`, directly under a label that already says "Loni, India — the world's most polluted city." Net effect: live homepage silently lost its headline number.
+  `{"value": "Loni", "pm25": "112.5"}` → `{"value": "112.5", "unit": "µg/m³", "note": "Loni, India"}`
+  *Source:* IQAir World Air Quality Report 2025 (pub. 24 Mar 2026) — Loni 112.5 µg/m³, most polluted city.
+- **`economic_pct_gdp` was stripping its own citation on override.** JSON value `"9.5%"` replaced the HTML's `"9.5% GDP (Lancet)"`, silently dropping the unit and source label from the live hero card.
+  `"9.5%"` → `"9.5% GDP (Lancet)"`
+  *Source:* Lancet Countdown on Health and Climate Change 2025, India data sheet.
+- **`india_avg_pm25.updated` had a year typo** ("2025-03" for a report published March **2026**), understating the data's actual vintage by a year.
+  `"2025-03"` → `"2026-03"`
+- **`cpcb_stations` was stale** — "~533" (undated "CPCB Annual Report") vs. the current CAAQMS network of ~565 stations (2025 data). Network has grown steadily (409 in 2022 → 423 in Feb 2023 → 558 in 2024 → 565 in 2025); the exact live count fluctuates ±10-20 depending on snapshot date, so this is stated as approximate.
+  `"~533"` → `"~565"`
+  *Source:* CPCB data via CREA "Tracing the Hazy Air 2026" (Jan 2026).
+- **Added a missing `delhi_annual_pm25` entry.** This key didn't exist in the JSON at all, so the homepage hero's hardcoded HTML value ("96") was never being kept current by anything — see the Delhi PM2.5 fix below, which this entry now enforces site-wide going forward.
+
+### The Delhi PM2.5 number — three different values on one site
+
+The homepage hero, the README, and old internal notes each carried a **different** figure for Delhi's annual PM2.5: 96, 91.6, ~82, and ~99.6 all appeared somewhere. None was correct for the current report. Verified against IQAir's press release for the report covering full-year 2025 data (published 24 Mar 2026): **Delhi's annual average is 82.2 µg/m³** (a three-year low, though still ~16× the WHO guideline, not 19×), and this is New Delhi's **8th consecutive year** as the world's most polluted capital.
+- `index.html` hero stat: `96` (note: "19x WHO (2025 avg)") → `82.2` (note: "16x WHO (IQAir 2025)")
+- `scripts/stats.json`: added `delhi_annual_pm25` = 82.2 µg/m³ so the hero card is enforced from a single source going forward
+- `README.md`: `New Delhi (91.6 µg/m³)` → `New Delhi (82.2 µg/m³, 8th straight year worst)`
+- *Source:* IQAir, 8th annual World Air Quality Report, iqair.com/newsroom/waqr-2025-pr (24 Mar 2026), covering calendar-2025 data. Corroborated by delhipollution.in and thedailyjagran.com.
+
+### index.html hero — source misattribution
+
+- **`deaths_annual` hero note said "State of Global Air 2025"** next to the value `1.72M` — but 1.72M is the **Lancet Countdown** figure (ambient PM2.5 only); State of Global Air's figure for India (total, incl. household air pollution) is ~2.1M. This conflated the platform's own two-source standing policy on a single card.
+  `State of Global Air 2025` → `Lancet Countdown 2025`
+
+### index.html — NCAP city-level figures never synced from earlier corrections
+
+These are figures that a prior fact-check round already corrected in `panels/budget.html`, but the same numbers, hardcoded separately in `index.html`'s per-city action tables, were never updated:
+- **15th Finance Commission grant scope, 2 occurrences**: `₹16,539 Cr for 49 cities` → `₹16,539 Cr for 42 million-plus cities` (matches the figure `budget.html` already carries; "49 cities" was a different, smaller XV-FC grouping).
+  *Source:* PIB/MoEFCC PRID 2002614.
+- **Mumbai NCAP row**: `₹380 Cr allocated / ₹220 Cr utilised (58%)`, cited to "CREA NCAP Analysis" → `15th FC: ₹620 Cr released, ~94% utilised; plus ₹95.5 Cr MoEFCC direct funds, 100% utilised`, re-attributed to BMC data via Free Press Journal (14 Feb 2025). The 58% figure was wrong; Mumbai is actually one of the highest utilizers.
+- **Patna NCAP row**: `₹120 Cr allocated / ₹84 Cr utilised (70%)`, cited to "CREA NCAP Analysis" → `₹298.60 Cr received / ₹194.26 Cr utilised (~65%)`, re-attributed to the Bihar government's own NGT filing (OA 687/2023) — the only credible per-city source located.
+- **Lucknow NCAP row removed**: `₹180 Cr allocated / ₹72 Cr utilised (40%)`, cited to "CREA NCAP Analysis" — no CREA report (2025 or 2026 edition) publishes this figure, and no other credible source was located. `budget.html` had already removed its equivalent row for the same reason weeks ago; `index.html` still carried it. Removed rather than invented, per standing policy.
+
+### app.js — Chart.js dataset never synced from panel corrections
+
+The homepage's "NCAP Fund Utilization" bar chart (`ncapChart`) held its own hardcoded data array, independent of the `budget.html` panel table. It still served the **pre-correction** numbers for every city except Delhi — Mumbai (₹380/₹220, 58% — wrong), Ghaziabad (₹49/₹13, ~26% — the exact wrong figure debunked in the first fact-check round), Noida (₹56/₹7, 13% — stale), Lucknow (₹180/₹72, 40% — unsourced) — misattributed in the chart title to "CREA Jan 2026" (CREA does not publish per-city ₹ Cr figures for any of these cities; confirmed by full-text search of both the 2025 and 2026 editions).
+Chart updated to the three cities with a verifiable current per-city source (Delhi, Noida, Ghaziabad — matching `budget.html`'s NCAP table below), title changed to avoid the false CREA attribution.
+
+### netlify/functions/air-query.mjs — the Ask JanVayu chatbot was citing a stale CAAQMS count
+
+Six places in the live chatbot's system prompt / data-context builder cited "~533 CAAQMS stations" as the CPCB reference figure — every chatbot answer discussing India's monitoring network was serving this stale number. Updated to ~565 (see `stats.json` fix above) with source. The paired "~250 cities" companion figure could not be independently verified this round (see Flagged, below) and was left unchanged rather than guessed.
+
+### panels/budget.html — NCAP per-city rows
+
+- **Noida row updated to the newest sourced figure.** `₹55.70 Cr allocated / ₹7.07 Cr utilised (13%)`, cited to "Outlook Business (Sep 2025)" → `₹127.00 Cr allocated / ₹30.00 Cr utilised (24%)`. The old figure was itself real (Sep 2025 committee data, though labelled "released" not "allocated" by its own source) but is superseded by a more current, more precisely sourced figure.
+  *Source:* Foundation for Responsive Governance (ResGov), "Financing Clean Air" Noida City Brief 3 (4 Jan 2026).
+- **Delhi and Ghaziabad source attribution fixed** (numbers unchanged, already correct): Delhi's ₹81.36/₹14.10/17% was cited to "Outlook Business (Sep 2025)" but does not match any Sep-2025 Outlook Business piece — it matches ResGov's Delhi City Brief 4 (23 Dec 2025) almost exactly. Ghaziabad's >80% was cited to "CREA 'Tracing the Hazy Air 2026'" but CREA's report contains no Ghaziabad fund-utilisation figure anywhere (confirmed by full-text search); the real source is a Jan 2026 Lok Sabha reply. Footer citations corrected; card values unchanged since they were already numerically right.
+- **75% utilisation rule note re-dated.** The card's "75% Rule (Sep 2025)" is a real policy, but CREA's report documents the **2024** version of this rule (Sep 2024 Apex Committee), not a Sep 2025 CREA finding — the Sep 2025 reiteration comes from the NCAP Implementation/Monitoring Committee via Business Standard/Outlook Business, not CREA. Attribution corrected; the rule itself (cities below 75% utilisation risk losing FY2025-26 allocation) is confirmed current.
+- **Crop Residue Management total updated**: `₹3,623 Cr` (Nov 2024 snapshot) → `₹4,266 Cr`, current as of the most recent official update. This is the fourth successive snapshot of the same metric (₹3,062 Cr → ₹3,623 Cr → ₹3,926.16 Cr → ₹4,266.47 Cr as the scheme adds fresh annual tranches); each was accurate on its date, only the newest is current today. The card date range updated 2018-2025 → 2018-2026.
+  *Source:* PIB / Ministry of Agriculture & Farmers Welfare, Inter-Ministerial CRM review, 17 Jun 2026 (now also includes Madhya Pradesh).
+  *Note:* the card's Punjab/Haryana/UP state-wise sub-breakdown (46%/30%/21%) is the older Nov 2024 snapshot and does not sum to the new total or include Madhya Pradesh — flagged inline on the card itself ("older snapshot — pending refresh") rather than inventing a new split; see Flagged below.
+
+### panels/accountability.html
+
+- **Odd-even scheme, 2 occurrences.** EPIC's actual 8am–8pm scheme-hours estimate is 14–16% (the site's "~13%" conflates a different full-24-hour/two-week-period estimate with the scheme-hours one).
+  `~13%` → `~14-16%` (promises tracker row + interventions table verification cell)
+  *Source:* EPIC/UChicago, Harish, Sudarshan, Greenstone, Pande, "Clearing the air on Delhi's odd-even program."
+- **Zigzag brick-kiln adoption, date-stamped.** The 45% (UP) / 71% (Haryana-NCR) figures are real and traceable, but date to a February 2021 CPCB/NGT-committee count, not current 2024-2026 data — no updated statewide figure could be located. Added an inline "(2021 data)" qualifier rather than silently implying currency.
+- **National "30% Compliance" zigzag figure — unsourced, replaced.** No CPCB/SPCB/CREA report states a national 30% compliance rate; state data is too heterogeneous to average cleanly to 30% (Bihar ~82-85%, Haryana-NCR ~71%, UP ~45%, some districts much lower). Replaced the invented-looking single number with a defensible qualitative framing drawn from the site's own already-cited state figures.
+  `30% Compliance` → `Uneven, 45-85% by State`
+- **Delhi Metro Phase 4 timeline — wrong.** "First sections opened Jan-Mar 2026" compressed two separate, year-apart events: the actual first section (Janakpuri West–Krishna Park Extension) opened **January 2025**, a full year earlier than stated; two more sections opened together on 8 March 2026.
+  `first sections opened Jan-Mar 2026` → `first section opened Jan 2025, two more Mar 2026`
+  *Source:* Metro Rail News, Outlook Traveller (Mar 2026 inauguration coverage); Wikipedia (Jan 2025 opening).
+- **Crop Residue Management figure** (promises-tracker verification cell) updated in step with the `budget.html` fix above: `₹3,062 Cr allocated (2018-24)` → `₹4,266 Cr released (2018-19 to 2026-27, PIB Jun 2026)`. The old figure additionally mislabeled "released" funds as "allocated" and had the wrong end-year (2018-24 vs. the source's actual 2018-19–2022-23 coverage).
+
+## Confirmed current (no change)
+
+- **Jaganathan et al. 2024 mortality coefficient** (`calc.mjs`): 8.6% (95% CI 6.4–10.8) excess all-cause mortality per +10 µg/m³ PM2.5 — exact match to the published paper (Lancet Planetary Health, Dec 2024).
+- **GRAP thresholds and school-closure rules** (`calc.mjs`): Stage I–IV AQI bands and the Class V / Class VI-IX+XI hybrid-mode provisions match the CAQM schedule's most recent revision (21.11.2025), confirmed still in force via a May 2026 Stage-I invocation under the same text.
+- **BS-VI sulphur reduction** (50→10 ppm, 80%, April 2020) — confirmed against PIB and IOCL sources.
+- **FAME I (₹895 Cr), FAME II (₹11,500 Cr), PM E-DRIVE (₹10,900 Cr)** outlays — all confirmed against PIB/Ministry of Heavy Industries releases. (PM E-DRIVE's tenure was separately extended to 2028, but its ₹10,900 Cr outlay is unchanged.)
+- **Delhi Metro Phase 4 scale**: ~112 km sanctioned, ~25 km operational — both confirmed (only the *opening date* was wrong, fixed above).
+- **NCAP non-attainment city count, 131** — confirmed as CPCB's own current official figure, though CREA's own reports have carried "130" across three consecutive editions without explanation; no source documents an actual removal of a city from the list, so 131 (the government's own list) is treated as current. Flagged below for future monitoring.
+- Berkeley Earth cigarette-equivalence (22 µg/m³·day ≈ 1 cigarette), AQLI life-expectancy coefficient (-0.98 yr per 10 µg/m³ above WHO), and the transport-exposure multipliers in `calc.mjs` — unchanged since the last verification round, no new evidence found to revise them.
+- `panels/economic.html`, `panels/source-selector.html` — unchanged since the 17 Jul round; still current per that round's verification.
+- The five new blog posts published 17–18 Jul 2026 are meta/product posts (about the fact-check process itself, the mascot, contributing, and a shipped-features roundup) with no new external checkable statistics.
+
+## Flagged for review (unresolved — need a human call)
+
+1. **CPCB CAAQMS "~250 cities" companion figure.** The station count (~565) was updated, but the paired city-coverage figure could not be independently verified this round — secondary sources mix the CAAQMS-only network with the larger combined CAAQMS+manual-NAMP total (1,600 stations / 584 cities), which is a different, larger metric. Recommend a dedicated check against CPCB's live monitoring-network page (returned HTTP 503 to non-Indian-origin requests during this round).
+2. **`budget.html`'s aggregate NCAP chart** (`budgetNcapChart` in `app.js`): MoEFCC Direct ₹1,615 Cr + XV-FC ₹11,800 Cr = Total ₹13,415 Cr. A prior round (17 Jul) found the XV-FC component should be ~₹11,021 Cr per Mongabay's coverage of CREA's report, but 1,615 + 11,021 ≠ 13,415 — the arithmetic doesn't reconcile against either the old or the suggested figure. Not touched this round; needs a fresh read of the CREA report's exact fund-release table before editing.
+3. **Crop Residue Management state-wise breakdown** (Punjab 46% / Haryana 30% / UP 21%, `budget.html`) is a Nov 2024 snapshot that doesn't sum to the newly-updated ₹4,266 Cr total and predates Madhya Pradesh's inclusion. Flagged inline on the card; no updated per-state split was located this round.
+4. **`accountability.html` interventions table**: "90/130 Studies Done (CREA 2026)" (real-time source apportionment) and "28/130 Cities Still No CAAQMS (2026)" were not part of this round's research scope and have not been independently verified — carried over unverified, not confirmed current.
+
+## Files checked, no issues found requiring changes
+
+`netlify/functions/lib/calc.mjs` (all constants current), `panels/economic.html`, `panels/aqi-explainer.html` (only an h4→h3 accessibility fix, no content change), `panels/source-selector.html`, `panels/resources.html`, `panels/voices.html`, `panels/faq.html`, `panels/progress.html` (all last verified 17 Jul, unchanged since), five blog posts published 17–18 Jul 2026.
+
+---
+
+*Prior rounds this month: [`fact-check-2026-07.md`](./fact-check-2026-07.md) (site-wide baseline sweep, 33 corrections), [`fact-check-2026-07b.md`](./fact-check-2026-07b.md) (round 2, 34 applied), [`fact-check-2026-07c.md`](./fact-check-2026-07c.md) (content sweep of previously-unchecked panels/posts, 18 applied/resolved). This round closes the gap those left open: the data files that inject values at runtime (`scripts/stats.json`, the live Ask JanVayu prompt data in `netlify/functions/air-query.mjs`), the README, and a Chart.js dataset in `app.js` that had drifted out of sync with already-corrected panel content.*

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     <link rel="preload" href="/fonts/fraunces-700.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/kalam-400.woff2" as="font" type="font/woff2" crossorigin>
     <!-- Discover the main stylesheet early (its <link> sits deeper in <head>). -->
-    <link rel="preload" as="style" href="/styles.css?v=202606122">
+    <link rel="preload" as="style" href="/styles.css?v=202606123">
     <!-- Google Fonts (DM Sans body, Newsreader, JetBrains Mono) loaded non-render-blocking:
          with font-display:swap and the system-ui fallback in --sans, text paints
          immediately and swaps in seamlessly, so this no longer gates first paint. -->
@@ -1409,7 +1409,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                         <div class="hero-stat">
                             <div class="hero-stat-value danger" data-stat="deaths_annual">1.72M</div>
                             <div class="hero-stat-label">Deaths/Year (India)</div>
-                            <div class="hero-stat-note">State of Global Air 2025</div>
+                            <div class="hero-stat-note">Lancet Countdown 2025</div>
                         </div>
                         <div class="hero-stat">
                             <div class="hero-stat-value" data-stat="economic_cost">$339.4B</div>
@@ -1417,9 +1417,9 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                             <div class="hero-stat-note" data-stat="economic_pct_gdp">9.5% GDP (Lancet)</div>
                         </div>
                         <div class="hero-stat">
-                            <div class="hero-stat-value" data-stat="delhi_annual_pm25">96</div>
+                            <div class="hero-stat-value" data-stat="delhi_annual_pm25">82.2</div>
                             <div class="hero-stat-label">Delhi Annual PM2.5</div>
-                            <div class="hero-stat-note">19x WHO (2025 avg)</div>
+                            <div class="hero-stat-note">16x WHO (IQAir 2025)</div>
                         </div>
                         <div class="hero-stat">
                             <div class="hero-stat-value" id="worst-city-pm25">--</div>
@@ -1826,7 +1826,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         </div>
     </footer>
 
-    <script src="/app.js?v=202606122"></script>
+    <script src="/app.js?v=202606123"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -2571,7 +2571,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
             <div class="grid-2">
                 <div class="card">
                     <div class="card-header"><span class="card-title">NCAP Fund Utilization</span></div>
-                    <div class="card-body"><div class="chart-container"><canvas id="ncapChart" role="img" aria-label="Bar chart of NCAP funds allocated versus utilised for six Indian cities (Delhi, Mumbai, Noida, Ghaziabad, Lucknow, Patna)."></canvas></div></div>
+                    <div class="card-body"><div class="chart-container"><canvas id="ncapChart" role="img" aria-label="Bar chart of NCAP funds allocated versus utilised for three Indian cities with verifiable per-city data (Delhi, Noida, Ghaziabad)."></canvas></div></div>
                 </div>
                 <div class="card">
                     <div class="card-header"><span class="card-title">GRAP Stages Explained</span></div>
@@ -4158,7 +4158,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                             </tr>
                             <tr>
                                 <td data-label="Date">31 Mar 2026</td>
-                                <td data-label="Action">15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) expired. No successor announced.</td>
+                                <td data-label="Action">15th Finance Commission clean air grants (&rupee;16,539 Cr for 42 million-plus cities) expired. No successor announced.</td>
                                 <td data-label="Source">15th FC report</td>
                                 <td data-label="Status"><span class="badge badge-danger">Expired</span></td>
                             </tr>
@@ -4202,9 +4202,9 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                         <tbody>
                             <tr>
                                 <td data-label="Date">2025-26</td>
-                                <td data-label="Action">NCAP allocation &rupee;380 Cr; &rupee;220 Cr utilised (58%). Bulk spent on road sweeping and dust suppression.</td>
-                                <td data-label="Source">CREA NCAP Analysis</td>
-                                <td data-label="Status"><span class="badge badge-warning">Moderate</span></td>
+                                <td data-label="Action">15th FC: &rupee;620 Cr released, ~94% utilised; plus &rupee;95.5 Cr MoEFCC direct funds, 100% utilised.</td>
+                                <td data-label="Source">BMC data via Free Press Journal, Feb 2025</td>
+                                <td data-label="Status"><span class="badge badge-success">On track</span></td>
                             </tr>
                             <tr>
                                 <td data-label="Date">2024</td>
@@ -4234,8 +4234,8 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                         <tbody>
                             <tr>
                                 <td data-label="Date">2025-26</td>
-                                <td data-label="Action">NCAP allocation &rupee;120 Cr; &rupee;84 Cr utilised (70%). Best utilisation rate among major cities.</td>
-                                <td data-label="Source">CREA NCAP Analysis</td>
+                                <td data-label="Action">NCAP + 15th FC funds &rupee;298.60 Cr received; &rupee;194.26 Cr utilised (~65%).</td>
+                                <td data-label="Source">Bihar govt. filing, NGT OA 687/2023</td>
                                 <td data-label="Status"><span class="badge badge-success">On track</span></td>
                             </tr>
                             <tr>
@@ -4264,12 +4264,6 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                     <table class="table responsive-cards">
                         <thead><tr><th style="width:110px;">Date</th><th>Action</th><th style="width:130px;">Source</th><th style="width:110px;">Status</th></tr></thead>
                         <tbody>
-                            <tr>
-                                <td data-label="Date">2025-26</td>
-                                <td data-label="Action">NCAP allocation &rupee;180 Cr; &rupee;72 Cr utilised (40%). Below 75% threshold &mdash; risks losing next-year funding.</td>
-                                <td data-label="Source">CREA NCAP Analysis</td>
-                                <td data-label="Status"><span class="badge badge-danger">Below threshold</span></td>
-                            </tr>
                             <tr>
                                 <td data-label="Date">2024</td>
                                 <td data-label="Action">PM2.5 annual avg ~76.5 &micro;g/m&sup3; (15&times; WHO). Indo-Gangetic plain trapping.</td>
@@ -4360,7 +4354,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">
                     <h3 style="font-size: 0.875rem">On the funding cliff</h3>
-                    <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;What happened to the 15th Finance Commission clean air grants (&rupee;16,539 Cr for 49 cities) that expired 31 March 2026?&rdquo;</p>
+                    <p style="font-size: 0.9375rem; font-weight: 500; line-height: 1.6;">&ldquo;What happened to the 15th Finance Commission clean air grants (&rupee;16,539 Cr for 42 million-plus cities) that expired 31 March 2026?&rdquo;</p>
                     <p style="font-size: 0.8125rem; color: var(--text-3); margin-top: 0.5rem;">Context: This bucket was 87% of all NCAP city funding. 16th FC recommendations expected Oct 2026 for FY27 (Apr 2027) &mdash; leaving a potential 12-month gap with no new allocation.</p>
                 </div>
                 <div class="info-box" style="border-left: 3px solid var(--accent);">

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -201,7 +201,7 @@ METHODOLOGY — HOW TO RECONCILE DIFFERING NUMBERS:
 
 2) WAQI single station vs CPCB CAAQMS network
    - WAQI 'geo:' returns the nearest single station to a centroid. NOT the city average. NOT all stations.
-   - CPCB CAAQMS has ~533 stations across ~250 cities; a city often has 5-20 stations with substantial variance (e.g. Delhi: Anand Vihar can be 200 µg/m³ while Lodhi Road is 90 µg/m³ on the same day).
+   - CPCB CAAQMS has ~565 stations across ~250 cities (2025); a city often has 5-20 stations with substantial variance (e.g. Delhi: Anand Vihar can be 200 µg/m³ while Lodhi Road is 90 µg/m³ on the same day).
    - When user asks "what is Delhi AQI", clarify: live readings shown are the NEAREST station, not a city average.
 
 3) CPCB annual vs IQAir World Air Quality Report
@@ -222,7 +222,7 @@ METHODOLOGY — HOW TO RECONCILE DIFFERING NUMBERS:
 
 const TOPICAL_REFERENCE = `
 MONITORING NETWORK (national):
-- CPCB CAAQMS (Continuous Ambient Air Quality Monitoring Stations): ~533 stations across ~250 Indian cities as of 2025 (CPCB Annual Report).
+- CPCB CAAQMS (Continuous Ambient Air Quality Monitoring Stations): ~565 stations across ~250 Indian cities as of 2025 (CPCB data via CREA 'Tracing the Hazy Air 2026', Jan 2026).
 - WAQI / aqicn.org: surfaces a subset of CAAQMS + community sensors. Geo lookups return the nearest single station.
 - Sensor.Community: ~3,000+ CC0 low-cost community sensors across India (the "Hyperlocal" panel on JanVayu blends these with CPCB/WAQI data).
 - CAG April 2025 audit: 88% of monitoring stations had data-quality issues at least once in 2023-24.
@@ -851,7 +851,7 @@ function buildSpreadAnalysis(cityKey, cityName, waqiPm25, stationList, sensorLis
   }
 
   if (items.length === 0) return "";
-  return `\n\nMULTI-SOURCE SPREAD ANALYSIS for ${cityName.toUpperCase()} (computed):\n${items.join("\n")}\nCitation reminder: WAQI = aqicn.org; community sensors = Sensor.Community (CC0, ±20-50% accuracy); IQAir 2025 = the 2025 edition, March 2025, covering 2024 data; CPCB CAAQMS = official Indian regulatory (~533 stations, ±5-10% accuracy).`;
+  return `\n\nMULTI-SOURCE SPREAD ANALYSIS for ${cityName.toUpperCase()} (computed):\n${items.join("\n")}\nCitation reminder: WAQI = aqicn.org; community sensors = Sensor.Community (CC0, ±20-50% accuracy); IQAir 2025 = the 2025 edition, March 2025, covering 2024 data; CPCB CAAQMS = official Indian regulatory (~565 stations, ±5-10% accuracy).`;
 }
 
 // v26.6.41 — prompt-trim (ported from PR #98): METHODOLOGY_REFERENCE (~1000
@@ -906,7 +906,7 @@ ${instruction9}
 10. TONE & LENGTH — Be WARM, patient and explanatory, like a knowledgeable, kind professor who genuinely wants the person to understand — never cold, bureaucratic, preachy or alarmist. Explain the WHY in plain language, and briefly define a technical term the first time you use it (e.g. "PM2.5 — the tiny particles that reach your bloodstream"). Make the person feel capable of acting. Keep it focused though: aim for ~150 words, lead with the direct answer in 1-2 sentences, then a few clear supporting points that teach, not lecture — no walls of text. Write PLAIN TEXT: do NOT use markdown — no **bold**, no # / ## / ### headings, no tables, no | pipes. For a short list, use a plain dash (-) at the start of a line.
 11. SOURCES — cite a source ONLY when the number actually comes from (a) the KEY REFERENCE DATA above, (b) the DATA CONTEXT / computed lines provided in this request, or (c) the TOPICAL/METHODOLOGY blocks when present. Cite the REAL source named there — e.g. "IQAir 2025", "Lancet Countdown 2025", "AQLI 2025", "CPCB CAAQMS", "CREA", "State of Global Air 2024", "Sensor.Community". For general advice, practical suggestions, or anything NOT backed by the data you were given, give the guidance plainly WITHOUT a citation — you may say "as a general guide" or "broadly". Do NOT attach a source tag to a number just to look authoritative. Keep any citation in the SAME LANGUAGE as your answer (never write an English "(Source: …)" inside a Hindi/Tamil/Marathi/Bengali reply).
 12. For NATIONAL/TOPICAL questions (EVs, low-cost sensors, BS-VI, monitoring network, court orders, NCAP): use the TOPICAL REFERENCE block when provided. Do NOT default to Delhi or single-station context unless the user explicitly asks about Delhi.
-13. For station-count questions: ALWAYS use the CPCB REFERENCE data if present in the DATA CONTEXT. Report the TOTAL count first, then bifurcate into CAAQMS (continuous, real-time) and manual (gravimetric, 24-hr sampling) stations. Also mention the CPCB national figure (~533 CAAQMS). If asking about low-cost sensors, use the community sensor data if available.
+13. For station-count questions: ALWAYS use the CPCB REFERENCE data if present in the DATA CONTEXT. Report the TOTAL count first, then bifurcate into CAAQMS (continuous, real-time) and manual (gravimetric, 24-hr sampling) stations. Also mention the CPCB national figure (~565 CAAQMS). If asking about low-cost sensors, use the community sensor data if available.
 14. If the DATA CONTEXT contains lines tagged "(computed)" — those are deterministic calculations JanVayu just ran (cigarette equivalence, mortality risk, life-expectancy loss, migration delta, transport exposure, purifier CADR, school-closure forecast, source apportionment, RTI template). Use those numbers verbatim. Do NOT recompute, re-round, or paraphrase the RTI template fields. Always carry the cited source.
 15. For RTI requests, if a "RTI APPLICATION TEMPLATE" block is in the DATA CONTEXT, present it AS-IS to the user with only minimal framing ("Here's a properly-formatted RTI for your case — replace bracketed fields and post / email to the listed PIO"). Do NOT rewrite the questions, statutory anchors, or department address.
 16. For generic "how is the air quality" questions: if a CITY-WIDE STATION RANGE is in the DATA CONTEXT, present the AQI range across all stations (e.g. "AQI ranges from X to Y across N stations") rather than quoting just one station. Name 2-3 representative stations. This gives a more accurate city-level picture.
@@ -1148,12 +1148,12 @@ export default async function handler(req) {
     if (cpcbRef) {
       dataContext += `\nCPCB REFERENCE for ${aqiResult.city} (CPCB Annual Report 2024-25): Total ${cpcbRef.total} monitoring stations — ${cpcbRef.caaqms} CAAQMS (continuous, real-time) + ${cpcbRef.manual} manual (gravimetric, 24-hr sampling). ${cpcbRef.note}.`;
     }
-    dataContext += `\nNOTE: The WAQI-indexed count above is a subset. CPCB CAAQMS national total is ~533 stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community adds ~3,000+ low-cost community sensors nationwide.`;
+    dataContext += `\nNOTE: The WAQI-indexed count above is a subset. CPCB CAAQMS national total is ~565 stations across ~250 Indian cities (CPCB data via CREA, Jan 2026). Sensor.Community adds ~3,000+ low-cost community sensors nationwide.`;
   } else if (isStationCountQuery(question)) {
     if (cpcbRef) {
       dataContext += `\nCPCB REFERENCE for ${aqiResult.city} (CPCB Annual Report 2024-25): Total ${cpcbRef.total} monitoring stations — ${cpcbRef.caaqms} CAAQMS (continuous, real-time) + ${cpcbRef.manual} manual (gravimetric, 24-hr sampling). ${cpcbRef.note}.`;
     }
-    dataContext += `\nSTATION COUNT NOTE: WAQI bounds query returned no list for ${aqiResult.city}. CPCB CAAQMS national total is ~533 stations across ~250 Indian cities (CPCB Annual Report). Sensor.Community runs ~3,000+ low-cost community sensors nationwide.`;
+    dataContext += `\nSTATION COUNT NOTE: WAQI bounds query returned no list for ${aqiResult.city}. CPCB CAAQMS national total is ~565 stations across ~250 Indian cities (CPCB data via CREA, Jan 2026). Sensor.Community runs ~3,000+ low-cost community sensors nationwide.`;
   }
 
   // v26.6.13 Phase A — Inject results from rankings / trend / hyperlocal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.122",
+  "version": "26.6.123",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/panels/accountability.html
+++ b/panels/accountability.html
@@ -18,9 +18,9 @@
                                 <tr><td data-label="Statement/Promise">"Stubble burning will end this year"</td><td data-label="By Whom">Punjab CM</td><td data-label="Date">2021, 2022, 2023, 2024</td><td data-label="Status"><span class="badge badge-danger">Repeated Every Year</span></td></tr>
                                 <tr><td data-label="Statement/Promise">"Smog towers will solve pollution"</td><td data-label="By Whom">DPCC/IIT</td><td data-label="Date">2021</td><td data-label="Status"><span class="badge badge-danger">₹20Cr Wasted</span></td></tr>
                                 <tr><td data-label="Statement/Promise">"1000 electric buses by 2023"</td><td data-label="By Whom">Delhi Transport</td><td data-label="Date">2021</td><td data-label="Status"><span class="badge badge-success">1,000 Target Met by 2024; ~4,538 by Apr 2026</span></td></tr>
-                                <tr><td data-label="Statement/Promise">"All brick kilns will use zigzag tech"</td><td data-label="By Whom">CPCB</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">30% Compliance</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"All brick kilns will use zigzag tech"</td><td data-label="By Whom">CPCB</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">Uneven, 45-85% by State</span></td></tr>
                                 <tr><td data-label="Statement/Promise">"Real-time source apportionment"</td><td data-label="By Whom">MoEFCC</td><td data-label="Date">2022</td><td data-label="Status"><span class="badge badge-warning">90/130 Studies Done (CREA 2026)</span></td></tr>
-                                <tr><td data-label="Statement/Promise">"Odd-even will reduce pollution 15%"</td><td data-label="By Whom">Delhi Govt</td><td data-label="Date">2016</td><td data-label="Status"><span class="badge badge-warning">~13% During Scheme Hours, Jan 2016 (EPIC)</span></td></tr>
+                                <tr><td data-label="Statement/Promise">"Odd-even will reduce pollution 15%"</td><td data-label="By Whom">Delhi Govt</td><td data-label="Date">2016</td><td data-label="Status"><span class="badge badge-warning">~14-16% During Scheme Hours, Jan 2016 (EPIC)</span></td></tr>
                                 <tr style="background: rgba(234,179,8,0.08);"><td data-label="Statement/Promise">"NCAP funds fully utilized"</td><td data-label="By Whom">MoEFCC/States</td><td data-label="Date">2019-25</td><td data-label="Status"><span class="badge badge-warning">Delhi: 17% (RTI 2025)</span></td></tr>
                                 <tr style="background: rgba(27,107,74,0.08);"><td data-label="Statement/Promise">"NCAP 40% reduction in 100 cities"</td><td data-label="By Whom">MoEFCC (NCAP)</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">Only 23/100 Met Target (CREA 2026)</span></td></tr>
                                 <tr style="background: rgba(27,107,74,0.08);"><td data-label="Statement/Promise">"Comprehensive monitoring in NCAP cities"</td><td data-label="By Whom">CPCB</td><td data-label="Date">2019</td><td data-label="Status"><span class="badge badge-danger">28/130 Cities Still No CAAQMS (2026)</span></td></tr>
@@ -260,7 +260,7 @@
                                     <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td data-label="Announced">2019</td>
                                     <td data-label="Grade"><span class="badge badge-warning">E3</span></td>
-                                    <td data-label="Verification Source">~25 km of ~112 km sanctioned operational (first sections opened Jan-Mar 2026); remainder under construction (DMRC). Ridership impact on emissions unquantified.</td>
+                                    <td data-label="Verification Source">~25 km of ~112 km sanctioned operational (first section opened Jan 2025, two more Mar 2026); remainder under construction (DMRC). Ridership impact on emissions unquantified.</td>
                                 </tr>
                                 <tr>
                                     <td data-label="Intervention"><strong>Electric Bus Fleet (1000 buses)</strong></td>
@@ -274,7 +274,7 @@
                                     <td data-label="Category"><span class="badge" style="background: #1D4ED8; color: white;">Transport</span></td>
                                     <td data-label="Announced">2016</td>
                                     <td data-label="Grade"><span class="badge badge-danger">E1</span></td>
-                                    <td data-label="Verification Source">EPIC/UChicago: ~13% PM2.5 drop during 8am-8pm in Jan 2016; no effect at night or in the Apr 2016 round. Exemptions and seasonal-only deployment limit impact.</td>
+                                    <td data-label="Verification Source">EPIC/UChicago: ~14-16% PM2.5 drop during 8am-8pm in Jan 2016; no effect at night or in the Apr 2016 round. Exemptions and seasonal-only deployment limit impact.</td>
                                 </tr>
 
                                 <!-- INDUSTRIAL -->
@@ -283,7 +283,7 @@
                                     <td data-label="Category"><span class="badge" style="background: #6D28D9; color: white;">Industrial</span></td>
                                     <td data-label="Announced">2019</td>
                                     <td data-label="Grade"><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
-                                    <td data-label="Verification Source">Zigzag adoption uneven — ~45% of kilns in UP, ~71% in Haryana-NCR (CPCB/SPCB inspections). Enforcement weak; seasonal operation continues.</td>
+                                    <td data-label="Verification Source">Zigzag adoption uneven — ~45% of kilns in UP, ~71% in Haryana-NCR (CPCB/NGT-committee data, 2021; no comprehensive newer statewide count located). Enforcement weak; seasonal operation continues.</td>
                                 </tr>
                                 <tr>
                                     <td data-label="Intervention"><strong>Industrial Emission Standards (FGD)</strong></td>
@@ -299,7 +299,7 @@
                                     <td data-label="Category"><span class="badge" style="background: #15803D; color: white;">Agricultural</span></td>
                                     <td data-label="Announced">2018</td>
                                     <td data-label="Grade"><span class="badge" style="background: #C2410C; color: white;">E2</span></td>
-                                    <td data-label="Verification Source">₹3,062 Cr allocated (2018-24). NASA FIRMS counts show Punjab fires well below the 2021 peak, though researchers note some burning shifted outside satellite overpass times, complicating year-on-year comparisons.</td>
+                                    <td data-label="Verification Source">₹4,266 Cr released (2018-19 to 2026-27, PIB Jun 2026). NASA FIRMS counts show Punjab fires well below the 2021 peak, though researchers note some burning shifted outside satellite overpass times, complicating year-on-year comparisons.</td>
                                 </tr>
                                 <tr>
                                     <td data-label="Intervention"><strong>PUSA Bio-Decomposer</strong></td>

--- a/panels/budget.html
+++ b/panels/budget.html
@@ -146,9 +146,9 @@
                                 </tr>
                                 <tr>
                                     <td data-label="City"><strong>Noida</strong></td>
-                                    <td data-label="Allocated (₹ Cr)">55.70</td>
-                                    <td data-label="Utilized (₹ Cr)">7.07</td>
-                                    <td data-label="Utilization %"><span class="badge badge-danger">13%</span></td>
+                                    <td data-label="Allocated (₹ Cr)">127.00</td>
+                                    <td data-label="Utilized (₹ Cr)">30.00</td>
+                                    <td data-label="Utilization %"><span class="badge badge-danger">24%</span></td>
                                     <td style="color: var(--green-700);" data-label="Status">Critical underutilization</td>
                                 </tr>
                                 <tr>
@@ -156,16 +156,16 @@
                                     <td data-label="Allocated (₹ Cr)">48.50</td>
                                     <td data-label="Utilized (₹ Cr)">&gt;39</td>
                                     <td data-label="Utilization %"><span class="badge badge-success">&gt;80%</span></td>
-                                    <td style="color: var(--green-700);" data-label="Status">High performer (CREA 2026)</td>
+                                    <td style="color: var(--green-700);" data-label="Status">High performer</td>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
                     <div style="margin-top: 1rem; padding: 0.75rem; background: rgba(124,58,237,0.1); border-radius: 6px; font-size: 0.875rem;">
-                        <strong>75% Rule (Sep 2025):</strong> Cities must now achieve 75% utilization to access 2025-26 NCAP allocation. Delhi, Noida, and several other NCR cities risk losing their allocations.
+                        <strong>75% Rule:</strong> The NCAP Monitoring Committee (Aug&ndash;Sep 2025) directed that no city fall below 75% fund utilization to keep accessing 2025-26 NCAP allocation. Delhi, Noida, and several other NCR cities risk losing their allocations.
                     </div>
                 </div>
-                <div class="card-footer">Sources: Delhi &amp; Noida &mdash; Outlook Business (Sep 2025); Ghaziabad &mdash; CREA &ldquo;Tracing the Hazy Air 2026&rdquo; (Jan 2026). Rows without a verifiable per-city source have been removed.</div>
+                <div class="card-footer">Sources: Delhi &mdash; ResGov &ldquo;Financing Clean Air&rdquo; Delhi City Brief 4 (23 Dec 2025); Noida &mdash; ResGov &ldquo;Financing Clean Air&rdquo; Noida City Brief 3 (4 Jan 2026); Ghaziabad &mdash; Lok Sabha reply, Jan 2026. CREA&rsquo;s NCAP progress reports do not publish city-level ₹ Cr figures for these cities. Rows without a verifiable per-city source have been removed.</div>
             </div>
 
             <!-- OTHER SCHEMES -->
@@ -204,13 +204,13 @@
                     <div class="card-header">
                         <span class="card-title" style="color: var(--amber);">
                             <span class="si si-shield"></span>
-                            Crop Residue Management (2018-2025)
+                            Crop Residue Management (2018-2026)
                         </span>
                     </div>
                     <div class="card-body" style="font-size: 0.875rem;">
                         <div class="grid-2" style="gap: 0.75rem; margin-bottom: 1rem;">
                             <div style="text-align: center; padding: 0.75rem; background: var(--bg); border-radius: 6px;">
-                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--amber);">₹3,623 Cr</div>
+                                <div style="font-size: 1.75rem; font-weight: 700; color: var(--amber);">₹4,266 Cr</div>
                                 <div style="font-size: 0.875rem; color: var(--text-3);">Total Released</div>
                             </div>
                             <div style="text-align: center; padding: 0.75rem; background: var(--bg); border-radius: 6px;">
@@ -219,7 +219,7 @@
                             </div>
                         </div>
                         <div style="margin-bottom: 0.75rem;">
-                            <strong>State-wise Release:</strong>
+                            <strong>State-wise Release (as of Nov 2024, older snapshot &mdash; pending refresh):</strong>
                             <ul style="margin-top: 0.25rem;">
                                 <li>Punjab: ₹1,681 Cr (46%)</li>
                                 <li>Haryana: ₹1,082 Cr (30%)</li>
@@ -230,7 +230,7 @@
                             <strong style="color: var(--green-700);">Success Story:</strong> Fire incidents dropped from 82,533 (2021) to 18,457 (2024). 3 lakh+ machines distributed.
                         </div>
                     </div>
-                    <div class="card-footer">Source: Business Standard (Nov 2024), ETV Bharat (Feb 2025)</div>
+                    <div class="card-footer">Total &mdash; PIB / Ministry of Agriculture &amp; Farmers Welfare (17 Jun 2026, now includes Madhya Pradesh); state-wise breakdown &mdash; Business Standard (Nov 2024), ETV Bharat (Feb 2025)</div>
                 </div>
             </div>
 

--- a/scripts/stats.json
+++ b/scripts/stats.json
@@ -1,13 +1,14 @@
 {
   "deaths_annual": { "value": "1.72 million", "source": "Lancet Countdown 2025", "updated": "2026-07" },
   "economic_cost": { "value": "$339.4 billion", "source": "Lancet Countdown 2025", "updated": "2026-07" },
-  "economic_pct_gdp": { "value": "9.5%", "source": "Lancet Countdown 2025", "updated": "2026-07" },
-  "india_avg_pm25": { "value": "48.9", "unit": "µg/m³", "source": "IQAir 2025", "updated": "2025-03" },
+  "economic_pct_gdp": { "value": "9.5% GDP (Lancet)", "source": "Lancet Countdown 2025", "updated": "2026-07" },
+  "india_avg_pm25": { "value": "48.9", "unit": "µg/m³", "source": "IQAir 2025", "updated": "2026-03" },
   "life_expectancy_loss": { "value": "3.5", "unit": "years", "source": "AQLI 2025", "updated": "2025" },
   "who_guideline": { "value": "5", "unit": "µg/m³" },
   "india_naaqs": { "value": "40", "unit": "µg/m³" },
-  "cpcb_stations": { "value": "~533", "source": "CPCB Annual Report" },
-  "ncap_cities": { "value": "131", "source": "NCAP" },
-  "most_polluted_city": { "value": "Loni", "pm25": "112.5", "source": "IQAir 2025" },
+  "cpcb_stations": { "value": "~565", "source": "CPCB via CREA 'Tracing the Hazy Air 2026' (Jan 2026)", "updated": "2026-01" },
+  "ncap_cities": { "value": "131", "source": "CPCB non-attainment cities list" },
+  "delhi_annual_pm25": { "value": "82.2", "unit": "µg/m³", "source": "IQAir 2025", "updated": "2026-03" },
+  "most_polluted_city": { "value": "112.5", "unit": "µg/m³", "note": "Loni, India", "source": "IQAir 2025" },
   "global_share_deaths": { "value": "~a quarter of the global PM2.5 death burden", "note": "India ~1.72M of the global total; not a majority — the earlier '70%' figure was incorrect", "source": "Lancet Countdown 2025" }
 }

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606122';
+const CACHE_VERSION = 'janvayu-202606123';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606122',
-  '/app.js?v=202606122',
+  '/styles.css?v=202606123',
+  '/app.js?v=202606123',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
Opening this manually — the scheduled fact-check routine pushed this branch successfully on 20 Jul, but the auto-PR GitHub Action failed to open the PR (`GitHub Actions is not permitted to create or approve pull requests` — a repo setting, see below). The work itself is fine and CI already ran on the branch.

## What the routine found and fixed
- **Critical:** `scripts/stats.json`'s `most_polluted_city` entry was overwriting the homepage's "112.5 µg/m³" with the bare string "Loni" at runtime (schema mismatch with the injector); `economic_pct_gdp` was stripping its own "GDP (Lancet)" qualifier. Both fixed.
- Propagated NCAP per-city corrections (already in `panels/budget.html`) that had never reached `index.html`'s per-city action tables, the app.js NCAP chart dataset, or the live Ask JanVayu prompt data in `netlify/functions/air-query.mjs` (which was serving a stale CAAQMS station count in every answer).
- Collapsed three inconsistent Delhi annual-PM2.5 values to one verified figure (82.2 µg/m³, IQAir 2025); corrected the EPIC odd-even effect size, an unsourced zigzag-kiln compliance figure, a wrong Delhi Metro Phase 4 date, and the Crop Residue Management funding figure.
- First-time audit of README.md's Key Statistics table.

Full findings: `docs/fact-check-2026-07-20.md`.

**Review the diff and CI before merging — never auto-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_