### PR TITLE
YouTube feed: fetch it, instead of waiting for a job that never ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.160] - 2026-08-09
+
+### New — X, by link and checked, rather than by scrape
+
+X's API is no longer freely readable, and X also blocks search engines from indexing recent posts, so a post from last week cannot be discovered from outside the platform at all. Rather than fake a feed or quote posts from memory, the Voices panel now carries an **On X** card with two honest halves:
+
+- **Live searches and accounts** &mdash; `#DelhiPollution`, `#AirPollution India`, `AQI India`, `#AQIForJanHit`, each opening X's live tab, plus @CPCB_OFFICIAL, @CAQM_Official, @moefcc, @airnewsalerts and @weatherindia. These are always current because X renders them, not us.
+- **Checked posts** &mdash; four posts quoted with author, date and wording, including CPCB's own GRAP Stage IV emergency declaration.
+
+Nothing is quoted unverified. `scripts/verify-x-links.py` checks each link against **X's public embed endpoint**, which needs no key and returns the author and text for a post that exists and a 404 for one that does not; the post's date is decoded from the ID in its own URL, which carries its creation timestamp. Every link on the page was re-checked through that script before it shipped, and the script is committed so it can be re-run.
+
+### New — two verified stories from this week
+
+- **Delhi's air is eating a World Heritage Site.** A joint IIT Roorkee / IIT Kanpur study in the *International Journal of Architectural Heritage* finds a black crust of gypsum &mdash; sulphur dioxide reacting with calcium-rich dust and moisture &mdash; accelerating the decay of Humayun's Tomb, trapping soot and metal particles from traffic, construction, biomass burning and industry. 3 August 2026.
+- **Delhi's first "good" air day in nearly three years.** 9 July 2026, daily average AQI **48**, the first inside the 0&ndash;50 band since 10 September 2023 &mdash; monsoon rain scavenging particles below cloud. It held for one day: 54 the next, 99 the day after, and back to *poor* through early August. Which is the argument for keeping annual and seasonal figures apart: one clean day is weather, the year is the air.
+
+## [v26.6.159] - 2026-08-09
+
+### Fixed — the Instagram feed was showing its own error messages as posts
+
+RSS-Bridge reports its failures as ordinary feed items, so the Social Feed panel was rendering five "citizen posts" titled **"Bridge returned error 401! (20674)"**, each linking to the bridge operator's internal hostname. Instagram now answers 401 to unauthenticated GraphQL, so this is the normal case rather than a blip: every one of the five items production was serving was an error.
+
+Errors are dropped and reported in the `errors` array instead of being dressed up as content. The Instagram tab falls back to what it always had underneath — labelled links to the hashtags — which is honest about being a signpost rather than a feed.
+
+Same principle as removing the X/Twitter tab: better to show nothing than something that is not what it claims to be.
+
 ## [v26.6.158] - 2026-08-09
 
 ### Fixed — the Reddit feed was carrying airline news
@@ -13,7 +39,7 @@ With the feed serving again, what it was serving became visible: *"Air India nam
 
 Measured rather than guessed. Of the 25 posts r/india's search returned, **6 named air quality in the title**. Matching on the post body instead lets nearly everything through — 23 of 25 — because a long rant about leaving the country will mention AQI once. That is a real sentiment, but it is not air-quality coverage, and shown under an unrelated headline it reads as a broken feed.
 
-So a post is kept only if **its title** says it. The per-subreddit limit goes 10 → 25 to make up the difference, at no extra request. The same expression is applied in the scheduled fetcher and the live fallback, so the cache and the fallback cannot disagree about what belongs in the feed. The Voices panel now says the feed is filtered, and why.
+So a post is kept only if **its title** says it &mdash; checked on the way into the cache *and* on the way out of it, so a cache written by an older deploy cannot put airline news on the page. The serving path, not whatever happens to be stored, decides what belongs in this feed. The per-subreddit limit goes 10 → 25 to make up the difference, at no extra request. The same expression is applied in the scheduled fetcher and the live fallback, so the cache and the fallback cannot disagree about what belongs in the feed. The Voices panel now says the feed is filtered, and why.
 
 ## [v26.6.157] - 2026-08-09
 

--- a/app.js
+++ b/app.js
@@ -4913,7 +4913,12 @@
             proxyFetches.push(
                 fetch('/.netlify/functions/youtube-feed', { signal: AbortSignal.timeout(4000) })
                     .then(r => r.text())
-                    .then(t => { if (t.startsWith('{')) { const d = JSON.parse(t); return (d.videos||[]).slice(0,10).map(v => ({ platform:'youtube', title:v.title, url:v.url, created:v.upload_date ? new Date(v.upload_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')) : new Date(), author:v.channel, text:v.description?.substring(0,200)||'', thumbnail:v.thumbnail, view_count:v.view_count, duration:v.duration })); } return []; })
+                    // The feed now comes from YouTube's own channel RSS, which
+                    // dates a video as `published` (ISO) and describes it as
+                    // `text`. The old yt-dlp shape — `upload_date` as YYYYMMDD,
+                    // `description` — is still read as a fallback so a cache
+                    // written before the change does not lose its dates.
+                    .then(t => { if (t.startsWith('{')) { const d = JSON.parse(t); return (d.videos||[]).slice(0,10).map(v => ({ platform:'youtube', title:v.title, url:v.url, created: v.published ? new Date(v.published) : (v.upload_date ? new Date(v.upload_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')) : new Date()), author:v.channel, text:(v.text||v.description||'').substring(0,200), thumbnail:v.thumbnail, view_count:v.view_count, duration:v.duration })); } return []; })
                     .catch(() => [])
             );
         }

--- a/netlify/functions/instagram-feed.js
+++ b/netlify/functions/instagram-feed.js
@@ -44,9 +44,21 @@ async function fetchFromBridge(instance, params) {
   }
 }
 
+// RSS-Bridge reports its own failures as ordinary feed items, so an Instagram
+// block came back as five "posts" titled "Bridge returned error 401!" — and the
+// Social Feed panel rendered them as citizen posts, complete with a link to the
+// bridge operator's internal hostname. Instagram now answers 401 to
+// unauthenticated GraphQL, so this is the normal case, not a blip. An error is
+// an error: it is dropped here and reported in the errors array instead of
+// being dressed up as content.
+function isBridgeError(item) {
+  const t = (item.title || '') + ' ' + (item.content_text || item.content_html || '');
+  return /bridge returned error|HttpException|\bError\b\s*\d{3}\b|Type:\s*\w*Exception/i.test(t);
+}
+
 function normalizeItems(data) {
   if (!data || !data.items) return [];
-  return data.items.map(item => ({
+  return data.items.filter(item => !isBridgeError(item)).map(item => ({
     title: (item.title || '').replace(/<[^>]+>/g, '').trim(),
     content: (item.content_html || item.content_text || '')
       .replace(/<[^>]+>/g, '')

--- a/netlify/functions/reddit-feed.js
+++ b/netlify/functions/reddit-feed.js
@@ -139,10 +139,16 @@ exports.handler = async function (event) {
   try {
     const store = getBlobStore("janvayu-feeds");
     const cached = await store.get("reddit", { type: "json" });
-    if (cached && cached.posts && cached.posts.length > 0) {
+    // The cache can hold posts written before the relevance rule existed, or
+    // by an older deploy. Applying the rule on the way out as well as on the
+    // way in means a stale cache cannot put airline news on the page: the
+    // serving path, not whatever happens to be stored, decides what belongs in
+    // this feed. If nothing survives, fall through and fetch fresh.
+    const kept = (cached && cached.posts || []).filter(isAboutAir);
+    if (kept.length > 0) {
       const params = event.queryStringParameters || {};
       const filter = params.filter || 'all';
-      let posts = cached.posts;
+      let posts = kept;
       if (filter !== 'all') {
         posts = posts.filter(p => p.sub === filter);
       }

--- a/netlify/functions/youtube-feed.js
+++ b/netlify/functions/youtube-feed.js
@@ -1,15 +1,162 @@
-// Netlify Function: YouTube AQI content feed
-// Serves pre-fetched YouTube data from Blobs (populated by Agent-Reach GitHub Action)
-// Falls back to curated search links if no cached data
+// Netlify Function: YouTube air-quality video feed
+//
+// This used to serve only from a Blobs key that a since-retired "Agent-Reach"
+// GitHub Action was supposed to fill. Nothing filled it, so the function
+// returned zero videos and no error — silently empty for however long.
+//
+// It now fetches for itself, by two routes:
+//
+//   1. Channel RSS — https://www.youtube.com/feeds/videos.xml?channel_id=…
+//      Public, no API key, no quota. Returns each channel's ~15 most recent
+//      videos, which we filter down to the ones actually about air. Verified
+//      working against all eight channels below.
+//
+//   2. The YouTube Data API — only if a YOUTUBE_API_KEY is set in the
+//      environment. This is the better route because it *searches* rather than
+//      filtering a recent-videos list, so it finds coverage from channels we
+//      never listed. The free tier is 10,000 units a day and a search costs
+//      100, so 100 searches a day cost nothing. Without a key the function
+//      simply skips this and uses route 1.
+//
+// The honest limit of route 1 alone: outside pollution season a general news
+// channel publishes nothing about air for weeks, so the feed is legitimately
+// empty in, say, August and full in November. Empty is reported as empty, with
+// the search links offered instead — not dressed up.
 
 const { getBlobStore } = require('./blob-store');
 
+// Resolved from each channel's page and checked: all eight return a feed.
+const CHANNELS = [
+  { name: 'Down To Earth', id: 'UCvvFJ4VAsUSemwS_sr4CU_w' },
+  { name: 'NDTV', id: 'UCZFMm1mMw0F81Z37aaEzTUA' },
+  { name: 'India Today', id: 'UCYPvAwZP8pZhSMW8qs7cVCw' },
+  { name: 'The Quint', id: 'UCSaf-7p3J_N-02p7jHzm5tA' },
+  { name: 'WION', id: 'UCWEIPvoxRwn6llPOIn555rQ' },
+  { name: 'Aaj Tak', id: 'UCt4t-jeY85JegMlZ-E5UWtA' },
+  { name: 'Scroll.in', id: 'UCl8zB2LZOiLLV0jYUMpTEgA' },
+  { name: 'The Hindu', id: 'UC3njZ48-FDxLleBYaP0SZIg' },
+];
+
+const SEARCH_QUERIES = [
+  'Delhi air quality AQI',
+  'India air pollution',
+  'stubble burning Punjab',
+];
+
 const YOUTUBE_SEARCH_LINKS = [
-  { query: 'Delhi Air Quality', url: 'https://www.youtube.com/results?search_query=delhi+air+quality+2026' },
+  { query: 'Delhi Air Quality', url: 'https://www.youtube.com/results?search_query=delhi+air+quality' },
   { query: 'India Air Pollution', url: 'https://www.youtube.com/results?search_query=india+air+pollution+AQI' },
   { query: 'Delhi Smog', url: 'https://www.youtube.com/results?search_query=delhi+smog+pollution' },
   { query: 'Clean Air India', url: 'https://www.youtube.com/results?search_query=clean+air+india+NCAP' },
 ];
+
+// The same rule the Reddit feed uses, for the same reason: a title has to name
+// air quality to count. Kept in step with ABOUT_AIR in reddit-feed.js.
+const ABOUT_AIR = /\b(air quality|air pollution|aqi|smog|smoggy|pm ?2\.?5|pm ?10|stubble burn\w*|particulate|clean air|ncap|grap|polluted|pollution)\b/i;
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+function decodeEntities(s) {
+  return String(s || '')
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+async function getText(url, timeoutMs = 8000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'JanVayu:AirQualityMonitor:v26.6 (+https://janvayu.in)' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseChannelFeed(xml, channelName) {
+  const out = [];
+  for (const entry of xml.split('<entry>').slice(1)) {
+    const pick = (tag) => {
+      const m = entry.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+      return m ? decodeEntities(m[1].trim()) : '';
+    };
+    const title = pick('title');
+    if (!title || !ABOUT_AIR.test(title)) continue;
+    const id = pick('yt:videoId');
+    out.push({
+      platform: 'youtube',
+      title,
+      channel: channelName,
+      videoId: id,
+      url: id ? `https://www.youtube.com/watch?v=${id}` : '',
+      thumbnail: id ? `https://i.ytimg.com/vi/${id}/hqdefault.jpg` : null,
+      published: pick('published') || pick('updated'),
+      text: pick('media:description').slice(0, 200),
+    });
+  }
+  return out;
+}
+
+// Route 1: channel feeds, one at a time. YouTube does not rate-limit these
+// anywhere near as hard as Reddit does, but a budget still guards the function
+// timeout — a partial feed beats a 502.
+async function fromChannels(budgetMs = 7000) {
+  const videos = [], errors = [];
+  const deadline = Date.now() + budgetMs;
+  for (let i = 0; i < CHANNELS.length; i++) {
+    if (Date.now() > deadline) {
+      errors.push(`skipped ${CHANNELS.length - i} channel(s): out of time`);
+      break;
+    }
+    if (i) await sleep(120);
+    const ch = CHANNELS[i];
+    try {
+      const xml = await getText(`https://www.youtube.com/feeds/videos.xml?channel_id=${ch.id}`);
+      videos.push(...parseChannelFeed(xml, ch.name));
+    } catch (e) {
+      errors.push(`${ch.name}: ${e.message}`);
+    }
+  }
+  return { videos, errors };
+}
+
+// Route 2: the Data API, when a key exists. Search reaches channels we never
+// listed, which is the whole reason it is worth having.
+async function fromSearchApi(key, budgetMs = 6000) {
+  const videos = [], errors = [];
+  const deadline = Date.now() + budgetMs;
+  for (const q of SEARCH_QUERIES) {
+    if (Date.now() > deadline) break;
+    const url = 'https://www.googleapis.com/youtube/v3/search'
+      + `?part=snippet&type=video&order=date&maxResults=10&regionCode=IN`
+      + `&q=${encodeURIComponent(q)}&key=${encodeURIComponent(key)}`;
+    try {
+      const data = JSON.parse(await getText(url));
+      for (const it of (data.items || [])) {
+        const title = decodeEntities(it.snippet?.title || '');
+        if (!title || !ABOUT_AIR.test(title)) continue;
+        videos.push({
+          platform: 'youtube',
+          title,
+          channel: it.snippet?.channelTitle || '',
+          videoId: it.id?.videoId || '',
+          url: it.id?.videoId ? `https://www.youtube.com/watch?v=${it.id.videoId}` : '',
+          thumbnail: it.snippet?.thumbnails?.high?.url || null,
+          published: it.snippet?.publishedAt || '',
+          text: decodeEntities(it.snippet?.description || '').slice(0, 200),
+        });
+      }
+    } catch (e) {
+      errors.push(`search "${q}": ${e.message}`);
+    }
+  }
+  return { videos, errors };
+}
 
 exports.handler = async function (event) {
   const headers = {
@@ -23,34 +170,73 @@ exports.handler = async function (event) {
     return { statusCode: 204, headers, body: '' };
   }
 
-  // Try Blobs cache (populated by Agent-Reach GitHub Action)
+  // Serve from cache when it holds anything, applying the relevance rule on the
+  // way out as well: a cache written by an older deploy should not be able to
+  // put an unrelated video on the page.
   try {
-    const store = getBlobStore("janvayu-feeds");
-    const cached = await store.get("youtube", { type: "json" });
-    if (cached && cached.videos && cached.videos.length > 0) {
+    const store = getBlobStore('janvayu-feeds');
+    const cached = await store.get('youtube', { type: 'json' });
+    const kept = (cached && cached.videos || []).filter(v => ABOUT_AIR.test(v.title || ''));
+    if (kept.length > 0) {
       return {
         statusCode: 200, headers,
-        body: JSON.stringify({
-          ...cached,
-          served_from: 'cache',
-        }),
+        body: JSON.stringify({ ...cached, videos: kept, count: kept.length, served_from: 'cache' }),
       };
     }
   } catch (e) {
-    console.log('YouTube blob read failed:', e.message);
+    console.log('YouTube blob read failed, fetching live:', e.message);
   }
 
-  // Fallback: return curated search links
+  const key = process.env.YOUTUBE_API_KEY;
+  const channelRun = await fromChannels();
+  const searchRun = key ? await fromSearchApi(key) : { videos: [], errors: [] };
+  const errors = [...channelRun.errors, ...searchRun.errors];
+
+  const seen = new Set();
+  const videos = [...searchRun.videos, ...channelRun.videos].filter(v => {
+    if (!v.videoId || seen.has(v.videoId)) return false;
+    seen.add(v.videoId);
+    return true;
+  });
+  videos.sort((a, b) => new Date(b.published) - new Date(a.published));
+
+  // Nothing found is a real answer, not a failure to hide. Outside pollution
+  // season the news channels genuinely publish nothing about air for weeks.
+  if (videos.length === 0) {
+    return {
+      statusCode: 200, headers,
+      body: JSON.stringify({
+        videos: [], count: 0, fallback: true,
+        search_links: YOUTUBE_SEARCH_LINKS,
+        source: key ? 'channel-rss + data-api' : 'channel-rss',
+        message: 'No air-quality videos in these channels’ recent uploads. Browse YouTube directly:',
+        errors: errors.length ? errors : undefined,
+        fetched_at: new Date().toISOString(),
+      }),
+    };
+  }
+
+  // Seed the cache so the next visitor is not another eight requests.
+  try {
+    const store = getBlobStore('janvayu-feeds');
+    await store.setJSON('youtube', {
+      videos: videos.slice(0, 30), count: videos.length,
+      source: key ? 'channel-rss + data-api' : 'channel-rss',
+      fetched_at: new Date().toISOString(), seeded_by: 'live-fetch',
+    });
+  } catch (e) {
+    console.log('Could not seed the youtube cache:', e.message);
+  }
+
   return {
-    statusCode: 200,
-    headers,
+    statusCode: 200, headers,
     body: JSON.stringify({
-      videos: [],
-      fallback: true,
-      search_links: YOUTUBE_SEARCH_LINKS,
-      count: 0,
-      source: 'agent-reach-ytdlp',
-      message: 'No cached videos available. Browse YouTube directly:',
+      videos: videos.slice(0, 30),
+      count: videos.length,
+      source: key ? 'channel-rss + data-api' : 'channel-rss',
+      served_from: 'live',
+      errors: errors.length ? errors : undefined,
+      fetched_at: new Date().toISOString(),
     }),
   };
 };

--- a/panels/voices.html
+++ b/panels/voices.html
@@ -20,7 +20,93 @@
                 </div>
             </div>
 
+            <!-- ═══ ON X ═══ -->
+            <div class="card mb-3" id="voices-x-card" style="border-left: 4px solid #000;">
+                <div class="card-header" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.4rem;">
+                    <span class="card-title">On X &mdash; live searches and checked posts</span>
+                    <span style="font-size: 0.7rem; color: var(--text-3);">links, not a scraped feed</span>
+                </div>
+                <div class="card-body">
+                    <p style="font-size: 0.82rem; line-height: 1.65; color: var(--text-2); margin: 0 0 0.9rem;" data-simple="X does not let websites read its posts for free any more. So instead of a fake feed, we link straight to X: the live searches always show the newest posts, and below them are older posts we checked one by one.">
+                        X&rsquo;s API is no longer freely readable and it blocks search engines from indexing recent posts, so no honest live feed is possible &mdash; and we would rather link out than fake one. The searches below open X directly and are always current. The posts under them were each checked against X&rsquo;s public embed endpoint, which returns the author and text for a post that exists and a 404 for one that does not, so nothing here is quoted from memory.
+                    </p>
+
+                    <div style="display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.1rem;">
+                        <a class="btn btn-sm" href="https://x.com/search?q=%23DelhiPollution&amp;f=live" target="_blank" rel="noopener" style="font-size: 0.72rem;">#DelhiPollution &mdash; live</a>
+                        <a class="btn btn-sm" href="https://x.com/search?q=%23AirPollution%20India&amp;f=live" target="_blank" rel="noopener" style="font-size: 0.72rem;">#AirPollution India &mdash; live</a>
+                        <a class="btn btn-sm" href="https://x.com/search?q=AQI%20India&amp;f=live" target="_blank" rel="noopener" style="font-size: 0.72rem;">AQI India &mdash; live</a>
+                        <a class="btn btn-sm" href="https://x.com/search?q=%23AQIForJanHit&amp;f=live" target="_blank" rel="noopener" style="font-size: 0.72rem;">#AQIForJanHit &mdash; live</a>
+                    </div>
+
+                    <p style="font-size: 0.75rem; color: var(--text-3); margin: 0 0 0.5rem;">Accounts worth following</p>
+                    <div style="display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.2rem;">
+                        <a class="btn btn-sm" href="https://x.com/CPCB_OFFICIAL" target="_blank" rel="noopener" style="font-size: 0.72rem;">@CPCB_OFFICIAL &middot; regulator</a>
+                        <a class="btn btn-sm" href="https://x.com/CAQM_Official" target="_blank" rel="noopener" style="font-size: 0.72rem;">@CAQM_Official &middot; GRAP orders</a>
+                        <a class="btn btn-sm" href="https://x.com/moefcc" target="_blank" rel="noopener" style="font-size: 0.72rem;">@moefcc &middot; ministry</a>
+                        <a class="btn btn-sm" href="https://x.com/airnewsalerts" target="_blank" rel="noopener" style="font-size: 0.72rem;">@airnewsalerts &middot; AIR News</a>
+                        <a class="btn btn-sm" href="https://x.com/weatherindia" target="_blank" rel="noopener" style="font-size: 0.72rem;">@weatherindia &middot; Weather Channel</a>
+                    </div>
+
+                    <p style="font-size: 0.75rem; color: var(--text-3); margin: 0 0 0.6rem;">Checked posts &mdash; author, date and wording confirmed against X&rsquo;s embed endpoint</p>
+
+                    <div class="voice-card" style="border-left: 3px solid #000;">
+                        <div class="voice-content">&ldquo;Residents of Delhi continued to breathe polluted air this morning, with little relief despite a gradual rise in temperatures across the national capital. The air quality at Anand Vihar was the worst, recording an Air Quality Index (AQI) of 302 at 9:05 am, falling into the &lsquo;very poor&rsquo; category.&rdquo;</div>
+                        <div class="voice-meta">@uniindianews &middot; 26 February 2026 &middot; <a href="https://x.com/uniindianews/status/2026889311254372676" target="_blank" rel="noopener">view on X</a></div>
+                    </div>
+
+                    <div class="voice-card" style="border-left: 3px solid #000;">
+                        <div class="voice-content">&ldquo;Visuals from the Anand Vihar area as a layer of toxic smog blankets the city. AQI around the area is 390, categorised as &lsquo;Very Poor&rsquo;, as claimed by CPCB.&rdquo;</div>
+                        <div class="voice-meta">@ANI &middot; 27 November 2025 &middot; <a href="https://x.com/ANI/status/1993858762415743445" target="_blank" rel="noopener">view on X</a></div>
+                    </div>
+
+                    <div class="voice-card" style="border-left: 3px solid #000;">
+                        <div class="voice-content">&ldquo;Today morning, Delhi gasped under a thick smog blanket for the 2nd day as AQI hit a staggering 442, marking &lsquo;severe&rsquo; air quality. Anand Vihar &amp; Burari Crossing led with 481 AQI&hellip;&rdquo;</div>
+                        <div class="voice-meta">@weatherindia &middot; 18 December 2024 &middot; <a href="https://x.com/weatherindia/status/1869253793751413043" target="_blank" rel="noopener">view on X</a></div>
+                    </div>
+
+                    <div class="voice-card" style="border-left: 3px solid #000;">
+                        <div class="voice-content">&ldquo;Keeping in view the prevailing trend of #AirQuality, Stage IV of the #GRAP i.e., &lsquo;Severe+ Air Quality&rsquo; (DELHI AQI &gt;450) is invoked today in Delhi NCR and adjoining areas.&rdquo;</div>
+                        <div class="voice-meta">@CPCB_OFFICIAL &middot; 5 November 2023 &middot; the regulator&rsquo;s own emergency declaration &middot; <a href="https://x.com/CPCB_OFFICIAL/status/1721186629413638278" target="_blank" rel="noopener">view on X</a></div>
+                    </div>
+
+                    <p style="font-size: 0.72rem; color: var(--text-3); margin: 0.9rem 0 0;">These are the most recent posts that are findable at all: X stops search engines indexing anything newer, so a post from last week cannot be discovered from outside the platform. The live searches above are the way to see this week. <code>scripts/verify-x-links.py</code> re-checks every link here.</p>
+                </div>
+            </div>
+
             <h3 style="font-family: var(--serif); font-size: 1.25rem; margin-bottom: 1rem; color: var(--ink);">Curated Highlights &amp; Key Moments</h3>
+
+                            <!-- This week — Humayun's Tomb / IIT study -->
+                            <div class="voice-card" style="border-left: 3px solid var(--amber);">
+                                <div class="voice-header">
+                                    <div class="voice-avatar" style="background: #B45309;"></div>
+                                    <div>
+                                        <div class="voice-name">Delhi&rsquo;s Air Is Eating a World Heritage Site</div>
+                                        <div class="voice-handle">IIT Roorkee &amp; IIT Kanpur &middot; Humayun&rsquo;s Tomb, Delhi</div>
+                                    </div>
+                                    <span class="voice-source">Research</span>
+                                </div>
+                                <div class="voice-content">
+                                    A black crust built up over years of polluted air is accelerating the decay of the 16th-century tomb&rsquo;s sandstone. The crust is mostly <strong>gypsum</strong> &mdash; formed when sulphur dioxide in the air reacts with calcium-rich dust and moisture &mdash; and it traps soot, dust and metal particles from vehicles, construction, road dust, biomass burning and industry into a darkening layer. The researchers recommend periodic removal of the crust.
+                                </div>
+                                <div class="voice-meta">3 August 2026 &middot; <em>International Journal of Architectural Heritage</em> &middot; <a href="https://www.tribuneindia.com/news/delhi/air-pollution-accelerating-decay-of-humayuns-tomb-iit-study/" target="_blank" rel="noopener">The Tribune</a> &middot; <a href="https://www.reddit.com/r/delhi/comments/1ve722p/air_pollution_accelerating_decay_of_humayuns_tomb/" target="_blank" rel="noopener">discussed on r/delhi</a></div>
+                            </div>
+
+                            <!-- Delhi's first 'good' air day in nearly three years -->
+                            <div class="voice-card" style="border-left: 3px solid var(--green-700);">
+                                <div class="voice-header">
+                                    <div class="voice-avatar" style="background: #16803C;"></div>
+                                    <div>
+                                        <div class="voice-name">Delhi&rsquo;s First &lsquo;Good&rsquo; Air Day in Nearly Three Years</div>
+                                        <div class="voice-handle">Commission for Air Quality Management &middot; city-wide daily average</div>
+                                    </div>
+                                    <span class="voice-source">Data</span>
+                                </div>
+                                <div class="voice-content">
+                                    On <strong>9 July 2026</strong> Delhi&rsquo;s daily average AQI fell to <strong>48</strong> &mdash; inside the CPCB&rsquo;s &ldquo;good&rdquo; band of 0&ndash;50, and the city&rsquo;s first such day since <strong>10 September 2023</strong>. Monsoon rain did it, by below-cloud scavenging: raindrops catch fine particles and carry them down. It did not last. The average was back to 54 the next day, 99 the day after, and Delhi was reading <em>poor</em> again through early August.
+                                    <br><br>This is exactly why the map keeps annual and seasonal figures apart. One clean day is weather. The year is the air.
+                                </div>
+                                <div class="voice-meta">9&ndash;11 July 2026 &middot; CAQM, via <a href="https://www.wionews.com/india-news/monsoon-magic-delhi-s-aqi-drops-to-48-records-first-good-air-day-of-2026-after-nearly-3-years-1783745628953" target="_blank" rel="noopener">WION</a></div>
+                            </div>
 
                             <!-- Okhla WTE — resident testimony -->
                             <div class="voice-card" style="border-left: 3px solid var(--red);">

--- a/scripts/verify-x-links.py
+++ b/scripts/verify-x-links.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Verify X links without an API key.
+
+publish.twitter.com/oembed is the public embed endpoint: it answers 200 with the
+post's real author and text for a post that exists, and 404 for one that does
+not. Snowflake IDs carry their own creation time, so the date comes off the URL
+itself. Between them, nothing gets published that was not checked.
+"""
+import json, re, ssl, os, sys, time, datetime, urllib.request, urllib.parse
+
+EPOCH = 1288834974657
+proxy = os.environ.get('HTTPS_PROXY')
+h = []
+if proxy: h.append(urllib.request.ProxyHandler({'https': proxy, 'http': proxy}))
+ca = os.environ.get('SSL_CERT_FILE')
+if ca: h.append(urllib.request.HTTPSHandler(context=ssl.create_default_context(cafile=ca)))
+op = urllib.request.build_opener(*h)
+
+def posted_at(url):
+    m = re.search(r'/status/(\d+)', url)
+    if not m: return None
+    return datetime.datetime.fromtimestamp(((int(m.group(1)) >> 22) + EPOCH) / 1000, datetime.timezone.utc)
+
+def verify(url):
+    canon = url.replace('https://x.com/', 'https://twitter.com/').split('?')[0]
+    api = 'https://publish.twitter.com/oembed?url=' + urllib.parse.quote(canon, safe='') + '&omit_script=1&dnt=true'
+    try:
+        with op.open(urllib.request.Request(api, headers={'User-Agent': 'JanVayu/26.6 (+https://janvayu.in)'}), timeout=25) as r:
+            d = json.load(r)
+    except urllib.error.HTTPError as e:
+        return {'url': url, 'ok': False, 'why': f'HTTP {e.code}'}
+    except Exception as e:
+        return {'url': url, 'ok': False, 'why': str(e)[:60]}
+    html_ = d.get('html', '')
+    m = re.search(r'<p[^>]*>(.*?)</p>', html_, re.S)
+    text = re.sub(r'<[^>]+>', '', m.group(1)) if m else ''
+    text = (text.replace('&amp;', '&').replace('&#39;', "'").replace('&quot;', '"')
+                .replace('&gt;', '>').replace('&lt;', '<')).strip()
+    when = posted_at(url)
+    return {'url': d.get('url', url), 'ok': True, 'author': d.get('author_name'),
+            'handle': (d.get('author_url') or '').rsplit('/', 1)[-1],
+            'date': when.strftime('%Y-%m-%d') if when else '', 'text': re.sub(r'\s+', ' ', text)}
+
+if __name__ == '__main__':
+    urls = [l.strip() for l in sys.stdin if l.strip()]
+    out = []
+    for i, u in enumerate(urls):
+        if i: time.sleep(1)
+        r = verify(u)
+        out.append(r)
+        if r['ok']:
+            print(f"OK   {r['date']}  @{r['handle']:16s} {r['text'][:88]}")
+        else:
+            print(f"FAIL {r['why']:10s} {u}")
+    json.dump([r for r in out if r['ok']], open('/tmp/xverified.json', 'w'), indent=1, ensure_ascii=False)


### PR DESCRIPTION
The function only ever served from a Blobs key that a since-retired "Agent-Reach" GitHub Action was meant to fill. Nothing filled it, so `/.netlify/functions/youtube-feed` returned `videos: 0` with no error — silently empty for however long.

It now fetches for itself, by two routes.

## Route 1 — channel RSS, no key, no quota

`https://www.youtube.com/feeds/videos.xml?channel_id=…` is public. Eight channels, each ID resolved from its own page and verified to return a feed:

| Channel | Feed |
|---|---|
| Down To Earth | ✓ |
| NDTV | ✓ |
| India Today | ✓ |
| The Quint | ✓ |
| WION | ✓ |
| Aaj Tak | ✓ |
| Scroll.in | ✓ |
| The Hindu | ✓ |

Exercised against live YouTube: **94 videos parsed across the eight**, every one carrying id, url, thumbnail and date.

## Route 2 — the Data API, only if a key exists

If `YOUTUBE_API_KEY` is set in the environment, the function also *searches*, which reaches channels we never listed — the whole reason it's worth having. The free tier is **10,000 units a day** and a search costs **100**, so three queries per fetch is far inside free. Without a key the route is skipped entirely and route 1 carries the feed.

## The filter earns its place immediately

Titles go through the same expression the Reddit feed uses. NDTV's recent uploads include **"Air India Pilot Dope Test Not Final Yet"** — the exact airline-news trap that filled the Reddit feed — and it is correctly rejected.

## The honest result today is zero

Of those 94 recent videos, **none** are about air quality. That is August: monsoon, and the news channels publish nothing on air for weeks. Zero is returned as zero, with the search links offered instead of padding. It will fill from October, and immediately if a key is added.

## Also fixed

`app.js` read `upload_date` (YYYYMMDD) and `description` — fields the old yt-dlp pipeline produced and channel RSS does not have, so every video would have shown as posted *now* with an empty description. It now reads `published`/`text`, falling back to the old names so a cache written before this change keeps its dates.

## Verification

- All 8 channel feeds fetched live: 200, 94 entries.
- Parser run over real NDTV XML with a permissive filter to prove extraction, not just rejection: 15/15 videos complete with id, url, thumbnail and date.
- Parser run with the shipped filter: 0 matches, correctly, and the airline-news item rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_