### PR TITLE
Agartala blog post, and give the chatbot each city's annual figure

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-08-07"
-version: "26.6.141"
+version: "26.6.142"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-08-07"
-version: "26.6.142"
+version: "26.6.143"

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606141-v141';
+const CACHE_NAME = 'ask-janvayu-202606142-v142';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606142-v142';
+const CACHE_NAME = 'ask-janvayu-202606143-v143';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/blog/README.md
+++ b/blog/README.md
@@ -10,6 +10,7 @@ Data, research, policy accountability, and what the numbers mean for 1.4 billion
 
 | Date | Post | Topic |
 |------|------|-------|
+| 7 Aug 2026 | [Agartala Breathes Like the Coal Belt, and Nobody Was Looking](posts/2026-08-07-agartala-northeast-outlier.md) | Analysis |
 | 7 Aug 2026 | [Every Capital, and the Directory We Never Read](posts/2026-08-07-every-capital-and-the-directory.md) | Product |
 | 7 Aug 2026 | [Ninety Cities, Ward by Ward — and the One We Had to Go Somewhere Else For](posts/2026-08-07-ninety-cities-ward-by-ward.md) | Product |
 | 5 Aug 2026 | [Every Village in India Is Now on the Map — Including the Ones No One Measures](posts/2026-08-05-every-village-on-the-map.md) | Product |

--- a/blog/_sidebar.md
+++ b/blog/_sidebar.md
@@ -4,6 +4,7 @@
 - [How We Write (contributor guide)](how-we-write.md)
 
 - **August 2026**
+  - [Agartala Breathes Like the Coal Belt, and Nobody Was Looking](posts/2026-08-07-agartala-northeast-outlier.md)
   - [Every Capital, and the Directory We Never Read](posts/2026-08-07-every-capital-and-the-directory.md)
   - [Ninety Cities, Ward by Ward — and the One We Had to Go Somewhere Else For](posts/2026-08-07-ninety-cities-ward-by-ward.md)
   - [Every Village in India Is Now on the Map — Including the Ones No One Measures](posts/2026-08-05-every-village-on-the-map.md)

--- a/blog/posts/2026-08-07-agartala-northeast-outlier.md
+++ b/blog/posts/2026-08-07-agartala-northeast-outlier.md
@@ -1,0 +1,51 @@
+# Agartala Breathes Like the Coal Belt, and Nobody Was Looking
+
+**Published:** 7 August 2026 | **Author:** Team JanVayu | **Reading time:** 5 min
+
+---
+
+India's Northeast is usually described in one breath: hills, forest, clean air. For most of the region that is simply true. Itanagar averages **23.5 µg/m³** of PM2.5 over a year. Aizawl **23.9**. Kohima **24.0**. Shillong **30.2**. Imphal **31.3**. All comfortably under India's annual limit of 40, in a country where 64% of the urban wards we map are above it.
+
+Agartala averages **61.3**.
+
+Tripura's capital is not a little worse than its neighbours. It is **two and a half times** Itanagar, and it sits in the same range as Durgapur (63.0) and Asansol (60.9) — the steel-and-coal belt of West Bengal. It is dirtier than Kolkata (49.1). Every one of its 51 wards is above India's annual limit, from Ward 9 at 57.0 to Ward 35 at 65.0. Ranked against all 142 cities on our ward map, Agartala is **34th dirtiest**.
+
+We only know this because, this week, Agartala got a ward map for the first time.
+
+## Why nobody had seen it
+
+Air pollution in India is measured where the monitors are. There are roughly **565 continuous CPCB stations** for the entire country. They cluster in the big cities and the Indo-Gangetic plain, which is both understandable and self-reinforcing: the places we measure are the places we discover problems, and the places we discover problems are where we put more monitors.
+
+Tripura is not one of those places. Neither is most of the Northeast. And when a region has almost no ground monitoring, the absence of alarming numbers reads as an absence of a problem.
+
+The satellite record does not work that way. It covers the whole country at about one kilometre, whether or not anyone is watching. Every one of India's 584,615 villages and all 9,015 wards on our map now carry an annual PM2.5 estimate from it (SatPM2.5 V6GL03, Atmospheric Composition Analysis Group, Washington University — a neural network over satellite aerosol measurements combined with an atmospheric model, calibrated against ground stations).
+
+That estimate has existed for Agartala all along. What was missing was the ward map to hang it on — and the reason *that* was missing is embarrassing, so we wrote it up separately in [Every Capital, and the Directory We Never Read](2026-08-07-every-capital-and-the-directory.md). The short version: the data was sitting in a file we had been downloading past for weeks.
+
+## What the number does and does not say
+
+Three honest limits, because a figure like this is easy to over-read.
+
+**It is an annual average, not a bad day.** 61.3 µg/m³ is what the air averages over a year. It says nothing about how bad a particular week in December gets, and for a city in a valley — Agartala sits in a low plain near the Bangladesh border, where winter inversions trap smoke close to the ground — the seasonal peak is likely to be considerably worse than the average. We do not yet have a monthly layer. That is the most important thing missing from this picture.
+
+**It is modelled, not measured in Agartala.** The satellite product is calibrated against ground monitors, but there are few nearby to calibrate against, which is precisely the situation that makes it valuable and also the situation where its uncertainty is highest. A ground reference station in Agartala would settle it. There is a strong case for one.
+
+**At ~1 km it smooths anything hyperlocal.** A single brick kiln, a crusher, a busy junction — none of these will show up. The within-city spread we can see (57.0 to 65.0) is real but narrow, which usually means the pollution is regional rather than driven by one point source inside the city.
+
+That last point matters for what to do about it. When every ward in a city sits within eight units of every other, the problem is unlikely to be a specific factory on a specific street. It looks like an airshed — the whole plain breathing the same thing.
+
+## What this is not
+
+It is not a claim that Agartala is a crisis city on the scale of Delhi (93.4) or Ghaziabad (92.7). It is not a ranking exercise. And it is emphatically not a reason to describe the Northeast as polluted: five of its capitals are among the cleanest urban air in India, and that deserves saying as loudly as the Agartala number.
+
+What it is, is a data point that could not previously exist, in a place that gets discussed as though the question had already been settled.
+
+## What would actually help
+
+**A reference-grade monitor reporting from Agartala.** When we query our own live-air pipeline for Agartala, nothing comes back — no CPCB or WAQI station is feeding a current reading for the city. (We have not audited Tripura's full monitoring inventory, so treat that as "nothing publicly reporting into the networks we read", not as a count of what exists.) A station whose data reaches the public feeds would convert a modelled estimate into a measured one, and let anyone check our figure rather than take it on faith. This is the kind of thing a state pollution control board can be asked for directly, and the kind of thing an RTI can establish the current status of. JanVayu has [RTI templates](https://www.janvayu.in/#rti-assistant) for exactly this.
+
+**Seasonal data.** An annual mean is the wrong instrument for a country whose pollution is violently seasonal. We are building a monthly layer; until then, treat 61.3 as a floor for winter rather than a description of it.
+
+**Someone local checking our work.** We have never been to Agartala. We have a satellite estimate, a ward map from a government GIS programme, and no ground truth. If you live there and this matches or contradicts what you breathe, we would like to know.
+
+Look at Agartala ward by ward on the [map](https://www.janvayu.in/#ward-map) — pick it from the city list and press **Air, yearly**. If you find something wrong, or you know of monitoring data we have missed, write to **contribute@janvayu.in**.

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     <link rel="preload" href="/fonts/fraunces-700.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/kalam-400.woff2" as="font" type="font/woff2" crossorigin>
     <!-- Discover the main stylesheet early (its <link> sits deeper in <head>). -->
-    <link rel="preload" as="style" href="/styles.css?v=202606142">
+    <link rel="preload" as="style" href="/styles.css?v=202606143">
     <!-- Google Fonts (DM Sans body, Newsreader, JetBrains Mono) loaded non-render-blocking:
          with font-display:swap and the system-ui fallback in --sans, text paints
          immediately and swaps in seamlessly, so this no longer gates first paint. -->
@@ -1828,7 +1828,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         </div>
     </footer>
 
-    <script src="/app.js?v=202606142"></script>
+    <script src="/app.js?v=202606143"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     <link rel="preload" href="/fonts/fraunces-700.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/kalam-400.woff2" as="font" type="font/woff2" crossorigin>
     <!-- Discover the main stylesheet early (its <link> sits deeper in <head>). -->
-    <link rel="preload" as="style" href="/styles.css?v=202606141">
+    <link rel="preload" as="style" href="/styles.css?v=202606142">
     <!-- Google Fonts (DM Sans body, Newsreader, JetBrains Mono) loaded non-render-blocking:
          with font-display:swap and the system-ui fallback in --sans, text paints
          immediately and swaps in seamlessly, so this no longer gates first paint. -->
@@ -1828,7 +1828,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         </div>
     </footer>
 
-    <script src="/app.js?v=202606141"></script>
+    <script src="/app.js?v=202606142"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>

--- a/netlify/functions/air-query.mjs
+++ b/netlify/functions/air-query.mjs
@@ -1393,6 +1393,24 @@ Top 5 worst: ${top5}
     if (wardBlock) dataContext += wardBlock;
   }
 
+  // The city's own ANNUAL figure, always — not just for ward questions.
+  // Without this the model has no annual number for the city itself and
+  // invents one: asked about Agartala (no live monitor) it replied that the
+  // annual mean "isn't listed", guessed a 30-50 range, and concluded Agartala
+  // was cleaner than Guwahati. It is 61.3 against Guwahati's 48.8. Two lines
+  // of real data are cheaper than that.
+  (function () {
+    const c = WARD_DATA[cityKey];
+    const ws = c && c.wards ? c.wards.filter(w => typeof w.p === 'number') : [];
+    if (ws.length < 3) return;
+    const vals = ws.map(w => w.p).sort((a, b) => a - b);
+    const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+    const over = vals.filter(v => v > 40).length;
+    const worst = ws.reduce((a, b) => (b.p > a.p ? b : a));
+    const best = ws.reduce((a, b) => (b.p < a.p ? b : a));
+    dataContext += `\n\nANNUAL AIR FOR ${c.name.toUpperCase()} (SatPM2.5 V6GL03 satellite, 2024 annual mean, ~1 km — USE THESE NUMBERS, do not estimate or infer them): city mean ${mean.toFixed(1)} µg/m³ across ${vals.length} wards, range ${vals[0].toFixed(1)}–${vals[vals.length - 1].toFixed(1)}. ${over} of ${vals.length} wards exceed India's annual limit of 40. Dirtiest ward ${worst.n} (${worst.p}), cleanest ${best.n} (${best.p}). India's annual limit is 40 and the WHO annual guideline is 5. This is an ANNUAL average, never a current reading — do not give it a 24-hour AQI band or same-day advice. If you compare this city with another, only compare it against another ANNUAL figure, and only one you have actually been given; if you have not been given the other city's annual number, say so rather than estimating it.`;
+  })();
+
   // Village / rural questions — the live monitor network cannot reach these
   // places at all, so answer from the annual satellite layer, by district.
   const villageQ = isVillageQuery(question) && !isWardQuery(question);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.142",
+  "version": "26.6.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.142",
+      "version": "26.6.143",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.141",
+  "version": "26.6.142",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.141",
+      "version": "26.6.142",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.141",
+  "version": "26.6.142",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.142",
+  "version": "26.6.143",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606142';
+const CACHE_VERSION = 'janvayu-202606143';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606142',
-  '/app.js?v=202606142',
+  '/styles.css?v=202606143',
+  '/app.js?v=202606143',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606141';
+const CACHE_VERSION = 'janvayu-202606142';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606141',
-  '/app.js?v=202606141',
+  '/styles.css?v=202606142',
+  '/app.js?v=202606142',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
## What does this PR do?

**1. The Agartala post.** The finding the 142-city expansion produced. Agartala averages **61.3 µg/m³** a year — 2.5× every other Northeast capital (Itanagar 23.5, Aizawl 23.9, Kohima 24.0, Shillong 30.2, Imphal 31.3), in the same range as Durgapur and Asansol, and dirtier than Kolkata. All 51 wards exceed India's annual limit; it ranks 34th of the 142 cities we map.

The post is deliberate about what the number is *not*: an annual mean rather than a winter reading, modelled rather than measured, smoothed at ~1 km. It says plainly that five Northeast capitals are among the cleanest urban air in India, so it can't be read as "the Northeast is polluted".

Two claims were cut during fact-checking rather than shipped. *"Tripura has minimal continuous monitoring"* couldn't be supported — our CPCB reference data covers 27 cities and has nothing for Agartala — so it's now the narrower thing actually observed, explicitly flagged as "nothing reporting into the networks we read" rather than a count of what exists. And "two-thirds of urban wards" is now the measured 64%.

**2. A hallucination the previous fix exposed.** #287 was verified against production and only half worked. Asked about Agartala, the bot correctly refused to invent a live reading — then invented the annual picture instead:

> *"The exact annual mean PM2.5 for Agartala isn't listed in the public summary tables, but the model shows that most Northeast-Indian capitals fall in the 30-50 µg/m³ range… Agartala's annual PM2.5 is likely near the regional mid-point — better than Guwahati."*

Agartala is **61.3**, Guwahati is **48.8**. That's backwards, and it's worse than the old "Live data unavailable" message because it's confidently wrong rather than merely unhelpful.

**Cause:** annual per-ward data only reached the model through `buildWardContext`, which runs only for ward-shaped questions. A plain "what is the annual air in X" got no annual number, so the model filled the gap. Every city on the ward map now carries a short ANNUAL AIR block regardless of question shape — mean, range, wards over 40, dirtiest and cleanest by name — plus an instruction not to compare against another city's annual figure it hasn't been given.

**Verified clean on production:** the village fix from #287 works. Nalanda returns the real numbers with no 24-hour band, and the only mention of a mask is the model correctly saying an annual mean shouldn't decide whether to wear one today.

## Type of Change
- [x] Bug fix
- [x] New feature / content
- [ ] Data update
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [x] Tested locally — `node --test`: 17/17 pass; `node --check` clean
- [x] No console errors — function and content only
- [x] Links verified — post listed in `_sidebar.md` and `README.md`; RTI link corrected to the real `#rti-assistant` anchor
- [x] Documentation updated — n/a

Note on deploys: the #287 merge never triggered a Netlify build — no deploy record was created, which is why v26.6.141 sat unpublished while the site served v26.6.140. Triggering a build via the API worked first time and the site is healthy, so this looks like a missed webhook rather than a usage block. Worth watching whether this merge auto-deploys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_