### PR TITLE
YouTube results have to be about India; the blog gets a real homepage section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Check stated figures against the data
         run: python3 scripts/check-site-figures.py
 
+      # data/stories.json feeds the homepage's blog section. It used to be
+      # hand-maintained and went six posts stale, so the front page showed
+      # nothing published that month. It is generated from blog/README.md now;
+      # this fails the build if someone publishes a post without regenerating.
+      - name: Check the homepage blog list matches the blog
+        run: python3 scripts/build-blog-index.py --check
+
   # Guard against the class of bug that took the chatbot (air-query) down for
   # ~2 weeks in May 2026: declaring `__dirname`/`__filename` at the top level
   # of a Netlify function. Netlify's esbuild bundler injects its own shims for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.162] - 2026-08-10
+
+### Fixed — the YouTube feed was carrying Canadian wildfire smoke
+
+`regionCode=IN` biases YouTube's ranking; it does not restrict the results. So *"Air Quality Concerns Grow Over Canadian Wildfire Smoke"*, from a five-million-subscriber US channel, passed the topic filter and the subscriber floor alike — right subject, wrong continent.
+
+A search result now has to look Indian, by any one of three signals: the channel's registered country is India; the text names India, an Indian city or state, or something only India has (GRAP, NCAP, CPCB, CAQM, parali); or the text is written in an Indian script, since a Devanagari or Tamil or Gurmukhi title is not about Canada. Any one is enough on purpose — requiring two would drop the BBC's India coverage, filed from an account registered elsewhere. Replayed against the live feed: **one dropped, twelve kept**, and the one was the wildfire piece.
+
+The channel's country comes from the `channels.list` call that was already being made for subscriber counts, so this costs nothing.
+
+### Fixed — the blog was barely on the homepage
+
+The whole of the front page's blog presence was one rotating card, drawn from a hand-maintained list of nine posts whose newest was 30 July. Six posts had been published in August, including three the day before. None of them could appear.
+
+`scripts/build-blog-index.py` generates the list from `blog/README.md` — the blog's own index — pulling a blurb from each post's first real paragraph. **9 posts → 34**, newest first, so publishing a post is now enough to put it on the front page.
+
+The homepage shows the **newest** post as the featured card rather than a weekly rotation — a rotation made sense when the list was short and evergreen, and merely hid new work once the blog started publishing several a week — followed by the next three in a row beneath it, and a link reading "Read all 34 posts". `guard-site-figures` in CI now also fails the build if a post is published without regenerating the list.
+
 ## [v26.6.161] - 2026-08-09
 
 ### Fixed — figures that had drifted, and something to stop them drifting again

--- a/data/stories.json
+++ b/data/stories.json
@@ -1,59 +1,242 @@
 {
-  "note": "Featured blog posts rotated weekly on the dashboard 'Story of the week' card. Ordered newest-ish first; rotation is deterministic by ISO week so it changes without a deploy. Edit freely.",
-  "stories": [
-    {
-      "title": "The Air Your MP Answers For",
-      "blurb": "The ward map grew from 15 to 39 cities, and the live map can now colour all 543 Lok Sabha constituencies by the air their voters breathe — plus the landfills, coal mines and red-category industrial parks upwind.",
-      "tag": "Product",
-      "url": "/blog/#/posts/2026-07-30-the-air-your-mp-answers-for"
-    },
-    {
-      "title": "We Fact-Checked Our Own Site — and Changed 33 Numbers",
-      "blurb": "We turned our own scrutiny on ourselves: a site-wide audit of every statistic against current primary sources. Here's what was wrong, and how we now check every week.",
-      "tag": "Transparency",
-      "url": "/blog/#/posts/2026-07-17-we-factchecked-ourselves"
-    },
-    {
-      "title": "The Pollution You Can't See Being Emitted",
-      "blurb": "Up to 42% of India's PM2.5 isn't emitted directly — it forms in the sky from gases like SO₂. Dust-first clean-air spending misses most of it.",
-      "tag": "Data",
-      "url": "/blog/#/posts/2026-07-08-secondary-pm25"
-    },
-    {
-      "title": "NCAP at the Finish Line: Has It Worked?",
-      "blurb": "The National Clean Air Programme's deadline has elapsed. We follow the promises and the money to see which cities delivered — and which moved backwards.",
-      "tag": "Policy",
-      "url": "/blog/#/posts/2026-04-05-ncap-deadline"
-    },
-    {
-      "title": "The $339 Billion Question: What Pollution Costs India",
-      "blurb": "Dirty air isn't only a health story — it's an economic one. Lost workdays, lower yields, and a bill worth about 9.5% of GDP.",
-      "tag": "Economics",
-      "url": "/blog/#/posts/2026-03-25-economic-cost"
-    },
-    {
-      "title": "India's Children Are Paying the Price",
-      "blurb": "Smaller lungs, higher exposure, developing brains. Why children carry a disproportionate share of the air-pollution burden.",
-      "tag": "Health",
-      "url": "/blog/#/posts/2026-04-01-children-air-pollution"
-    },
-    {
-      "title": "How Farmers Outsmart Satellites: The Stubble-Burning Shell Game",
-      "blurb": "Fire counts fell — but so did the satellites' ability to see them. A look at what the overpass-timing shift hides.",
-      "tag": "Investigation",
-      "url": "/blog/#/posts/2026-03-28-stubble-burning-satellites"
-    },
-    {
-      "title": "A City Is Not One Number: Mapping India's Air Ward by Ward",
-      "blurb": "Your city's headline AQI hides enormous variation. We map fine-particle pollution down to the municipal ward.",
-      "tag": "Data",
-      "url": "/blog/#/posts/2026-06-10-how-polluted-is-your-ward"
-    },
-    {
-      "title": "The Lancet's Causal Evidence: 1.5 Million Deaths",
-      "blurb": "Correlation isn't causation — until it is. How Jaganathan et al. 2024 established a causal link between PM2.5 and mortality in India.",
-      "tag": "Research",
-      "url": "/blog/#/posts/2026-04-08-lancet-causal-evidence"
-    }
-  ]
+ "stories": [
+  {
+   "tag": "Essay",
+   "title": "What the Air Looks Like",
+   "date": "9 Aug 2026",
+   "blurb": "Everything else on this site is a number. Thirty-one photographs are not, and it is worth saying why they are here.",
+   "url": "/blog/#/posts/2026-08-09-what-the-air-looks-like"
+  },
+  {
+   "tag": "Guide",
+   "title": "How to Read the JanVayu Map",
+   "date": "9 Aug 2026",
+   "blurb": "The map now holds a number for every place in India. Not every city — every place: all 983,149 administrative areas the country is divided into, from the 36 states down to the 584,615 villages, and every gram panchayat, block, district,…",
+   "url": "/blog/#/posts/2026-08-09-how-to-read-the-map"
+  },
+  {
+   "tag": "Explainer",
+   "title": "Why We Lead With PM2.5, Not AQI",
+   "date": "9 Aug 2026",
+   "blurb": "At a conference last week, a reader made a point worth acting on: our headline figures often led with AQI, when PM2.5 is the measure that carries the health consequences.",
+   "url": "/blog/#/posts/2026-08-09-why-pm25-not-aqi"
+  },
+  {
+   "tag": "Analysis",
+   "title": "We Were Measuring the Wrong Green",
+   "date": "8 Aug 2026",
+   "blurb": "Earlier today we published a result that bothered us. We had put surface temperature on all 70,417 of India's municipal wards, and green cover alongside it, and the two barely moved together: a national correlation of −0.07.",
+   "url": "/blog/#/posts/2026-08-08-tree-cover-answers-it"
+  },
+  {
+   "tag": "Analysis",
+   "title": "Surface Heat on Every Ward in India — and What It Showed",
+   "date": "8 Aug 2026",
+   "blurb": "The map has a new Colour menu. Alongside annual air, you can now shade any boundary by surface heat, and — for wards — by green cover and built-up share.",
+   "url": "/blog/#/posts/2026-08-08-heat-on-every-ward"
+  },
+  {
+   "tag": "Product",
+   "title": "One Map, Every Boundary in India",
+   "date": "8 Aug 2026",
+   "blurb": "Until yesterday, finding out how polluted your neighbourhood is meant knowing something you shouldn't have to know: whether the place you live is officially a ward or a village.",
+   "url": "/blog/#/posts/2026-08-08-one-map-every-boundary"
+  },
+  {
+   "tag": "Analysis",
+   "title": "Agartala Breathes Like the Coal Belt, and Nobody Was Looking",
+   "date": "7 Aug 2026",
+   "blurb": "India's Northeast is usually described in one breath: hills, forest, clean air. For most of the region that is simply true.",
+   "url": "/blog/#/posts/2026-08-07-agartala-northeast-outlier"
+  },
+  {
+   "tag": "Product",
+   "title": "Every Capital, and the Directory We Never Read",
+   "date": "7 Aug 2026",
+   "blurb": "This morning we published a post saying West Bengal's municipal wards were not openly available.",
+   "url": "/blog/#/posts/2026-08-07-every-capital-and-the-directory"
+  },
+  {
+   "tag": "Product",
+   "title": "Ninety Cities, Ward by Ward — and the One We Had to Go Somewhere Else For",
+   "date": "7 Aug 2026",
+   "blurb": "If you live in an Indian city, the number you see on the news is a city average. It is one figure standing in for a few million people, and it hides the thing you actually want to know: whether your neighbourhood breathes worse than the…",
+   "url": "/blog/#/posts/2026-08-07-ninety-cities-ward-by-ward"
+  },
+  {
+   "tag": "Product",
+   "title": "Every Village in India Is Now on the Map — Including the Ones No One Measures",
+   "date": "5 Aug 2026",
+   "blurb": "India's air pollution story is told almost entirely through its cities. Delhi in November.",
+   "url": "/blog/#/posts/2026-08-05-every-village-on-the-map"
+  },
+  {
+   "tag": "Product",
+   "title": "The Air Your MP Answers For: Our Maps Now Cover 39 Cities, 543 Constituencies, and the Places the Smoke Starts",
+   "date": "30 Jul 2026",
+   "blurb": "Until this week, our ward map could show you fifteen cities. If you lived in Patna, Ludhiana, Ghaziabad or Indore — some of the most polluted places in the country — the answer to \"how bad is my ward?\" was: we don't have the boundaries.",
+   "url": "/blog/#/posts/2026-07-30-the-air-your-mp-answers-for"
+  },
+  {
+   "tag": "Quality",
+   "title": "Testing the Chatbot to Make It Reliable",
+   "date": "22 Jul 2026",
+   "blurb": "These days we ask chatbots almost everything. Sometimes we ask them things that really matter — like whether the air outside is safe to breathe.",
+   "url": "/blog/#/posts/2026-07-22-testing-ask-janvayu"
+  },
+  {
+   "tag": "Community",
+   "title": "You Don't Need to Code to Make India's Air Data Better",
+   "date": "18 Jul 2026",
+   "blurb": "People assume there are only two ways to help a project like JanVayu: write code, or send money.",
+   "url": "/blog/#/posts/2026-07-18-how-to-contribute"
+  },
+  {
+   "tag": "Culture",
+   "title": "Why JanVayu's Mascot Is a Sparrow",
+   "date": "18 Jul 2026",
+   "blurb": "Meet Vayu Gauraiya — vayu, the air; gauraiya, the house sparrow. She's the face of Ask JanVayu, our chatbot — the little watchful friend who greets you when you come with a question.",
+   "url": "/blog/#/posts/2026-07-18-why-our-mascot-is-a-sparrow"
+  },
+  {
+   "tag": "Platform",
+   "title": "The Robots That Keep JanVayu Honest: How Routines Maintain the Platform",
+   "date": "18 Jul 2026",
+   "blurb": "A platform that holds others accountable with numbers has no business letting its own numbers rot.",
+   "url": "/blog/#/posts/2026-07-18-routines-that-keep-janvayu-honest"
+  },
+  {
+   "tag": "Data integrity",
+   "title": "We Fact-Checked Our Own Site — and Changed 33 Numbers",
+   "date": "17 Jul 2026",
+   "blurb": "JanVayu exists to hold others accountable with numbers. So the numbers had better be right.",
+   "url": "/blog/#/posts/2026-07-17-we-factchecked-ourselves"
+  },
+  {
+   "tag": "Platform",
+   "title": "A Working Language Switcher, an Accessibility Sweep, and a Much Lighter Site",
+   "date": "15 Jul 2026",
+   "blurb": "This week's releases (v26.6.58 to v26.6.71) were less about new panels and more about the plumbing: making what already exists work properly, load faster, and reach more people.",
+   "url": "/blog/#/posts/2026-07-15-multilingual-accessibility-lighter"
+  },
+  {
+   "tag": "Product",
+   "title": "What Shipped This Week: Forecasts, Fire Maps, and Pollution Beyond the Lungs",
+   "date": "14 Jul 2026",
+   "blurb": "We shipped five releases over the past few days (v26.6.43 to v26.6.47). Here is what changed and why it is useful.",
+   "url": "/blog/#/posts/2026-07-14-forecast-fire-and-beyond-the-lungs"
+  },
+  {
+   "tag": "Data",
+   "title": "The Pollution You Can't See Being Emitted: Up to 42% of India's PM2.5 Is Made in the Sky",
+   "date": "8 Jul 2026",
+   "blurb": "When we picture air pollution, we picture a source: a truck's exhaust, a brick kiln's chimney, a field of burning stubble, a cloud of construction dust.",
+   "url": "/blog/#/posts/2026-07-08-secondary-pm25"
+  },
+  {
+   "tag": "Research",
+   "title": "The Citation That Didn't Exist: How We Found \"Krishna et al.\" Was Really Jaganathan",
+   "date": "2 Jul 2026",
+   "blurb": "An accountability platform lives or dies by its citations. If we ask the public to trust a number — 1.72 million deaths a year, a +10 µg/m³ rise causing 8.6% more all-cause mortality — we owe them a source they can open, read, and check.",
+   "url": "/blog/#/posts/2026-07-02-citation-integrity"
+  },
+  {
+   "tag": "Product",
+   "title": "Ask JanVayu Can Now Answer About Your Ward",
+   "date": "25 Jun 2026",
+   "blurb": "When we built the Ward Atlas — a map of every municipal ward across 14 cities, coloured by air, heat, green cover and built-up area — it lived only on the map.",
+   "url": "/blog/#/posts/2026-06-25-ask-janvayu-knows-your-ward"
+  },
+  {
+   "tag": "Data",
+   "title": "Live vs Annual: The Honest Version of \"How Polluted Is Your Ward?\"",
+   "date": "11 Jun 2026",
+   "blurb": "When we built the Ward Atlas — a map that colours every municipal ward of a city by its air, heat, green cover and built-up area — we ran into a question that's easy to get wrong, and that a lot of dashboards do get wrong.",
+   "url": "/blog/#/posts/2026-06-11-live-vs-annual-honest-ward-data"
+  },
+  {
+   "tag": "Data",
+   "title": "A City Is Not One Number: Mapping India's Air Ward by Ward",
+   "date": "10 Jun 2026",
+   "blurb": "When the news says \"Delhi AQI is 320,\" it hides something important: there is no single Delhi.",
+   "url": "/blog/#/posts/2026-06-10-how-polluted-is-your-ward"
+  },
+  {
+   "tag": "Health",
+   "title": "The Same Sun, a Different City: Why Your Neighbourhood's Heat Is an Air-Quality Story",
+   "date": "10 Jun 2026",
+   "blurb": "On a peak summer afternoon, a CSE satellite thermal survey of Delhi recorded land-surface temperatures reaching nearly 61°C in its most built-up, treeless zones while tree-covered areas like Lutyens' Delhi and the Yamuna floodplain…",
+   "url": "/blog/#/posts/2026-06-10-urban-heat-island"
+  },
+  {
+   "tag": "Platform",
+   "title": "Quality You Can Measure: Lighthouse, axe, Lazy-Loading, Mobile",
+   "date": "8 May 2026",
+   "blurb": "The same day we shipped six Learning Games and refreshed the May 2026 data, we did a quieter but arguably more important thing: we made the platform's quality measurable on every PR.",
+   "url": "/blog/#/posts/2026-05-08-quality-and-performance"
+  },
+  {
+   "tag": "Platform",
+   "title": "Six Learning Games: Jeopardy, Quiz, Source Matcher, Snakes & Ladders, Jodi Match, Tambola",
+   "date": "8 May 2026",
+   "blurb": "We have shipped a self-paced Learning Games panel — six short games, all original, designed for classrooms, RWA meetings, family movie nights, and idle ten-minute browsing on a phone.",
+   "url": "/blog/#/posts/2026-05-08-learning-games"
+  },
+  {
+   "tag": "Data",
+   "title": "Data Refresh, May 2026: Latest Numbers, Updated Hero",
+   "date": "6 May 2026",
+   "blurb": "We try to publish the source-of-truth dataset for India's air quality crisis. That only works if we keep the front-of-site numbers current.",
+   "url": "/blog/#/posts/2026-05-06-data-corrections-may"
+  },
+  {
+   "tag": "Platform",
+   "title": "What's New: Cigarette Equivalence, City Rankings, Community Sensors, Workshops",
+   "date": "26 Apr 2026",
+   "blurb": "JanVayu shipped its largest single update since launch this week. Here is what changed, why, and what each piece is for.",
+   "url": "/blog/#/posts/2026-04-26-shipped-this-week"
+  },
+  {
+   "tag": "Data",
+   "title": "IQAir 2025: India's Air Got Worse",
+   "date": "12 Apr 2026",
+   "blurb": "On March 24, 2026, IQAir released its eighth annual World Air Quality Report — the most comprehensive global assessment of PM2.5 pollution, covering 9,446 cities across 143 countries.",
+   "url": "/blog/#/posts/2026-04-12-iqair-2025-india"
+  },
+  {
+   "tag": "Research",
+   "title": "The Lancet's Causal Evidence: 1.5 Million Deaths (Jaganathan et al. 2024)",
+   "date": "8 Apr 2026",
+   "blurb": "For years, the relationship between air pollution and death in India has been described in the language of association.",
+   "url": "/blog/#/posts/2026-04-08-lancet-causal-evidence"
+  },
+  {
+   "tag": "Policy",
+   "title": "NCAP at the Finish Line: Has India's Clean Air Programme Worked?",
+   "date": "5 Apr 2026",
+   "blurb": "In January 2019, India launched the National Clean Air Programme with a promise: reduce particulate matter concentrations by 20 to 30 percent across 131 cities by 2024, later revised to 40 percent by 2025-26.",
+   "url": "/blog/#/posts/2026-04-05-ncap-deadline"
+  },
+  {
+   "tag": "Health",
+   "title": "India's Children Are Paying the Price",
+   "date": "1 Apr 2026",
+   "blurb": "Air pollution in India is not an abstract environmental problem. It is a child health emergency.",
+   "url": "/blog/#/posts/2026-04-01-children-air-pollution"
+  },
+  {
+   "tag": "Investigation",
+   "title": "How Farmers Outsmart Satellites: The Stubble Burning Shell Game",
+   "date": "28 Mar 2026",
+   "blurb": "Every October, as the kharif paddy harvest ends across Punjab and Haryana, a familiar ritual begins.",
+   "url": "/blog/#/posts/2026-03-28-stubble-burning-satellites"
+  },
+  {
+   "tag": "Economics",
+   "title": "The $339 Billion Question: What Pollution Costs India",
+   "date": "25 Mar 2026",
+   "blurb": "India's air pollution crisis is usually framed as a health emergency. It is that.",
+   "url": "/blog/#/posts/2026-03-25-economic-cost"
+  }
+ ]
 }

--- a/index.html
+++ b/index.html
@@ -783,6 +783,22 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
 @media (prefers-color-scheme: dark) { .story-week-card.featured { background: var(--bg-card); } }
 @media (max-width: 600px) { .story-week-card.featured { padding: 1.2rem 1.15rem; } }
 
+/* ── "From the blog" — the three most recent posts beside the featured one.
+   The blog had one rotating card on the whole homepage, drawn from a
+   hand-maintained list that had gone six posts stale, so the front page never
+   showed anything published this month. This row is generated from the blog's
+   own index, newest first. ── */
+.blog-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; margin-top: 0.75rem; }
+.blog-mini { display: block; text-decoration: none; border: 1px solid var(--border); border-radius: 0.6rem; padding: 0.85rem 1rem; background: var(--bg-card); transition: box-shadow 0.15s, transform 0.15s; }
+.blog-mini:hover { box-shadow: 0 5px 16px rgba(0,0,0,0.07); transform: translateY(-1px); }
+.blog-mini-tag { display: block; font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--green-700); margin-bottom: 0.35rem; }
+.blog-mini-title { display: block; font-family: var(--serif, Georgia, serif); font-size: 0.98rem; line-height: 1.3; color: var(--ink); margin-bottom: 0.3rem; }
+.blog-mini-date { display: block; font-size: 0.72rem; color: var(--text-3); }
+.blog-all { display: inline-block; margin-top: 0.85rem; font-size: 0.88rem; font-weight: 600; color: var(--green-700); text-decoration: none; }
+.blog-all:hover { text-decoration: underline; }
+@media (max-width: 860px) { .blog-row { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .blog-row { grid-template-columns: 1fr; } }
+
 /* ── Searchable city combobox ── */
 .city-combo { position: relative; flex: 1; min-width: 0; }
 .city-combo-input { width: 100%; box-sizing: border-box; font-family: var(--sans); font-size: 0.72rem; font-weight: 600; background: var(--bg-section); color: var(--ink); border: 1px solid var(--border); border-radius: 6px; padding: 5px 8px 5px 26px; cursor: text; text-align: left; }
@@ -1535,6 +1551,8 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                     <span class="story-week-blurb" id="story-week-blurb"></span>
                     <span class="story-week-cta">Read the story <span aria-hidden="true">&rarr;</span></span>
                 </a>
+                <div class="blog-row" id="blog-latest-row" hidden></div>
+                <a class="blog-all" id="blog-all-link" href="/blog/" hidden>Read every post on the JanVayu blog <span aria-hidden="true">&rarr;</span></a>
 
                 <!-- How JanVayu works — system diagram -->
                 <div class="dash-section">
@@ -6928,7 +6946,10 @@ window.handleWorkshopSubmit = async function (event, kind) {
                 var now = new Date();
                 var start = new Date(now.getFullYear(), 0, 1);
                 var week = Math.floor((now - start) / (7 * 24 * 60 * 60 * 1000));
-                var s = list[((week % list.length) + list.length) % list.length];
+                // The newest post is the featured one. A weekly rotation made
+                // sense when the list was short and evergreen; with the blog
+                // publishing several a week it just hid the new work.
+                var s = list[0];
                 var tag = document.getElementById('story-week-tag');
                 var title = document.getElementById('story-week-title');
                 var blurb = document.getElementById('story-week-blurb');
@@ -6937,6 +6958,28 @@ window.handleWorkshopSubmit = async function (event, kind) {
                 if (blurb) blurb.textContent = s.blurb || '';
                 if (s.url) card.setAttribute('href', s.url);
                 card.hidden = false;
+
+                // The next three, so the front page shows the blog is alive
+                // rather than showing one post and hoping.
+                var row = document.getElementById('blog-latest-row');
+                var all = document.getElementById('blog-all-link');
+                if (row && list.length > 1) {
+                    row.innerHTML = list.slice(1, 4).map(function (b) {
+                        var esc = function (x) {
+                            return String(x || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                        };
+                        return '<a class="blog-mini" href="' + esc(b.url) + '">'
+                            + '<span class="blog-mini-tag">' + esc(b.tag || 'Blog') + '</span>'
+                            + '<span class="blog-mini-title">' + esc(b.title) + '</span>'
+                            + '<span class="blog-mini-date">' + esc(b.date || '') + '</span>'
+                            + '</a>';
+                    }).join('');
+                    row.hidden = false;
+                }
+                if (all) {
+                    all.textContent = 'Read all ' + list.length + ' posts on the JanVayu blog \u2192';
+                    all.hidden = false;
+                }
             })
             .catch(function() { /* stories.json unavailable — card stays hidden */ });
     })();

--- a/netlify/functions/youtube-feed.js
+++ b/netlify/functions/youtube-feed.js
@@ -154,9 +154,43 @@ const RECENT_DAYS = 90;
 const MIN_VIEWS = 20000;      // a video that travelled on its own
 const MIN_SUBSCRIBERS = 5000; // or a channel that is somebody
 
+// …and it has to be about India. `regionCode=IN` biases the ranking, it does
+// not restrict the results, so "Air Quality Concerns Grow Over Canadian
+// Wildfire Smoke" from a five-million-subscriber US channel passed the topic
+// filter and the subscriber floor alike: right subject, wrong continent.
+//
+// Three signals, any one of which is enough:
+//   · the channel's registered country is India;
+//   · the text names India, an Indian city or state, or something only India
+//     has — GRAP, NCAP, CPCB, CAQM, parali;
+//   · the text is written in an Indian script. A Devanagari or Tamil or
+//     Gurmukhi title is not about Canada.
+// Any one passing is deliberate. Requiring two would drop the BBC's India
+// coverage, which is filed from an account registered elsewhere.
+const INDIA_TERMS = new RegExp([
+  'india', 'indian', 'bharat', 'delhi', '\\bncr\\b', 'noida', 'gurgaon', 'gurugram', 'ghaziabad',
+  'faridabad', 'mumbai', 'kolkata', 'chennai', 'bengaluru', 'bangalore', 'hyderabad', 'pune',
+  'ahmedabad', 'lucknow', 'kanpur', 'patna', 'jaipur', 'indore', 'bhopal', 'nagpur', 'surat',
+  'varanasi', 'agra', 'ludhiana', 'amritsar', 'chandigarh', 'dehradun', 'ranchi', 'raipur',
+  'bhubaneswar', 'guwahati', 'shillong', 'byrnihat', 'srinagar', 'kochi', 'coimbatore',
+  'visakhapatnam', 'punjab', 'haryana', 'rajasthan', 'gujarat', 'maharashtra', 'bihar',
+  'jharkhand', 'odisha', 'assam', 'meghalaya', 'kerala', 'karnataka', 'telangana',
+  'uttar pradesh', 'madhya pradesh', 'tamil nadu', 'west bengal',
+  'cpcb', 'caqm', '\\bgrap\\b', '\\bncap\\b', 'parali', 'stubble', 'diwali', 'monsoon',
+].join('|'), 'i');
+
+// Devanagari, Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada, Malayalam.
+const INDIC_SCRIPT = /[ऀ-ൿ]/;
+
+function aboutIndia(v, channelCountry) {
+  if (channelCountry === 'IN') return true;
+  const text = `${v.title || ''} ${v.channel || ''} ${v.text || ''}`;
+  return INDIA_TERMS.test(text) || INDIC_SCRIPT.test(text);
+}
+
 // Bump when the rules above change, so cached results chosen under the old
 // ones are discarded rather than served for another four hours.
-const FEED_VERSION = 3;
+const FEED_VERSION = 4;
 
 async function fromSearchApi(key, budgetMs = 6000) {
   const videos = [], errors = [];
@@ -200,32 +234,48 @@ async function fromSearchApi(key, budgetMs = 6000) {
         (async () => {
           const chIds = [...new Set(videos.map(v => v.channelId).filter(Boolean))].slice(0, 50);
           if (!chIds.length) return { items: [] };
+          // snippet as well as statistics: it carries the channel's country,
+          // which is the cheapest reliable "is this India" signal there is.
           return JSON.parse(await getText(
-            'https://www.googleapis.com/youtube/v3/channels?part=statistics&id='
+            'https://www.googleapis.com/youtube/v3/channels?part=statistics,snippet&id='
             + chIds.join(',') + '&key=' + encodeURIComponent(key)));
         })(),
       ]);
 
-      const views = {}, subs = {};
+      const views = {}, subs = {}, country = {};
       for (const v of (vidStats.items || [])) views[v.id] = Number(v.statistics?.viewCount || 0);
-      for (const c of (chStats.items || [])) subs[c.id] = Number(c.statistics?.subscriberCount || 0);
+      for (const c of (chStats.items || [])) {
+        subs[c.id] = Number(c.statistics?.subscriberCount || 0);
+        country[c.id] = c.snippet?.country || '';
+      }
 
       const before = videos.length;
-      // Kept if the channel is established OR the video travelled on its own.
-      // Missing data counts as a pass either way: absent statistics are not
-      // evidence of slop, and dropping on them would thin the feed silently.
+      const dropped = { small: 0, foreign: 0 };
       const kept = videos.filter(v => {
+        // Is it about India? regionCode only biases the ranking, it does not
+        // restrict it, so a US channel on Canadian wildfire smoke passed every
+        // other test — right subject, wrong continent.
+        if (!aboutIndia(v, country[v.channelId])) { dropped.foreign++; return false; }
+        // Established channel, or a video that travelled on its own. Missing
+        // data passes either test: absent statistics are not evidence of slop,
+        // and dropping on them would thin the feed silently.
         const s = v.channelId in subs ? subs[v.channelId] : null;
         const w = v.videoId in views ? views[v.videoId] : null;
         if (s === null && w === null) return true;
-        return (s !== null && s >= MIN_SUBSCRIBERS) || (w !== null && w >= MIN_VIEWS);
+        if ((s !== null && s >= MIN_SUBSCRIBERS) || (w !== null && w >= MIN_VIEWS)) return true;
+        dropped.small++;
+        return false;
       });
-      kept.forEach(v => { v.views = views[v.videoId]; v.channelSubscribers = subs[v.channelId]; });
+      kept.forEach(v => {
+        v.views = views[v.videoId];
+        v.channelSubscribers = subs[v.channelId];
+        v.channelCountry = country[v.channelId] || undefined;
+      });
       videos.length = 0;
       videos.push(...kept);
       if (before - kept.length) {
-        console.log(`youtube: dropped ${before - kept.length} of ${before} search result(s) — `
-          + `channel under ${MIN_SUBSCRIBERS} subscribers and video under ${MIN_VIEWS} views`);
+        console.log(`youtube: kept ${kept.length} of ${before} search result(s) — `
+          + `dropped ${dropped.foreign} not about India, ${dropped.small} too small`);
       }
     } catch (e) {
       // If the statistics fail, keep the unfiltered search results rather than

--- a/scripts/build-blog-index.py
+++ b/scripts/build-blog-index.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate the homepage's blog data from the blog itself.
+
+`data/stories.json` was hand-maintained, so it drifted: nine posts, the newest
+from 30 July, while six had been published in August. The homepage's "story of
+the week" was rotating through a rotation that no longer contained this week.
+
+The blog's own index table in `blog/README.md` already carries the date, title,
+path and topic of every post. This reads it, pulls a blurb from the first real
+paragraph of each post, and writes the file the homepage reads — so publishing
+a post is enough to put it on the front page.
+
+    python3 scripts/build-blog-index.py            # write data/stories.json
+    python3 scripts/build-blog-index.py --check    # fail if it is out of date
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / 'blog' / 'README.md'
+OUT = ROOT / 'data' / 'stories.json'
+
+ROW = re.compile(r'^\|\s*(\d{1,2}\s+\w+\s+\d{4})\s*\|\s*\[([^\]]+)\]\(([^)]+)\)\s*\|\s*([^|]*?)\s*\|', re.M)
+MONTHS = {m: i for i, m in enumerate(
+    ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'], 1)}
+
+
+def sort_key(date_text):
+    """'9 Aug 2026' -> (2026, 8, 9), so the newest sorts first."""
+    m = re.match(r'(\d{1,2})\s+(\w{3})\w*\s+(\d{4})', date_text)
+    if not m:
+        return (0, 0, 0)
+    return (int(m.group(3)), MONTHS.get(m.group(2)[:3], 0), int(m.group(1)))
+
+
+def blurb_for(rel_path):
+    """The first paragraph that is prose, not a heading, byline, rule or figure."""
+    p = ROOT / 'blog' / rel_path
+    if not p.exists():
+        return ''
+    for raw in p.read_text(encoding='utf-8').split('\n\n'):
+        line = raw.strip()
+        if (not line or line.startswith(('#', '---', '<', '|', '!', '>', '*Published'))
+                or line.startswith('**Published:')):
+            continue
+        text = re.sub(r'<[^>]+>', '', line)
+        text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)      # links -> their text
+        text = re.sub(r'[*_`]', '', text).replace('\n', ' ').strip()
+        if len(text) < 40:
+            continue
+        # One sentence is enough for a card; two if the first is very short.
+        parts = re.split(r'(?<=[.!?])\s+', text)
+        out = parts[0]
+        if len(out) < 90 and len(parts) > 1:
+            out += ' ' + parts[1]
+        return out if len(out) <= 240 else out[:237].rsplit(' ', 1)[0] + '…'
+    return ''
+
+
+def build():
+    rows = ROW.findall(INDEX.read_text(encoding='utf-8'))
+    if not rows:
+        raise SystemExit('No post rows found in blog/README.md — has the table format changed?')
+    stories = []
+    for date_text, title, path, topic in rows:
+        slug = path.replace('posts/', '').replace('.md', '')
+        stories.append({
+            'tag': topic.strip() or 'Blog',
+            'title': title.strip(),
+            'date': date_text.strip(),
+            'blurb': blurb_for(path),
+            'url': f'/blog/#/posts/{slug}',
+        })
+    stories.sort(key=lambda s: sort_key(s['date']), reverse=True)
+    return {'stories': stories}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--check', action='store_true', help='exit 1 if the file is out of date')
+    args = ap.parse_args()
+
+    data = build()
+    text = json.dumps(data, ensure_ascii=False, indent=1) + '\n'
+
+    if args.check:
+        current = OUT.read_text(encoding='utf-8') if OUT.exists() else ''
+        if current != text:
+            print(f'{OUT.relative_to(ROOT)} is out of date — run scripts/build-blog-index.py')
+            return 1
+        print(f'{OUT.relative_to(ROOT)} matches the blog index ({len(data["stories"])} posts).')
+        return 0
+
+    OUT.write_text(text, encoding='utf-8')
+    print(f'{len(data["stories"])} posts -> {OUT.relative_to(ROOT)}')
+    for s in data['stories'][:3]:
+        print(f'  {s["date"]:>12s}  {s["tag"]:14s} {s["title"][:52]}')
+    missing = [s['title'] for s in data['stories'] if not s['blurb']]
+    if missing:
+        print(f'  no blurb found for {len(missing)}: {", ".join(missing[:3])}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## The feed was carrying Canadian wildfire smoke

`regionCode=IN` biases YouTube's ranking — it does not restrict the results. So this passed the topic filter *and* the subscriber floor:

> **TODAY** (5,080,000 subscribers, US) — *"Air Quality Concerns Grow Over Canadian Wildfire Smoke"*

Right subject, wrong continent.

A search result now has to look Indian, by **any one** of three signals:

- the channel's **registered country** is India;
- the text names India, an Indian city or state, or something only India has — **GRAP, NCAP, CPCB, CAQM, parali**;
- the text is in an **Indian script**. A Devanagari, Tamil or Gurmukhi title is not about Canada.

Any one is enough on purpose. Requiring two would drop the BBC's India coverage, which is filed from an account registered elsewhere.

Replayed against the live feed as it stands: **1 dropped, 12 kept** — and the one was the wildfire piece. The channel's country arrives in the `channels.list` call already being made for subscriber counts, so this costs nothing extra.

## The blog was barely on the homepage

The front page's entire blog presence was **one rotating card**, fed by a hand-maintained list of nine posts whose newest was **30 July**. Six posts had gone up in August — three of them the previous day — and none of them could appear, because they weren't in the list.

`scripts/build-blog-index.py` generates the list from `blog/README.md`, the blog's own index, pulling a blurb from each post's first real paragraph. **9 posts → 34**, newest first. Publishing a post is now enough to put it on the front page.

The homepage now shows:

- the **newest** post as the featured card — a weekly rotation suited a short evergreen list, and merely hid new work once the blog started publishing several a week;
- **the next three** in a row beneath it, so the front page shows the blog is alive rather than showing one post and hoping;
- **"Read all 34 posts on the JanVayu blog →"**.

CI gains `build-blog-index.py --check`, so publishing a post without regenerating the list fails the build — the same treatment as the figures checker, and for the same reason: this drifted silently for six posts and nobody saw it.

## Verification

- India rule replayed in Node against the 13 videos the live feed is serving right now: 12 kept, the wildfire piece dropped, nothing else touched.
- Homepage checked in a real browser: featured card reads *"What the Air Looks Like"* linking to the right post, three minis beneath (`How to Read the JanVayu Map`, `Why We Lead With PM2.5`, `We Were Measuring the Wrong Green`), link reads "Read all 34 posts", no page errors, no horizontal overflow at 390px.
- Both `--check` guards pass locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_