### PR TITLE
Stop the AI slop reaching the YouTube feed, and document the API key

### DIFF
--- a/docs/technical/environment-variables.md
+++ b/docs/technical/environment-variables.md
@@ -69,6 +69,39 @@ The free tier is sufficient for the AI features in JanVayu.
 
 ---
 
+## Optional Variables
+
+The site works without these. Each one improves a single feature and nothing breaks if it is absent.
+
+### `YOUTUBE_API_KEY`
+**Used by:** `youtube-feed.js`
+
+Without it, the video feed reads eight Indian news and environment channels' public RSS feeds and keeps the videos whose titles name air quality. That needs no key and no quota, but it can only find coverage from channels we listed, and outside pollution season those channels publish nothing about air for weeks — so the feed is legitimately empty in, say, August.
+
+With it, the function also **searches** YouTube, which reaches channels nobody listed.
+
+**How to get it:**
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and sign in with any Google account.
+2. Create a project (top bar → **New Project**), or pick an existing one.
+3. **APIs & Services → Library**, search for **YouTube Data API v3**, open it, press **Enable**.
+4. **APIs & Services → Credentials → Create Credentials → API key**. Copy the key.
+5. Press **Edit API key** and under **API restrictions** choose **Restrict key** → *YouTube Data API v3*. Leave application restrictions as **None**: Netlify functions have no fixed IP to allow-list. Restricting it to one API means a leaked key can do nothing but read public YouTube data.
+6. In Netlify: **Site configuration → Environment variables → Add a variable**, name `YOUTUBE_API_KEY`, paste the value, then redeploy.
+
+**No card required.** The free quota is **10,000 units a day** and a search costs **100**, so 100 searches a day cost nothing. The function spends 300 units per cache refill — three queries — and the result is cached, so a busy day uses a fraction of a percent of the allowance.
+
+**It is read server-side only.** The key lives in the Netlify function and is never sent to the browser, so it does not need to be public like the WAQI token. Do not put it in `index.html`.
+
+**To confirm it is working**, fetch the function and look at `source`:
+
+```bash
+curl -s https://www.janvayu.in/.netlify/functions/youtube-feed | head -c 200
+```
+
+`"source": "channel-rss"` means no key is set. `"source": "channel-rss + data-api"` means the key is in use.
+
+---
+
 ## Public Key (Not a Secret)
 
 ### WAQI API Token
@@ -91,4 +124,7 @@ NETLIFY_SITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 # AI features (Groq — Llama 3.3 70B)
 GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional: YouTube search for the video feed (free tier, no card)
+YOUTUBE_API_KEY=AIzaSyXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```

--- a/netlify/functions/youtube-feed.js
+++ b/netlify/functions/youtube-feed.js
@@ -125,15 +125,37 @@ async function fromChannels(budgetMs = 7000) {
   return { videos, errors };
 }
 
-// Route 2: the Data API, when a key exists. Search reaches channels we never
-// listed, which is the whole reason it is worth having.
+// Search reaches the whole of YouTube, which is the point of having it and
+// also its problem. Ordered by date it returned, top of the feed, an
+// AI-generated speculation from a channel called "AI GENETATOR" — the title
+// filter checks the subject, not whether anyone made anything. Two changes:
+//
+//   order=relevance inside a recent window, rather than order=date over
+//   everything. Pure recency ranks whatever was uploaded most recently, and
+//   generated video is uploaded constantly. Relevance within the last 90 days
+//   still gives a current feed without handing it to whoever posts most.
+//
+//   A view floor, applied only to search results. videos.list costs 1 unit
+//   against search's 100, so the view count is effectively free to fetch. The
+//   eight listed channels are known publishers and are exempt — this is for
+//   the open web, where a video nobody has watched is usually a video nobody
+//   made.
+const RECENT_DAYS = 90;
+const MIN_VIEWS = 1000;
+
+// Bump when the rules above change, so cached results chosen under the old
+// ones are discarded rather than served for another four hours.
+const FEED_VERSION = 2;
+
 async function fromSearchApi(key, budgetMs = 6000) {
   const videos = [], errors = [];
   const deadline = Date.now() + budgetMs;
+  const since = new Date(Date.now() - RECENT_DAYS * 864e5).toISOString().replace(/\.\d+/, '');
   for (const q of SEARCH_QUERIES) {
     if (Date.now() > deadline) break;
     const url = 'https://www.googleapis.com/youtube/v3/search'
-      + `?part=snippet&type=video&order=date&maxResults=10&regionCode=IN`
+      + `?part=snippet&type=video&order=relevance&maxResults=10&regionCode=IN`
+      + `&publishedAfter=${encodeURIComponent(since)}`
       + `&q=${encodeURIComponent(q)}&key=${encodeURIComponent(key)}`;
     try {
       const data = JSON.parse(await getText(url));
@@ -155,6 +177,32 @@ async function fromSearchApi(key, budgetMs = 6000) {
       errors.push(`search "${q}": ${e.message}`);
     }
   }
+
+  // One videos.list call for the whole batch — 1 unit, up to 50 ids.
+  const ids = videos.map(v => v.videoId).filter(Boolean).slice(0, 50);
+  if (ids.length) {
+    try {
+      const stats = JSON.parse(await getText(
+        'https://www.googleapis.com/youtube/v3/videos?part=statistics&id='
+        + ids.join(',') + '&key=' + encodeURIComponent(key)));
+      const views = {};
+      for (const v of (stats.items || [])) views[v.id] = Number(v.statistics?.viewCount || 0);
+      const before = videos.length;
+      // Unknown view count is kept: a missing statistic is not evidence of
+      // slop, and dropping on absent data would quietly thin the feed.
+      const kept = videos.filter(v => !(v.videoId in views) || views[v.videoId] >= MIN_VIEWS);
+      kept.forEach(v => { v.views = views[v.videoId]; });
+      videos.length = 0;
+      videos.push(...kept);
+      if (before - kept.length) {
+        console.log(`youtube: dropped ${before - kept.length} search result(s) under ${MIN_VIEWS} views`);
+      }
+    } catch (e) {
+      // If statistics fail, keep the unfiltered search results rather than
+      // returning nothing — the title filter has already done the topic work.
+      errors.push(`statistics: ${e.message}`);
+    }
+  }
   return { videos, errors };
 }
 
@@ -173,10 +221,18 @@ exports.handler = async function (event) {
   // Serve from cache when it holds anything, applying the relevance rule on the
   // way out as well: a cache written by an older deploy should not be able to
   // put an unrelated video on the page.
+  //
+  // The version stamp is how a change to the selection rules takes effect
+  // without anyone emptying the cache by hand. Tightening the rules is
+  // pointless if four hours of cached results written under the old ones keep
+  // being served — so a cache stamped with a different version is ignored and
+  // refetched. Bump FEED_VERSION whenever what belongs in this feed changes.
   try {
     const store = getBlobStore('janvayu-feeds');
     const cached = await store.get('youtube', { type: 'json' });
-    const kept = (cached && cached.videos || []).filter(v => ABOUT_AIR.test(v.title || ''));
+    const fresh = cached && cached.feed_version === FEED_VERSION;
+    const kept = (fresh && cached.videos || []).filter(v => ABOUT_AIR.test(v.title || ''));
+    if (!fresh && cached) console.log('youtube: cache written under older rules, refetching');
     if (kept.length > 0) {
       return {
         statusCode: 200, headers,
@@ -220,6 +276,7 @@ exports.handler = async function (event) {
   try {
     const store = getBlobStore('janvayu-feeds');
     await store.setJSON('youtube', {
+      feed_version: FEED_VERSION,
       videos: videos.slice(0, 30), count: videos.length,
       source: key ? 'channel-rss + data-api' : 'channel-rss',
       fetched_at: new Date().toISOString(), seeded_by: 'live-fetch',


### PR DESCRIPTION
The key is set in Netlify and the feed went from **0 videos to 23**, all from the previous two days, from channels that were never in the hardcoded list — Byrnihat, Delhi pollution explainers, air pollution and India's monuments in Tamil. Search earns its place.

It also brought this, at the top of the feed:

> **AI GENETATOR** — *"#pollution in India if we continue like this to 2080"*

The title filter checks the *subject*, not whether anyone actually made anything. On a site whose case is that every figure is checkable, generated speculation leading the Voices panel is corrosive.

## The fix

**`order=relevance` inside a 90-day window**, instead of `order=date` over everything. Pure recency ranks whatever was uploaded most recently, and generated video is uploaded constantly. Relevance within a recent window keeps the feed current without handing it to whoever posts most.

**A view floor of 1,000, on search results only.** `videos.list` costs **1 unit** against search's **100**, so the view count is effectively free — one call for the whole batch. The eight listed channels are known publishers and are exempt; this is for the open web, where a video nobody has watched is usually a video nobody made.

Two deliberate softenings, because a filter that overreaches is worse than none:
- A video whose statistics are **missing** is kept. Absent data is not evidence of slop, and dropping on it would quietly thin the feed.
- If the statistics call **fails entirely**, the unfiltered search results are kept rather than none — the title filter has already done the topic work.

**`FEED_VERSION`, stamped on the cache and checked on read.** Tightening the rules achieves nothing if four hours of results chosen under the old ones keep being served. A cache stamped with a different version is ignored and refetched. Hand-emptying a blob would have fixed today and nothing after it.

## Also — the key is documented now

`YOUTUBE_API_KEY` was read by the code and mentioned in no doc, so the only way to learn it existed was to read the function. `docs/technical/environment-variables.md` gains an **Optional Variables** section: how to get the key, why to restrict it by API rather than by IP (Netlify functions have no fixed address), what the free quota actually allows — 10,000 units a day, 100 per search, 300 spent per cache refill — and a one-line `curl` that tells you whether the key is live from whether `source` reads `channel-rss` or `channel-rss + data-api`.

## How the key was stored

Set through the Netlify API as a **secret**, scoped to `builds` and `functions` only, across all four contexts. Confirmed masked on read — the API returns a 20-character placeholder, not the value. It is read server-side inside the function and never reaches the browser.

## Verification

- Key tested against Google's API **before** wiring it into Netlify, so a failure would have been unambiguous.
- Live function after deploy: `videos: 23 | source: channel-rss + data-api | errors: none`.
- I'll confirm the slop is gone from the live output after this merges, and report the before/after count rather than assuming the filter worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_