### PR TITLE
Move receptors and "My area" onto the unified map; national land-cover and heat pipelines

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-08-08"
-version: "26.6.146"
+version: "26.6.147"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ keywords:
   - open-data
 
 date-released: "2026-08-08"
-version: "26.6.145"
+version: "26.6.146"

--- a/app.js
+++ b/app.js
@@ -1982,6 +1982,33 @@
         const v = si.value.trim(); if (!v) return;
         wardZoomToFeature(v);
     };
+    // "My area" on the unified map. The ward panel's version needs a loaded
+    // city file to find the nearest ward centroid; the map has no such file —
+    // boundaries arrive as tiles for whatever is on screen. So this just takes
+    // you to your location at a zoom where the chosen level actually renders,
+    // which is the honest equivalent and works at every level rather than only
+    // inside a listed city.
+    window.mapLocateMe = function mapLocateMe() {
+        const note = (m) => { const el = document.getElementById('map-boundary-note'); if (el) el.textContent = m; };
+        if (!navigator.geolocation) { note('Geolocation is not available in this browser.'); return; }
+        if (!map) return;
+        note('Locating…');
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                const { latitude: lat, longitude: lon } = pos.coords;
+                const lvl = BOUNDARY_LEVELS[boundaryLevel];
+                // Zoom past the level's minimum so features are actually drawn,
+                // not just technically in range.
+                const z = lvl ? Math.min(lvl.max, Math.max(lvl.min + 1, 12)) : 11;
+                map.setView([lat, lon], z);
+                note(boundaryLevel && lvl
+                    ? `Showing your area. ${lvl.note}. Tap any boundary for its yearly figure.`
+                    : 'Showing your area. Pick a level from Boundaries to colour it by annual air.');
+            },
+            () => note('Could not get your location (permission denied?).'),
+            { timeout: 8000 });
+    };
+
     window.wardLocateMe = function wardLocateMe() {
         const status = document.getElementById('ward-map-status');
         if (!navigator.geolocation) { if (status) status.textContent = 'Geolocation is not available in this browser.'; return; }

--- a/app.js
+++ b/app.js
@@ -2112,15 +2112,23 @@
         return L.layerGroup([grid, markers]);
     }
     const wardReceptorLayers = {};   // kind → VectorGrid layer (while on)
-    window.toggleWardReceptor = async function toggleWardReceptor(btn, kind) {
+    const mainReceptorLayers = {};   // same, for the unified map
+    // `target` lets the same overlay run on either map. The ward panel passes
+    // nothing and keeps its own map; the unified map passes 'main'. Layers are
+    // tracked per map so turning schools off in one place doesn't strand the
+    // layer in the other.
+    window.toggleWardReceptor = async function toggleWardReceptor(btn, kind, target) {
         const cfg = WARD_RECEPTORS[kind];
-        const statusEl = document.getElementById('ward-map-status');
-        if (!cfg || !wardMap) return;
+        const onMain = target === 'main';
+        const mp = onMain ? map : wardMap;
+        const statusEl = document.getElementById(onMain ? 'map-boundary-note' : 'ward-map-status');
+        const store = onMain ? mainReceptorLayers : wardReceptorLayers;
+        if (!cfg || !mp) return;
         const willBeOn = !btn.classList.contains('active');
         btn.classList.toggle('active', willBeOn);
         btn.setAttribute('aria-pressed', willBeOn ? 'true' : 'false');
         if (!willBeOn) {
-            if (wardReceptorLayers[kind]) { try { wardMap.removeLayer(wardReceptorLayers[kind]); } catch (e) {} delete wardReceptorLayers[kind]; }
+            if (store[kind]) { try { mp.removeLayer(store[kind]); } catch (e) {} delete store[kind]; }
             return;
         }
         try { await ensureVectorGrid(); } catch (e) {
@@ -2128,12 +2136,12 @@
             if (statusEl) statusEl.textContent = 'The overlay library could not load — try again in a moment.';
             return;
         }
-        if (!wardMap || wardReceptorLayers[kind]) return;
+        if (!wardMap || store[kind]) return;
         try {
             // Receptor dots must sit ABOVE the ward choropleth (grid tiles
             // default to the tile pane, underneath it).
-            if (!wardMap.getPane('jv-receptors')) {
-                wardMap.createPane('jv-receptors').style.zIndex = 450;
+            if (!mp.getPane('jv-receptors')) {
+                mp.createPane('jv-receptors').style.zIndex = 450;
             }
             let layer;
             if (cfg.collector) {
@@ -2152,13 +2160,13 @@
                 layer.on('click', (e) => {
                     const p = e.layer && e.layer.properties;
                     if (!p) return;
-                    L.popup({ maxWidth: 240 }).setLatLng(e.latlng).setContent(cfg.popup(p)).openOn(wardMap);
+                    L.popup({ maxWidth: 240 }).setLatLng(e.latlng).setContent(cfg.popup(p)).openOn(mp);
                 });
             }
-            layer.addTo(wardMap);
-            wardReceptorLayers[kind] = layer;
+            layer.addTo(mp);
+            store[kind] = layer;
         } catch (e) {
-            console.warn('[JanVayu] ward receptor layer:', e);
+            console.warn('[JanVayu] receptor layer:', e);
             btn.classList.remove('active');
             if (statusEl) statusEl.textContent = 'Could not load that overlay right now (indianopenmaps.com may be busy).';
         }

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606145-v145';
+const CACHE_NAME = 'ask-janvayu-202606146-v146';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/ask/sw.js
+++ b/ask/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ask-janvayu-202606146-v146';
+const CACHE_NAME = 'ask-janvayu-202606147-v147';
 const STATIC_ASSETS = [
   '/ask/',
   '/ask/index.html',

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     <link rel="preload" href="/fonts/fraunces-700.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/kalam-400.woff2" as="font" type="font/woff2" crossorigin>
     <!-- Discover the main stylesheet early (its <link> sits deeper in <head>). -->
-    <link rel="preload" as="style" href="/styles.css?v=202606146">
+    <link rel="preload" as="style" href="/styles.css?v=202606147">
     <!-- Google Fonts (DM Sans body, Newsreader, JetBrains Mono) loaded non-render-blocking:
          with font-display:swap and the system-ui fallback in --sans, text paints
          immediately and swaps in seamlessly, so this no longer gates first paint. -->
@@ -1850,7 +1850,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         </div>
     </footer>
 
-    <script src="/app.js?v=202606146"></script>
+    <script src="/app.js?v=202606147"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -2961,6 +2961,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                     </select>
                     <button type="button" id="map-toggle-schools-btn" class="map-layer-btn" onclick="window.toggleWardReceptor &amp;&amp; window.toggleWardReceptor(this, 'schools', 'main')" aria-pressed="false" title="Schools (UDISE/NCOG) — children are among the most vulnerable to dirty air">Schools</button>
                     <button type="button" id="map-toggle-health-btn" class="map-layer-btn" onclick="window.toggleWardReceptor &amp;&amp; window.toggleWardReceptor(this, 'health', 'main')" aria-pressed="false" title="Health centres (Bharatmaps) — who has to treat the consequences">Health centres</button>
+                    <button type="button" id="map-locate-btn" class="map-layer-btn" onclick="window.mapLocateMe &amp;&amp; window.mapLocateMe()" title="Jump to your location at a zoom where the selected boundary level is visible">My area</button>
                     </div>
                     <div id="india-map"></div>
                     <p id="map-boundary-note" style="font-size:0.72rem; color:var(--text-3); margin:0.4rem 0 0; text-align:center;"></p>

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     <link rel="preload" href="/fonts/fraunces-700.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/kalam-400.woff2" as="font" type="font/woff2" crossorigin>
     <!-- Discover the main stylesheet early (its <link> sits deeper in <head>). -->
-    <link rel="preload" as="style" href="/styles.css?v=202606145">
+    <link rel="preload" as="style" href="/styles.css?v=202606146">
     <!-- Google Fonts (DM Sans body, Newsreader, JetBrains Mono) loaded non-render-blocking:
          with font-display:swap and the system-ui fallback in --sans, text paints
          immediately and swaps in seamlessly, so this no longer gates first paint. -->
@@ -1850,7 +1850,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         </div>
     </footer>
 
-    <script src="/app.js?v=202606145"></script>
+    <script src="/app.js?v=202606146"></script>
 
 <!-- SEO: Static content for crawlers that don't execute JS -->
 <noscript>
@@ -2959,6 +2959,8 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                         <option value="ulb">City / ULB</option>
                         <option value="ward">Ward</option>
                     </select>
+                    <button type="button" id="map-toggle-schools-btn" class="map-layer-btn" onclick="window.toggleWardReceptor &amp;&amp; window.toggleWardReceptor(this, 'schools', 'main')" aria-pressed="false" title="Schools (UDISE/NCOG) — children are among the most vulnerable to dirty air">Schools</button>
+                    <button type="button" id="map-toggle-health-btn" class="map-layer-btn" onclick="window.toggleWardReceptor &amp;&amp; window.toggleWardReceptor(this, 'health', 'main')" aria-pressed="false" title="Health centres (Bharatmaps) — who has to treat the consequences">Health centres</button>
                     </div>
                     <div id="india-map"></div>
                     <p id="map-boundary-note" style="font-size:0.72rem; color:var(--text-3); margin:0.4rem 0 0; text-align:center;"></p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.146",
+  "version": "26.6.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.146",
+      "version": "26.6.147",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "janvayu",
-  "version": "26.6.145",
+  "version": "26.6.146",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "janvayu",
-      "version": "26.6.145",
+      "version": "26.6.146",
       "dependencies": {
         "@netlify/blobs": "^10.0.0",
         "resend": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.145",
+  "version": "26.6.146",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janvayu",
-  "version": "26.6.146",
+  "version": "26.6.147",
   "description": "JanVayu - India Air Quality Monitor",
   "private": true,
   "engines": {

--- a/scripts/build-lst-mosaic.py
+++ b/scripts/build-lst-mosaic.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+build-lst-mosaic.py — one national land-surface-temperature raster for India,
+built once, so heat stops being the odd layer out.
+
+The problem this replaces. Every other layer here works the same way: one
+national raster, one zonal pass. PM2.5 loads a single grid and bincounts every
+polygon against it; WorldCover reads windows from a fixed global raster. Heat
+alone did a per-city STAC search, scene pick and cloud mask — 3,675 times over.
+Every heat bug we have traces to that shape: the coverage seam that leaves six
+Thiruvananthapuram wards blank, Bhopal sitting on a stale 2023 scene, cloud
+holes, and a per-city job that has to be re-run forever.
+
+Compositing fixes the class, not the instances:
+  * cloud holes fill in, because a median across scenes sees through them;
+  * scene-edge seams vanish, because adjacent path/rows overlap in a mosaic;
+  * "a single hot-season afternoon" becomes a seasonal median, which is the
+    time-aware heat item that has been on the roadmap for months;
+  * and every boundary level — ward, panchayat, village, block — gets heat
+    from the same zonal pass, instead of only the levels someone listed.
+
+Resolution. A 30 m national grid would need 13.2 Gpx and ~66 GB just to
+accumulate, which is not available here. 100 m needs 5.95 GB and still gives
+roughly 200 pixels for a typical 2 km² ward — plenty of within-ward detail,
+and far finer than the 1 km MODIS alternative where most wards would be one or
+two pixels. Accumulators are memory-mapped so RAM stays flat regardless.
+
+Output: data/rasters/lst_india_100m.tif — int16 decidegrees Celsius,
+-32768 = no data. Read it exactly like the PM2.5 grid.
+
+Usage:  python3 scripts/build-lst-mosaic.py [--limit N] [--bbox W S E N]
+"""
+
+import json, os, sys, math
+from pathlib import Path
+
+import numpy as np
+import requests
+import rasterio
+from rasterio.transform import from_origin
+from rasterio.warp import reproject, Resampling, transform_bounds
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = ROOT / 'data' / 'rasters'
+WORK = Path(os.environ.get('JV_CACHE', '/tmp/jv-boundaries')) / 'lst'
+WORK.mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('GDAL_HTTP_PROXY', os.environ.get('HTTPS_PROXY', ''))
+if os.path.exists('/root/.ccr/ca-bundle.crt'):
+    os.environ.setdefault('GDAL_CAINFO', '/root/.ccr/ca-bundle.crt')
+    os.environ.setdefault('REQUESTS_CA_BUNDLE', '/root/.ccr/ca-bundle.crt')
+
+STAC = 'https://planetarycomputer.microsoft.com/api/stac/v1/search'
+SIGN = 'https://planetarycomputer.microsoft.com/api/sas/v1/sign'
+
+# India, generously bounded.
+W, S, E, N = 68.0, 6.0, 98.0, 38.0
+RES = 0.001                     # ~111 m
+WINDOW = '2026-03-01/2026-06-15'   # pre-monsoon: hottest, clearest
+CLOUD_MAX = 40                  # generous — the median rejects what the mask misses
+PER_PR = 4                      # scenes per path/row to composite
+
+if '--bbox' in sys.argv:
+    i = sys.argv.index('--bbox')
+    W, S, E, N = (float(v) for v in sys.argv[i + 1:i + 5])
+LIMIT = int(sys.argv[sys.argv.index('--limit') + 1]) if '--limit' in sys.argv else 0
+
+WIDTH = int(round((E - W) / RES))
+HEIGHT = int(round((N - S) / RES))
+TRANSFORM = from_origin(W, N, RES, RES)
+
+SUM_PATH = WORK / 'sum.f32'
+CNT_PATH = WORK / 'cnt.u8'
+
+
+def scenes():
+    """Least-cloudy pre-monsoon scenes, a few per WRS path/row across India.
+
+    Searching the whole country at once and taking the top N by cloud would
+    cluster them in whichever region happened to be clearest, leaving holes
+    elsewhere. Grouping by path/row guarantees national coverage.
+    """
+    by_pr = {}
+    step = 3.0
+    lat = S
+    while lat < N:
+        lon = W
+        while lon < E:
+            r = requests.post(STAC, json={
+                'collections': ['landsat-c2-l2'],
+                'bbox': [lon, lat, min(lon + step, E), min(lat + step, N)],
+                'datetime': WINDOW,
+                'query': {'eo:cloud_cover': {'lt': CLOUD_MAX},
+                          'platform': {'in': ['landsat-8', 'landsat-9']}},
+                'sortby': [{'field': 'eo:cloud_cover', 'direction': 'asc'}],
+                'limit': 100}, timeout=120)
+            if r.ok:
+                for it in r.json().get('features', []):
+                    # L2SR products carry surface reflectance only — no thermal
+                    # band. Taking them costs a path/row one of its slots and
+                    # then fails on read, so they are rejected here rather than
+                    # discovered scene by scene.
+                    if 'lwir11' not in (it.get('assets') or {}):
+                        continue
+                    p = it['properties']
+                    key = (p.get('landsat:wrs_path'), p.get('landsat:wrs_row'))
+                    by_pr.setdefault(key, [])
+                    if len(by_pr[key]) < PER_PR and it['id'] not in [x['id'] for x in by_pr[key]]:
+                        by_pr[key].append(it)
+            lon += step
+        lat += step
+    out = [it for v in by_pr.values() for it in v]
+    print(f'{len(by_pr)} path/rows, {len(out)} scenes to composite', flush=True)
+    return out
+
+
+def add_scene(item, acc_sum, acc_cnt):
+    """Warp one scene's masked LST into the national grid and accumulate."""
+    href = item['assets']['lwir11']['href']
+    qa_href = item['assets'].get('qa_pixel', {}).get('href')
+    signed = requests.get(SIGN, params={'href': href}, timeout=120).json()['href']
+    signed_qa = requests.get(SIGN, params={'href': qa_href}, timeout=120).json()['href'] if qa_href else None
+
+    with rasterio.open('/vsicurl/' + signed) as src:
+        arr = src.read(1)
+        if arr.size == 0:
+            return False
+        temps = arr.astype('float32') * 0.00341802 + 149 - 273.15
+        valid = (arr != 0) & (temps > 10) & (temps < 75)
+
+        if signed_qa:
+            try:
+                with rasterio.open('/vsicurl/' + signed_qa) as q:
+                    qa = q.read(1)
+                # Collection-2 QA_PIXEL: bit 3 cloud, 4 cloud shadow, 5 snow,
+                # 1 dilated cloud. Drop all of them; the median handles the rest.
+                bad = ((qa >> 1) & 1) | ((qa >> 3) & 1) | ((qa >> 4) & 1) | ((qa >> 5) & 1)
+                valid &= (bad == 0)
+            except Exception:
+                pass                      # no QA is survivable; bounds filter still applies
+
+        if not valid.any():
+            return False
+        temps = np.where(valid, temps, np.nan)
+
+        # Destination window: only the part of the national grid this scene covers.
+        wb = transform_bounds(src.crs, 'EPSG:4326', *src.bounds)
+        c0 = max(0, int((wb[0] - W) / RES) - 1)
+        c1 = min(WIDTH, int((wb[2] - W) / RES) + 2)
+        r0 = max(0, int((N - wb[3]) / RES) - 1)
+        r1 = min(HEIGHT, int((N - wb[1]) / RES) + 2)
+        if c1 <= c0 or r1 <= r0:
+            return False
+
+        dst = np.full((r1 - r0, c1 - c0), np.nan, dtype='float32')
+        reproject(
+            source=temps, destination=dst,
+            src_transform=src.transform, src_crs=src.crs,
+            dst_transform=from_origin(W + c0 * RES, N - r0 * RES, RES, RES),
+            dst_crs='EPSG:4326', resampling=Resampling.average,
+            src_nodata=np.nan, dst_nodata=np.nan)
+
+    good = np.isfinite(dst)
+    if not good.any():
+        return False
+    acc_sum[r0:r1, c0:c1] += np.where(good, dst, 0)
+    acc_cnt[r0:r1, c0:c1] += good.astype('uint8')
+    return True
+
+
+def main():
+    print(f'grid {WIDTH} x {HEIGHT} @ {RES}deg  ({WIDTH*HEIGHT/1e6:.0f} Mpx)', flush=True)
+    acc_sum = np.memmap(SUM_PATH, dtype='float32', mode='w+', shape=(HEIGHT, WIDTH))
+    acc_cnt = np.memmap(CNT_PATH, dtype='uint8', mode='w+', shape=(HEIGHT, WIDTH))
+
+    items = scenes()
+    if LIMIT:
+        items = items[:LIMIT]
+    used = 0
+    for i, it in enumerate(items, 1):
+        try:
+            if add_scene(it, acc_sum, acc_cnt):
+                used += 1
+        except Exception as e:
+            print(f'  [{i}/{len(items)}] {it["id"]}: {str(e)[:70]}', flush=True)
+            continue
+        if i % 10 == 0:
+            print(f'  [{i}/{len(items)}] {used} scenes composited', flush=True)
+    acc_sum.flush(); acc_cnt.flush()
+
+    print('writing mosaic…', flush=True)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    dst_path = OUT_DIR / 'lst_india_100m.tif'
+    profile = dict(driver='GTiff', height=HEIGHT, width=WIDTH, count=1,
+                   dtype='int16', nodata=-32768, crs='EPSG:4326',
+                   transform=TRANSFORM, compress='deflate', predictor=2,
+                   tiled=True, blockxsize=512, blockysize=512)
+    covered = 0
+    with rasterio.open(dst_path, 'w', **profile) as dst:
+        for r in range(0, HEIGHT, 2048):           # row bands, so RAM stays flat
+            r1 = min(HEIGHT, r + 2048)
+            s = np.asarray(acc_sum[r:r1]); c = np.asarray(acc_cnt[r:r1])
+            out = np.full(s.shape, -32768, dtype='int16')
+            m = c > 0
+            out[m] = np.round(s[m] / c[m] * 10).astype('int16')
+            covered += int(m.sum())
+            dst.write(out, 1, window=rasterio.windows.Window(0, r, WIDTH, r1 - r))
+    mb = dst_path.stat().st_size / 1e6
+    print(f'\n{used}/{len(items)} scenes composited')
+    print(f'{covered/1e6:.0f} Mpx with data ({covered/(WIDTH*HEIGHT)*100:.1f}% of the grid)')
+    print(f'wrote {dst_path} — {mb:.0f} MB')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build-ward-landcover-national.py
+++ b/scripts/build-ward-landcover-national.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+build-ward-landcover-national.py — green cover and built-up share for all
+70,417 municipal wards in the country, not the 142 cities the ward panel knew.
+
+Why: the unified boundary map made the ward panel redundant except for four
+layers that only existed for those 142 cities — heat, green cover, built-up,
+and the receptor overlays. Folding them into the map as-is would have meant a
+green-cover layer that works in 142 places and silently does nothing in the
+other 3,533 ULBs, which is the same "your town isn't in our list" failure the
+unified map just removed. So the layers have to go national before the panel
+can go away.
+
+Green and built-up are the tractable half: ESA WorldCover is a fixed 10 m
+global raster, and the zonal pass is the same rasterise-and-count already used
+per city. Heat is the expensive half — it needs a per-city Landsat scene search
+and cloud masking across 3,675 ULBs — and is deliberately not attempted here.
+
+Reads the cached ward slim produced by build-boundary-tiles.py, adds `g` and
+`b` per ward, and rewrites it in place so the tiles can be rebuilt from it.
+
+Usage:  python3 scripts/build-ward-landcover-national.py [--limit N]
+"""
+
+import json, os, sys, importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = Path(os.environ.get('JV_CACHE', '/tmp/jv-boundaries'))
+SLIM = CACHE / 'ward.slim.geojsonl'
+OUT = CACHE / 'ward.slim.lc.geojsonl'
+
+_spec = importlib.util.spec_from_file_location('bws', ROOT / 'scripts' / 'build-ward-satellite.py')
+bws = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bws)
+
+LIMIT = int(sys.argv[sys.argv.index('--limit') + 1]) if '--limit' in sys.argv else 0
+CHUNK = 2000
+
+
+def centroid(geom):
+    """Area-weighted centroid; WorldCover tiles are picked from it."""
+    from shapely.geometry import shape
+    try:
+        g = shape(geom)
+        c = g.representative_point()
+        return round(c.x, 5), round(c.y, 5)
+    except Exception:
+        return None, None
+
+
+def main():
+    if not SLIM.exists():
+        raise SystemExit(f'{SLIM} missing — run build-boundary-tiles.py ward first')
+
+    done = ok = 0
+    buf = []
+    with open(SLIM, encoding='utf8') as fin, open(OUT, 'w', encoding='utf8') as fout:
+
+        def flush():
+            nonlocal ok, done
+            if not buf:
+                return
+            # per_ward_worldcover groups tile opens by centroid, so a chunk
+            # that spans one WorldCover tile costs one open rather than N.
+            try:
+                vals = bws.per_ward_worldcover(buf)
+            except Exception as e:
+                print(f'  chunk failed ({e}) — leaving {len(buf)} wards without land cover', flush=True)
+                vals = [(None, None)] * len(buf)
+            for f, (g, b) in zip(buf, vals):
+                if g is not None:
+                    f['properties']['g'] = g
+                    f['properties']['b'] = b
+                    ok += 1
+                f['properties'].pop('cx', None)
+                f['properties'].pop('cy', None)
+                fout.write(json.dumps(f, separators=(',', ':')) + '\n')
+            done += len(buf)
+            print(f'  {done} wards processed, {ok} with land cover', flush=True)
+            buf.clear()
+
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            f = json.loads(line)
+            cx, cy = centroid(f['geometry'])
+            if cx is None:
+                f['properties'].pop('cx', None)
+                fout.write(json.dumps(f, separators=(',', ':')) + '\n')
+                done += 1
+                continue
+            f['properties']['cx'], f['properties']['cy'] = cx, cy
+            buf.append(f)
+            if len(buf) >= CHUNK:
+                # Keep wards sharing a WorldCover tile together — sorting the
+                # chunk by tile makes the grouping inside the zonal pass hit.
+                buf.sort(key=lambda x: bws.wc_tile_name(x['properties']['cx'], x['properties']['cy']))
+                flush()
+            if LIMIT and done >= LIMIT:
+                break
+        buf.sort(key=lambda x: bws.wc_tile_name(x['properties']['cx'], x['properties']['cy']))
+        flush()
+
+    print(f'\n{done} wards, {ok} with green/built ({ok / max(done,1) * 100:.1f}%)')
+    print(f'wrote {OUT}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build-ward-landcover-national.py
+++ b/scripts/build-ward-landcover-national.py
@@ -19,7 +19,17 @@ and cloud masking across 3,675 ULBs — and is deliberately not attempted here.
 Reads the cached ward slim produced by build-boundary-tiles.py, adds `g` and
 `b` per ward, and rewrites it in place so the tiles can be rebuilt from it.
 
-Usage:  python3 scripts/build-ward-landcover-national.py [--limit N]
+Resilience, learned the hard way. The first full run reached 14,000 of 70,417
+wards and then stalled, and its success rate fell from 99.9% to 71% on the way.
+The cause was transient "Read failed" errors from the remote WorldCover COGs —
+and two design faults of mine made a blip expensive: a failed read lost the
+whole 2,000-ward chunk rather than the wards actually affected, and there was
+no retry and no resume, so a stall meant starting over. Now: each chunk is
+retried with backoff, a chunk that still fails is split so only the genuinely
+unreadable wards are lost, and completed wards are appended so a re-run picks
+up where it stopped.
+
+Usage:  python3 scripts/build-ward-landcover-national.py [--limit N] [--restart]
 """
 
 import json, os, sys, importlib.util
@@ -35,7 +45,33 @@ bws = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(bws)
 
 LIMIT = int(sys.argv[sys.argv.index('--limit') + 1]) if '--limit' in sys.argv else 0
-CHUNK = 2000
+RESTART = '--restart' in sys.argv
+CHUNK = 500          # smaller: a failed read now costs 500 wards, not 2,000
+RETRIES = 3
+
+
+def zonal_with_retry(feats, depth=0):
+    """Land cover for a batch, retrying transient remote-read failures.
+
+    /vsicurl reads against the WorldCover bucket fail intermittently. A single
+    blip used to cost the entire batch, so failures are retried with backoff
+    and then bisected — an unreadable ward loses only itself, not its
+    neighbours.
+    """
+    import time
+    for attempt in range(RETRIES):
+        try:
+            return bws.per_ward_worldcover(feats)
+        except Exception as e:
+            if attempt == RETRIES - 1:
+                if len(feats) == 1 or depth > 6:
+                    print(f'    giving up on {len(feats)} ward(s): {e}', flush=True)
+                    return [(None, None)] * len(feats)
+                mid = len(feats) // 2
+                print(f'    splitting {len(feats)} wards after repeated failure', flush=True)
+                return zonal_with_retry(feats[:mid], depth + 1) + zonal_with_retry(feats[mid:], depth + 1)
+            time.sleep(2 ** attempt)
+    return [(None, None)] * len(feats)
 
 
 def centroid(geom):
@@ -53,9 +89,18 @@ def main():
     if not SLIM.exists():
         raise SystemExit(f'{SLIM} missing — run build-boundary-tiles.py ward first')
 
+    # Resume: count what a previous run already wrote and skip that many.
+    already = 0
+    if OUT.exists() and not RESTART:
+        with open(OUT, encoding='utf8') as f:
+            already = sum(1 for _ in f)
+        if already:
+            print(f'resuming — {already} wards already written', flush=True)
+
     done = ok = 0
     buf = []
-    with open(SLIM, encoding='utf8') as fin, open(OUT, 'w', encoding='utf8') as fout:
+    mode = 'a' if (already and not RESTART) else 'w'
+    with open(SLIM, encoding='utf8') as fin, open(OUT, mode, encoding='utf8') as fout:
 
         def flush():
             nonlocal ok, done
@@ -63,11 +108,7 @@ def main():
                 return
             # per_ward_worldcover groups tile opens by centroid, so a chunk
             # that spans one WorldCover tile costs one open rather than N.
-            try:
-                vals = bws.per_ward_worldcover(buf)
-            except Exception as e:
-                print(f'  chunk failed ({e}) — leaving {len(buf)} wards without land cover', flush=True)
-                vals = [(None, None)] * len(buf)
+            vals = zonal_with_retry(buf)
             for f, (g, b) in zip(buf, vals):
                 if g is not None:
                     f['properties']['g'] = g
@@ -80,9 +121,13 @@ def main():
             print(f'  {done} wards processed, {ok} with land cover', flush=True)
             buf.clear()
 
+        seen = 0
         for line in fin:
             line = line.strip()
             if not line:
+                continue
+            seen += 1
+            if seen <= already:      # already written by an earlier run
                 continue
             f = json.loads(line)
             cx, cy = centroid(f['geometry'])

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606145';
+const CACHE_VERSION = 'janvayu-202606146';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606145',
-  '/app.js?v=202606145',
+  '/styles.css?v=202606146',
+  '/app.js?v=202606146',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',

--- a/sw.js
+++ b/sw.js
@@ -7,12 +7,12 @@
 //   the cached shell. WAQI / Netlify Function responses are also cached so
 //   the user sees the last-known AQI when offline.
 
-const CACHE_VERSION = 'janvayu-202606146';
+const CACHE_VERSION = 'janvayu-202606147';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
-  '/styles.css?v=202606146',
-  '/app.js?v=202606146',
+  '/styles.css?v=202606147',
+  '/app.js?v=202606147',
   '/fonts/fraunces-400.woff2',
   '/fonts/fraunces-600.woff2',
   '/fonts/fraunces-700.woff2',


### PR DESCRIPTION
## What does this PR do?

**Two of the four panel-only features move to the unified map** — the user-visible half of this PR.

**Schools and health-centre overlays.** Both were already national vector tile sets, independent of the 142-city ward list. The only blocker was `toggleWardReceptor` being hardcoded to the ward panel's map. It now takes a target: the panel calls it as before, the map passes `'main'`. Layers are tracked per map so turning schools off in one place can't strand it in the other.

**"My area".** The panel's version finds the nearest ward centroid from a loaded city file — the map has no such file, since boundaries arrive as tiles. So this does the honest equivalent rather than imitating it: geolocate, then move to a zoom where the selected level actually renders. It works anywhere in the country at any level, rather than only inside a listed city.

**Pipelines for the remaining two layers.**

`build-ward-landcover-national.py` — green cover and built-up for **all 70,417 wards**, complete: 66,371 with values (94.3%), green 0–100% (mean 44), built 0–100% (mean 54), and **green+built never exceeds 100% in any ward**. The final pass ran at 99.9% with zero hard failures.

`build-lst-mosaic.py` — heat as **one national raster instead of 3,675 per-city searches**. Every heat bug we have traces to that per-city shape: the Thiruvananthapuram coverage seam, Bhopal on a stale 2023 scene, cloud holes. Compositing fixes the class — cloud holes fill in, scene seams vanish, and "a single hot-season afternoon" becomes a seasonal median. Proven on Delhi: 31.6–58.0 °C, median 46.2, zero implausible pixels.

## Type of Change
- [x] New feature / content
- [x] Bug fix
- [ ] Data update
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [x] Tested locally — `node --test`: 17/17 pass
- [x] No console errors — driven in a mobile browser context: schools overlay activates on the unified map, "My area" jumps to a granted position at ward zoom and reports correctly, mobile layout unchanged
- [x] Links verified — n/a
- [x] Documentation updated — rationale in script docstrings

**Known limits, stated plainly.** The national heat mosaic has **not** completed — it stalls partway through 1,516 scenes and needs debugging; only the pipeline ships here, no heat data. Land cover is computed but **not yet baked into `ward.pmtiles`**, so green/built aren't selectable on the map yet. The ward panel therefore stays. Two `L2SR`-vs-`L2SP` and retry/resume bugs in these pipelines are documented in their commit messages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_