### PR TITLE
Auto-PR routines: PAT fallback so PR-creation survives Actions policy

### DIFF
--- a/.github/workflows/auto-pr-factcheck.yml
+++ b/.github/workflows/auto-pr-factcheck.yml
@@ -20,7 +20,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Open or update the weekly fact-check PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT (ROUTINE_PR_TOKEN) if configured — a user token can open
+          # PRs even when the repo's "Allow GitHub Actions to create and approve
+          # pull requests" setting is off. Falls back to the default GITHUB_TOKEN,
+          # which works once that setting is enabled.
+          GH_TOKEN: ${{ secrets.ROUTINE_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           existing=$(gh pr list --head claude/weekly-factcheck --base main --state open --json number --jq '.[0].number' 2>/dev/null || true)
           if [ -n "$existing" ]; then

--- a/.github/workflows/auto-pr-routines.yml
+++ b/.github/workflows/auto-pr-routines.yml
@@ -20,7 +20,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Open or update the routine PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT (ROUTINE_PR_TOKEN) if configured — a user token can open
+          # PRs even when the org/repo "Allow GitHub Actions to create and approve
+          # pull requests" setting is off. Falls back to the default GITHUB_TOKEN,
+          # which works once that setting is enabled.
+          GH_TOKEN: ${{ secrets.ROUTINE_PR_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}
         run: |
           if [ "$BRANCH" = "claude/ask-eval" ]; then


### PR DESCRIPTION
## Why

The scheduled maintenance routines (weekly fact-check, weekly Ask JanVayu eval, fortnightly staleness sweep) run in fresh sessions that **push their branch** (this works — CI runs on it) and then a GitHub Action opens the PR. That last step has been failing:

```
pull request create failed: GitHub Actions is not permitted to create or approve pull requests
```

This is an **org/repo policy** ("Allow GitHub Actions to create and approve pull requests") that overrides the workflow's `pull-requests: write` grant. On an org-owned repo the **org-level** setting takes precedence over the repo checkbox.

## Change

Both auto-PR workflows now route `gh` through `ROUTINE_PR_TOKEN` when it's configured, falling back to the default `GITHUB_TOKEN`:

```yaml
GH_TOKEN: ${{ secrets.ROUTINE_PR_TOKEN || secrets.GITHUB_TOKEN }}
```

- **With the org/repo setting on:** the default token works, no secret needed.
- **With a PAT secret added:** a user token opens PRs regardless of that policy.

Belt-and-suspenders: the routines keep working either way. No site-facing change, so no version bump.

## To activate the PAT path (optional)
Create a fine-grained PAT with **Pull requests: write** on `JanVayu/JanVayu`, add it as repo secret **`ROUTINE_PR_TOKEN`**. If omitted, behaviour is unchanged (uses `GITHUB_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMg4YBmbh89ZGifF5o66Ce)_