### PR TITLE
Homepage: 20 tools for an even grid, and diagrams brought up to date

### DIFF
--- a/blog/diagrams/atlas-layers.svg
+++ b/blog/diagrams/atlas-layers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 660" role="img" aria-label="How the JanVayu boundary atlas is built: four sources feed three satellite passes and one boundary pass, every polygon gets up to five numbers baked in, and seven administrative levels ship as PMTiles the browser reads by range request">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 660" role="img" aria-label="How the JanVayu boundary atlas is built: four sources — SatPM2.5 annual and monthly grids, Landsat 8/9 scenes, ESA WorldCover 2021 and boundary geometry — feed a national heat mosaic and a tile-major land-cover pass, then one zonal pass bakes up to nine numbers into every polygon: annual PM2.5, the same by season for winter, summer, monsoon and post-monsoon, surface heat, tree cover, green cover and built-up. Seven administrative levels ship as PMTiles the browser reads by range request.">
   <style>
     .k   { font-family:'Kalam','Comic Sans MS',cursive; }
     .h   { font-family:'Kalam','Comic Sans MS',cursive; font-weight:700; }

--- a/blog/diagrams/atlas-layers.svg
+++ b/blog/diagrams/atlas-layers.svg
@@ -12,15 +12,15 @@
   </style>
 
   <text x="490" y="34" text-anchor="middle" class="h" font-size="26" fill="#146c33">How the boundary atlas is built</text>
-  <text x="490" y="57" text-anchor="middle" class="k" font-size="14.5" fill="#5b6b60">four sources &#183; four passes &#183; every polygon carries its own numbers</text>
+  <text x="490" y="57" text-anchor="middle" class="k" font-size="14.5" fill="#5b6b60">four sources &#183; five passes &#183; every polygon carries its own numbers</text>
 
   <!-- ── Column 1: sources ── -->
   <text x="30" y="92" class="h" font-size="14" fill="#5b6b60">WHAT WE START WITH</text>
 
   <rect class="blu" x="26" y="104" width="228" height="62" rx="12"/>
   <text x="42" y="128" class="h" font-size="15" fill="#075985">SatPM2.5 V6GL03</text>
-  <text x="42" y="147" class="k" font-size="12" fill="#5b6b60">~1 km annual grid, 2024</text>
-  <text x="42" y="161" class="k" font-size="11.5" fill="#5b6b60">satellite AOD + GEOS-Chem</text>
+  <text x="42" y="147" class="k" font-size="12" fill="#5b6b60">~1 km, 2024 &#8212; annual grid</text>
+  <text x="42" y="161" class="k" font-size="11.5" fill="#5b6b60">plus 12 monthly grids</text>
 
   <rect class="blu" x="26" y="178" width="228" height="70" rx="12"/>
   <text x="42" y="202" class="h" font-size="15" fill="#075985">Landsat 8/9 C2 L2</text>
@@ -68,17 +68,19 @@
   <!-- ── Column 3: what each polygon ends up carrying ── -->
   <text x="556" y="92" class="h" font-size="14" fill="#5b6b60">WHAT EACH AREA CARRIES</text>
 
-  <rect class="grn" x="552" y="104" width="196" height="196" rx="12"/>
+  <rect class="grn" x="552" y="104" width="196" height="238" rx="12"/>
   <text x="568" y="130" class="h" font-size="15" fill="#146c33">p &#8194;annual PM2.5</text>
   <text x="568" y="152" class="h" font-size="15" fill="#146c33">h &#8194;surface heat</text>
   <text x="568" y="174" class="h" font-size="15" fill="#146c33">t &#8194;tree cover</text>
   <text x="568" y="196" class="h" font-size="15" fill="#146c33">g &#8194;green cover</text>
   <text x="568" y="218" class="h" font-size="15" fill="#146c33">b &#8194;built-up</text>
-  <text x="568" y="245" class="k" font-size="11.5" fill="#5b6b60">plus name, code and</text>
-  <text x="568" y="259" class="k" font-size="11.5" fill="#5b6b60">parent city</text>
-  <text x="568" y="273" class="k" font-size="11" fill="#8a5300">99.8&#8211;100% filled</text>
+  <text x="568" y="243" class="h" font-size="13.5" fill="#146c33">w s r o&#8194;the same, by season</text>
+  <text x="568" y="262" class="k" font-size="11" fill="#5b6b60">winter &#183; summer &#183; monsoon &#183;</text>
+  <text x="568" y="276" class="k" font-size="11" fill="#5b6b60">post-monsoon</text>
+  <text x="568" y="300" class="k" font-size="11" fill="#5b6b60">plus name, code, parent city</text>
+  <text x="568" y="320" class="k" font-size="11" fill="#8a5300">99.8&#8211;100% filled</text>
 
-  <path class="ln" d="M508 476 L 530 476 L 530 300 L 552 300" marker-end="url(#a)"/>
+  <path class="ln" d="M508 476 L 530 476 L 530 330 L 552 330" marker-end="url(#a)"/>
 
   <!-- ── Column 4: the levels ── -->
   <text x="790" y="92" class="h" font-size="14" fill="#5b6b60">AT SEVEN LEVELS</text>
@@ -102,7 +104,7 @@
   <text x="568" y="466" class="h" font-size="15" fill="#8a5300">Shipped as PMTiles</text>
   <text x="568" y="486" class="k" font-size="11.5" fill="#5b6b60">one file per level; the browser asks only for the</text>
   <text x="568" y="500" class="k" font-size="11.5" fill="#5b6b60">byte ranges on screen &#8212; Delhi NCR draws ~700</text>
-  <text x="568" y="514" class="k" font-size="11.5" fill="#5b6b60">wards from about 120 KB of a 37 MB archive</text>
+  <text x="568" y="514" class="k" font-size="11.5" fill="#5b6b60">wards from about 120 KB of a 42 MB archive</text>
 
   <path class="dash" d="M870 334 L 870 440" marker-end="url(#ad)"/>
 

--- a/docs/data-sources/boundary-map.md
+++ b/docs/data-sources/boundary-map.md
@@ -9,7 +9,7 @@ which was retired in v26.6.151. The panel baked values into one GeoJSON per
 city for 142 cities; the boundary map reads national PMTiles archives with
 per-feature properties baked in, for the whole country.
 
-<img src="/blog/diagrams/atlas-layers.svg" alt="How the boundary atlas is built: four sources — SatPM2.5 annual grid, Landsat 8/9 scenes, ESA WorldCover 2021, and boundary geometry from LGD, Swachh Bharat Mission, WB AMRUT and Living Atlas — feed a national heat mosaic and a tile-major land-cover pass, then one zonal pass stamps five numbers onto every polygon: annual PM2.5, surface heat, tree cover, green cover and built-up. Those ship as PMTiles across seven administrative levels from 36 states down to 68,596 wards and 584,615 villages, read by the browser through HTTP range requests." style="width:100%;max-width:980px;display:block;margin:1.5rem auto;">
+<img src="/blog/diagrams/atlas-layers.svg" alt="How the boundary atlas is built: four sources — SatPM2.5 annual and monthly grids, Landsat 8/9 scenes, ESA WorldCover 2021, and boundary geometry from LGD, Swachh Bharat Mission, WB AMRUT and Living Atlas — feed a national heat mosaic and a tile-major land-cover pass, then one zonal pass stamps nine numbers onto every polygon: annual PM2.5, the same by season for winter, summer, monsoon and post-monsoon, surface heat, tree cover, green cover and built-up. Those ship as PMTiles across seven administrative levels from 36 states down to 68,596 wards and 584,615 villages, read by the browser through HTTP range requests." style="width:100%;max-width:980px;display:block;margin:1.5rem auto;">
 
 The shape is the point: every layer is one national raster and one zonal pass.
 Nothing is computed per city, so adding a level costs a pass rather than a
@@ -45,7 +45,7 @@ which republishes LGD and Swachh Bharat Mission geometries.
 
 Each level is one PMTiles archive in `data/tiles/`. The browser issues HTTP
 range requests for only the byte ranges covering what is on screen — rendering
-Delhi NCR styles about 700 wards from roughly 120 KB of a 36 MB archive.
+Delhi NCR styles about 700 wards from roughly 120 KB of a 42 MB archive.
 
 Villages are the exception: their archive is 267 MB, over GitHub's 100 MB file
 limit, so that level still loads through the older per-district TopoJSON path.

--- a/index.html
+++ b/index.html
@@ -1667,6 +1667,18 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                         <div class="quick-link-icon" style="background: #FEF2F2; color: var(--red);"><span class="si si-bar-chart" style="width:20px;height:20px;"></span></div>
                         <div><h3>City Rankings</h3><p>Cleanest &amp; most polluted &mdash; live, 7-day, 30-day</p></div>
                     </div>
+                    <div class="quick-link" onclick="showPanel('forecast')">
+                        <div class="quick-link-icon" style="background: #EFF6FF; color: #2563EB;"><span class="si si-flare" style="width:20px;height:20px;"></span></div>
+                        <div><h3>AQI Forecast</h3><p>72-hour outlook from SAFAR and CPCB &mdash; and whether it came true</p></div>
+                    </div>
+                    <div class="quick-link" onclick="showPanel('fire-tracker')">
+                        <div class="quick-link-icon" style="background: #FEF2F2; color: #C0392B;"><span class="si si-fire" style="width:20px;height:20px;"></span></div>
+                        <div><h3>Farm Fire Tracker</h3><p>Live stubble-burning counts from NASA FIRMS, by state and district</p></div>
+                    </div>
+                    <div class="quick-link" onclick="showPanel('indoor')">
+                        <div class="quick-link-icon" style="background: #F5F3FF; color: #7C3AED;"><span class="si si-home" style="width:20px;height:20px;"></span></div>
+                        <div><h3>Indoor Air</h3><p>&ldquo;Stay indoors&rdquo; assumes indoor air is safe. Often it isn&rsquo;t</p></div>
+                    </div>
                     <div class="quick-link" onclick="showPanel('resources')">
                         <div class="quick-link-icon" style="background: #FEF3C7; color: #B45309;"><span class="si si-book" style="width:20px;height:20px;"></span></div>
                         <div><h3>Research &amp; Reading</h3><p>29 India-focused peer-reviewed studies, with citations</p></div>


### PR DESCRIPTION
Three follow-ups from reader feedback, all small.

## The tool grid is 20, not 17

Centring the odd card out was a workaround; four rows of four plus a lone fifth row is still a partial row. Three real panels were missing from the directory anyway — and all three are things the "how it works" diagram promises on the same page:

- **AQI Forecast** — 72-hour outlook from SAFAR and CPCB, and whether it came true
- **Farm Fire Tracker** — live stubble-burning counts from NASA FIRMS
- **Indoor Air** — "stay indoors" assumes indoor air is safe

So the directory now matches what the diagram above it claims, and the grid squares at five rows of four.

## The atlas diagram had already gone stale

It shipped in the same pull request that added air by season and did not mention it: "four passes", SatPM2.5 described as an annual grid only, five values per polygon where there are now nine. That is the same failure the homepage diagram had just been corrected for, one day later — a picture describing a platform one version out of date is *more* convincing than stale prose, not less.

Now shows the twelve monthly grids as a source and the four seasonal keys alongside the five it had. The `aria-label` was stale in the same way and is fixed too, so a screen-reader user does not get the two-day-old version.

## Two sizes that had drifted

The ward archive is 42 MB since the atlas was deduplicated and the seasons added, not 37 MB. Corrected in the diagram and in the method doc.

## Type of Change
- [x] Bug fix
- [x] New feature / content
- [x] Documentation

## Checklist
- [x] Tested locally — 20 cards measured at `[4,4,4,4,4]` on 1280px and one per row at 390px; both diagrams re-rendered and read
- [x] No console errors — zero at both viewports
- [x] Links verified — the three new cards open real panels (`forecast`, `fire-tracker`, `indoor`)
- [x] Documentation updated — method doc alt text and archive size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_