### PR TITLE
The Reddit cache had never been filled, which is why the 429s happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.157] - 2026-08-09
+
+### Fixed — the Reddit feed's cache had never been filled
+
+Restoring the feed to Reddit's Atom endpoint fixed the function that serves it, and production confirmed it: 0 posts became 10. But the four remaining subreddits came back **429**, and chasing that turned up the actual fault.
+
+`reddit-feed` is designed to serve from a Blobs cache that `scheduled-fetch` refills every four hours, with a live fetch only as a fallback. **`scheduled-fetch` was still calling `search.json`** — the endpoint Reddit refuses from datacentre IPs. So every scheduled run failed, the cache was never filled, and *every visitor* took the fallback path: five simultaneous Reddit requests per page view, all from one shared Netlify IP. The 429s were self-inflicted.
+
+Three changes, smallest first:
+
+- **`scheduled-fetch` reads the Atom feed too**, sequentially with a 500 ms gap. Five requests every four hours does not trouble any rate limit.
+- **The live fallback paces itself** — one subreddit at a time with a 400 ms gap and one retry on 429, under a 7-second budget so a slow subreddit cannot time the function out. Whatever is dropped is named in the response rather than silently missing, and errors now carry the subreddit that produced them, so `HTTP 429 ×4` becomes something diagnosable.
+- **The fallback seeds the cache** with what it fetched, so the next visitor is served rather than repeating the fan-out. Only an unfiltered fetch is stored — caching a filtered one would pass a fraction of the feed off as the whole thing.
+
 ## [v26.6.156] - 2026-08-09
 
 ### New — the map can finally answer "what about *this* year?"

--- a/netlify/functions/reddit-feed.js
+++ b/netlify/functions/reddit-feed.js
@@ -162,6 +162,24 @@ exports.handler = async function (event) {
   });
   unique.sort((a, b) => b.created - a.created);
 
+  // Seed the cache with whatever the live path just managed to get. Without
+  // this, every visitor who arrives before the next scheduled run repeats the
+  // whole fan-out, and Reddit rate-limits the shared Netlify IP for all of
+  // them. Only a full-feed fetch is stored — a filtered one would cache a
+  // fraction of the feed as though it were the whole thing.
+  if (filter === 'all' && unique.length) {
+    try {
+      const store = getBlobStore("janvayu-feeds");
+      await store.setJSON("reddit", {
+        posts: unique.slice(0, 40), count: unique.length,
+        source: 'reddit-proxy', fetched_at: new Date().toISOString(),
+        seeded_by: 'live-fallback',
+      });
+    } catch (e) {
+      console.log('Could not seed the reddit cache:', e.message);
+    }
+  }
+
   return {
     statusCode: 200, headers,
     body: JSON.stringify({

--- a/netlify/functions/scheduled-fetch.mjs
+++ b/netlify/functions/scheduled-fetch.mjs
@@ -62,34 +62,68 @@ async function fetchWithTimeout(url, opts = {}, timeoutMs = 8000) {
 }
 
 // ── Reddit fetcher ──
+// This job is what fills the Blobs cache the reddit-feed function serves. It
+// had been calling search.json, which Reddit refuses from datacentre IPs, so
+// every run failed silently, the cache stayed empty, and every visitor fell
+// through to reddit-feed's live path — five requests per page view, from one
+// shared Netlify IP, which is what was earning the 429s. Reading the Atom feed
+// here, on a 4-hourly schedule, is both the fix and the point: the live path
+// goes back to being a fallback nobody normally reaches.
+function decodeEntities(s) {
+  return String(s || '')
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function parseRedditAtom(xml, sub) {
+  const out = [];
+  for (const e of xml.split('<entry>').slice(1)) {
+    const pick = (tag) => {
+      const m = e.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+      return m ? decodeEntities(m[1].replace(/<!\[CDATA\[|\]\]>/g, '').trim()) : '';
+    };
+    const title = pick('title');
+    if (!title) continue;
+    const linkM = e.match(/<link[^>]*href="([^"]+)"/);
+    out.push({
+      platform: 'reddit', sub,
+      title,
+      author: pick('name') || null,
+      url: linkM ? linkM[1] : null,
+      created: Date.parse(pick('updated') || pick('published')) || Date.now(),
+      // The Atom feed carries no score, comment count or thumbnail. They are
+      // null rather than invented.
+      score: null, comments: null, thumbnail: null,
+      text: decodeEntities(pick('content')).replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ').trim().substring(0, 200),
+    });
+  }
+  return out;
+}
+
 async function fetchReddit() {
   const allPosts = [];
   const errors = [];
-  const results = await Promise.allSettled(
-    SUBREDDITS.map(async ({ sub, query }) => {
-      const url = `https://www.reddit.com/r/${sub}/search.json?q=${encodeURIComponent(query)}&sort=new&restrict_sr=on&limit=10&t=month`;
+  // Sequential with a gap: Reddit rate-limits per IP, and five simultaneous
+  // requests from one Netlify region look like one impatient client.
+  for (let i = 0; i < SUBREDDITS.length; i++) {
+    const { sub, query } = SUBREDDITS[i];
+    if (i) await new Promise(r => setTimeout(r, 500));
+    const url = `https://www.reddit.com/r/${sub}/search.rss?q=${encodeURIComponent(query)}` +
+                `&sort=new&restrict_sr=on&limit=10&t=month`;
+    try {
       const res = await fetchWithTimeout(url, {
         headers: {
           'User-Agent': 'JanVayu:AirQualityMonitor:v26.6 (+https://janvayu.in)',
-          'Accept': 'application/json',
+          'Accept': 'application/atom+xml, application/xml',
         },
       });
-      const data = await res.json();
-      return (data.data?.children || []).map(c => ({
-        platform: 'reddit', sub,
-        title: c.data.title, author: c.data.author,
-        url: `https://reddit.com${c.data.permalink}`,
-        score: c.data.score, comments: c.data.num_comments,
-        created: c.data.created_utc * 1000,
-        text: (c.data.selftext || '').substring(0, 200),
-        thumbnail: c.data.thumbnail?.startsWith('http') ? c.data.thumbnail : null,
-      }));
-    })
-  );
-  results.forEach(r => {
-    if (r.status === 'fulfilled') allPosts.push(...r.value);
-    else errors.push(r.reason.message);
-  });
+      allPosts.push(...parseRedditAtom(await res.text(), sub));
+    } catch (e) {
+      errors.push(`${sub}: ${e.message}`);
+    }
+  }
   // Deduplicate
   const seen = new Set();
   const unique = allPosts.filter(p => {


### PR DESCRIPTION
Follow-up to #302. Restoring the feed to Reddit's Atom endpoint fixed the serving function — production went from **0 posts to 10** — but four subreddits still came back `429`. Chasing that turned up the actual fault.

## What was wrong

`reddit-feed` is designed to serve from a Blobs cache that `scheduled-fetch` refills every four hours, with a live fetch only as a fallback.

**`scheduled-fetch` was still calling `search.json`** — the endpoint Reddit refuses from datacentre IPs. So every scheduled run failed, the cache was never filled, and *every visitor* took the fallback path: five simultaneous Reddit requests per page view, all from one shared Netlify IP.

The rate limiting was self-inflicted. The Atom fix in #302 addressed the symptom in one of the two places that needed it.

## What changed

- **`scheduled-fetch` reads the Atom feed**, sequentially with a 500 ms gap between subreddits. Five requests every four hours troubles no rate limit.
- **The live fallback seeds the cache** with what it fetched, so the next visitor is served rather than repeating the fan-out. Only an unfiltered fetch is stored — caching a filtered one would pass a fraction of the feed off as the whole thing.

Together with the pacing already merged in #302 (one subreddit at a time, one retry on 429, a 7-second budget so a slow subreddit cannot time the function out), the live path should now be something almost nobody reaches.

## Honest note on verification

Right now the live function returns five `429`s — my own repeated production testing exhausted the limit for that IP. The errors are at least diagnosable now (`india: HTTP 429` rather than a bare `HTTP 429` ×4), which is itself part of the #302 change working. I'll re-check after this deploys and the limit resets, and report the actual post count either way rather than leaving the changelog claiming a fix that does not hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_