### PR TITLE
The social card advertised X, not YouTube — and one of its links was dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.163] - 2026-08-10
+
+### Fixed — the social card advertised X and not YouTube, and one of its links was dead
+
+The homepage card read **"Live from Reddit & X"**. X has not been readable since its API closed — it was removed from the Voices panel days ago — while YouTube search, now working on a key, was not mentioned at all. The card now reads **"Live from Reddit, YouTube & news"**, which is what actually runs.
+
+Three more faults surfaced from looking at the same card properly:
+
+- **A dead link on the live site.** The curated X list offered `@ABOROMOHANTY (CSE)` for Anumita Roychowdhury. That handle **404s**. Her account is [@AnumitaRoychowd](https://x.com/AnumitaRoychowd), verified resolving before it went in.
+- **A label that contradicted its own link**, reading `@suaboromohanty (CREA)` above a link to `x.com/SunilDahiya16`. The description under it was right; only the handle was wrong. Now `@SunilDahiya16 (CREA)`.
+- **A four-second wait for nothing on every load.** The feed still called `twitter-feed`, which reads Nitter — whose public instances have gone. Measured against production, the endpoint does not answer at all, so every visitor opening the panel waited for the timeout to expire in exchange for zero posts. The call is gone; the curated links stay, because links to a live X search are the honest thing X can still offer.
+
+The panel's own description claimed "auto-updating posts … from X/Twitter, Reddit, Instagram, and YouTube". It now names Reddit, YouTube and Indian news as the feeds, and says plainly that X and Instagram are links out rather than feeds, and why. The two search-index entries describing the panel said the same wrong thing and were corrected with it.
+
 ## [v26.6.162] - 2026-08-10
 
 ### Fixed — the YouTube feed was carrying Canadian wildfire smoke

--- a/app.js
+++ b/app.js
@@ -4915,14 +4915,12 @@
 
         // Try Netlify Functions for Twitter/Instagram/News (with timeout, non-blocking)
         const proxyFetches = [];
-        if (filter === 'all' || filter === 'twitter') {
-            proxyFetches.push(
-                fetch('/.netlify/functions/twitter-feed', { signal: AbortSignal.timeout(4000) })
-                    .then(r => r.text())
-                    .then(t => { if (t.startsWith('{')) { const d = JSON.parse(t); return (d.posts||[]).map(p => ({ platform:'twitter', title:p.text, url:p.link, created:new Date(p.date), author:p.author, text:p.description?.substring(0,200)||'' })); } return []; })
-                    .catch(() => [])
-            );
-        }
+        // No call to twitter-feed. That endpoint reads Nitter, whose public
+        // instances have gone; measured against production it does not answer
+        // at all, so this was a guaranteed four-second wait on every load of
+        // the feed in exchange for nothing. The curated X entries below are
+        // links to live searches and accounts, which is what X can still
+        // honestly offer.
         if (filter === 'all' || filter === 'instagram') {
             proxyFetches.push(
                 fetch('/.netlify/functions/instagram-feed', { signal: AbortSignal.timeout(4000) })
@@ -5026,8 +5024,8 @@
             { platform: 'twitter', title: 'Search #DelhiAirPollution on X', url: 'https://x.com/search?q=%23DelhiAirPollution&f=live', created: new Date(), text: 'Live search results for Delhi air pollution discussions on X/Twitter. Click to see the latest posts.' },
             { platform: 'twitter', title: 'Search #DelhiSmog on X', url: 'https://x.com/search?q=%23DelhiSmog&f=live', created: new Date(), text: 'Trending discussions about Delhi smog and air quality crisis.' },
             { platform: 'twitter', title: 'Search #AirPollutionIndia on X', url: 'https://x.com/search?q=%23AirPollutionIndia&f=live', created: new Date(), text: 'Pan-India air pollution discussions, policy debates, and citizen reports.' },
-            { platform: 'twitter', title: '@ABOROMOHANTY (CSE)', url: 'https://x.com/ABOROMOHANTY', created: new Date(), text: 'Anumita Roychowdhury, CSE — leading air quality researcher and policy advocate.' },
-            { platform: 'twitter', title: '@suaboromohanty (CREA)', url: 'https://x.com/SunilDahiya16', created: new Date(), text: 'Sunil Dahiya, CREA analyst — data-driven air quality analysis.' }
+            { platform: 'twitter', title: '@AnumitaRoychowd (CSE)', url: 'https://x.com/AnumitaRoychowd', created: new Date(), text: 'Anumita Roychowdhury, CSE — leading air quality researcher and policy advocate.' },
+            { platform: 'twitter', title: '@SunilDahiya16 (CREA)', url: 'https://x.com/SunilDahiya16', created: new Date(), text: 'Sunil Dahiya, CREA analyst — data-driven air quality analysis.' }
         ];
     }
 
@@ -7243,7 +7241,7 @@ Generated via JanVayu (janvayu.in) — India's citizen air quality platform`;
         { id: 'accountability-brief', title: 'Accountability Brief (AI)', desc: 'Ward-level briefs for councillors and journalists', keywords: 'brief accountability ward councillor journalist ai llama report' },
         { id: 'resources', title: 'Reading List', desc: 'Reports, studies, expert organizations', keywords: 'resources library reading list research report study paper crea cse iqair lancet' },
         { id: 'downloads', title: 'Downloads', desc: 'PDFs, legal docs, data exports', keywords: 'download pdf export data document template rti' },
-        { id: 'social-feed', title: 'Social Media Feed', desc: 'Live posts from Reddit, X, Instagram, YouTube about air pollution', keywords: 'social media twitter x reddit instagram youtube feed live posts' },
+        { id: 'social-feed', title: 'Social Media Feed', desc: 'Live posts from Reddit, YouTube and Indian news; X and Instagram as links out', keywords: 'social media twitter x reddit instagram youtube feed live posts' },
         { id: 'aqi-story', title: 'The Air We Breathe', desc: 'Editorial story with text flowing around live AQI data', keywords: 'editorial story pretext text layout narrative air quality crisis deaths NCAP' },
         { id: 'live-news', title: 'Live News', desc: 'Auto-updating air quality news from multiple sources', keywords: 'news live updates articles headlines breaking' },
         { id: 'aqi-alerts', title: 'AQI Alerts', desc: 'Browser push notifications for dangerous AQI levels', keywords: 'alerts notifications push warning threshold' },

--- a/index.html
+++ b/index.html
@@ -1688,7 +1688,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
                     </div>
                     <div class="quick-link" onclick="showPanel('social-feed')">
                         <div class="quick-link-icon" style="background: #FFF7ED; color: #F97316;"><span class="si si-article" style="width:20px;height:20px;"></span></div>
-                        <div><h3 data-i18n="ql_social_t">Social Feed</h3><p data-i18n="ql_social_d">Live from Reddit &amp; X</p></div>
+                        <div><h3 data-i18n="ql_social_t">Social Feed</h3><p data-i18n="ql_social_d">Live from Reddit, YouTube &amp; news</p></div>
                     </div>
                     <div class="quick-link" onclick="showPanel('aqi-alerts')">
                         <div class="quick-link-icon" style="background: #FEF2F2; color: var(--red);"><span class="si si-notifications" style="width:20px;height:20px;"></span></div>
@@ -4696,7 +4696,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
 <template id="tmpl-social-feed">
     <div class="container">
         <h2 style="font-family: var(--serif); font-size: 1.75rem; margin-bottom: 0.5rem;">Live Social Media Feed</h2>
-        <p style="color: var(--text-2); margin-bottom: 1.5rem;" data-simple="See what people are posting right now about air pollution on Twitter, Reddit, Instagram, and YouTube. Updates automatically every 15 minutes.">Auto-updating posts about India's air quality from X/Twitter, Reddit, Instagram, and YouTube. Refreshes every 15 minutes.</p>
+        <p style="color: var(--text-2); margin-bottom: 1.5rem;" data-simple="See what people are posting right now about air pollution on Twitter, Reddit, Instagram, and YouTube. Updates automatically every 15 minutes.">Auto-updating posts about India&rsquo;s air quality from Reddit, YouTube and Indian news, refreshed every 15 minutes. X and Instagram are links out, not feeds: neither can be read without a paid or authenticated API, and we would rather send you to the live search than show a feed that is not one.</p>
 
         <div style="display: flex; gap: 0.5rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
             <button class="btn btn-sm" style="background: var(--green-700); color: var(--on-accent);" onclick="loadSocialFeed('all')">All</button>
@@ -6269,7 +6269,7 @@ const ROLE_CONFIG = {
             { panel: 'voices', title: 'Voices Online', desc: 'Social media sentiment archive' },
             { panel: 'downloads', title: 'Downloads', desc: 'Reports & presentations' },
             { panel: 'resources', title: 'Reading List', desc: 'Verified data sources' },
-            { panel: 'social-feed', title: 'Social Media Feed', desc: 'Reddit, Twitter, Instagram, YouTube' }
+            { panel: 'social-feed', title: 'Social Media Feed', desc: 'Reddit, YouTube and news, plus links out to X and Instagram' }
         ]
     },
     citizen: {


### PR DESCRIPTION
The homepage card read **"Live from Reddit & X"**. X has not been readable since its API closed — it was removed from the Voices panel days ago — while YouTube search, now working on a key, wasn't mentioned at all. It now reads **"Live from Reddit, YouTube & news"**, which is what actually runs.

Looking at that card properly turned up three more faults behind it.

### A dead link in production

The curated X list offered `@ABOROMOHANTY (CSE)` for Anumita Roychowdhury. That handle **404s** — checked, not assumed:

```
404  https://x.com/ABOROMOHANTY
200  https://x.com/AnumitaRoychowd     ← her actual account
```

Replaced, and the new one verified resolving before it went in.

### A label that contradicted its own link

`@suaboromohanty (CREA)` sat above a link to `x.com/SunilDahiya16`. The description underneath was correct — Sunil Dahiya, CREA — so only the handle was wrong, apparently copied from the line above it. Now `@SunilDahiya16 (CREA)`.

### A four-second wait for nothing, on every load

The feed still called `/.netlify/functions/twitter-feed`, which reads Nitter — whose public instances have gone. Measured against production:

```
curl: (28) Operation timed out after 30001 milliseconds with 0 bytes received
```

The endpoint does not answer **at all**. So every visitor who opened the panel waited out a 4-second timeout in exchange for zero posts. The call is removed. The curated links stay, because a link to a live X search is the honest thing X can still offer.

### And the copy that described all this wrongly

The panel's own description promised "auto-updating posts … from X/Twitter, Reddit, Instagram, and YouTube". It now names the three that are genuinely feeds, and says plainly that X and Instagram are links out rather than feeds, and why. The two search-index entries repeating the same claim were corrected with it.

## Verification

Checked in a real browser, not by reading the diff:

- Homepage card renders `Social Feed — Live from Reddit, YouTube & news`.
- Network log on opening the panel: `reddit-feed` called, **`twitter-feed` not called**.
- Both surviving X profile links return 200; the five curated entries render with handles matching their hrefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_