### PR TITLE
The testimony wall looked untouched after 108 voices were added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v26.6.165] - 2026-08-10
+
+### Fixed — the testimony wall looked untouched after 108 voices were added
+
+The count said 250, the language chips gained Nepali, and the page opened on exactly the same quotes it always had. The wall rendered in file order and the new field-collected entries were appended, so **all 108 of them sat at position 142 or below** — past the fold, effectively unread. Anyone who opened it saw no change, which is a fair reading of "not updated": the visible page genuinely wasn't.
+
+A wall of testimony should not have a permanent bottom. The order is now shuffled with a seed taken from the date, so every voice reaches the top over time instead of whoever was added last never being read. The order holds steady through a single day, so a quote seen an hour ago is still where it was and can be sent to someone else. Search, the language filter and the counts are unaffected.
+
+Measured after the change: 3 of the opening 8 cards are field-collected, against 0 before, which is about what 108 in 250 should give.
+
 ## [v26.6.164] - 2026-08-10
 
 ### Fixed — Ask JanVayu knew none of this week's work, and two of its facts were stale

--- a/index.html
+++ b/index.html
@@ -2005,9 +2005,36 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
         if (__testimoniesLoaded) return;
         try {
             const res = await fetch('/data/testimonies.json');
-            if (res.ok) { CITIZEN_TESTIMONIES = await res.json(); }
+            if (res.ok) { CITIZEN_TESTIMONIES = shuffleDaily(await res.json()); }
         } catch (e) { console.warn('Testimonies failed to load:', e); }
         __testimoniesLoaded = true;
+    }
+
+    // The wall used to render in file order, which meant it opened on the same
+    // few quotes every day and whoever was appended last was never read: adding
+    // 108 field-collected voices put every one of them at position 142 or below,
+    // so the page looked untouched even as the count went from 142 to 250.
+    //
+    // A wall of testimony should not have a permanent bottom. The order is
+    // shuffled with a seed derived from the date, so every voice gets its turn
+    // at the top over time, while the order holds steady through a single day —
+    // someone can scroll back to a quote they saw an hour ago, or send it to
+    // somebody else, and find it in the same place.
+    function shuffleDaily(list) {
+        const d = new Date();
+        let seed = d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+        const rand = () => {
+            // xorshift32 — deterministic for a given day, and good enough to
+            // deal a pack of 250 cards.
+            seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5;
+            return ((seed >>> 0) % 100000) / 100000;
+        };
+        const out = list.slice();
+        for (let i = out.length - 1; i > 0; i--) {
+            const j = Math.floor(rand() * (i + 1));
+            [out[i], out[j]] = [out[j], out[i]];
+        }
+        return out;
     }
 
     function renderTestimonies(filterLang) {
@@ -2115,7 +2142,7 @@ p a, li a, dd a { text-decoration: underline; text-underline-offset: 0.14em; }
 
             <div class="testimony-toolbar">
                 <input type="search" id="testimony-search" placeholder="Search by city, state or words&hellip;" oninput="renderTestimonies()" style="flex: 1 1 220px; min-width: 180px; padding: 7px 12px; border: 1px solid var(--border); border-radius: 8px; font-family: var(--sans); font-size: 0.85rem; background: var(--bg-card); color: var(--ink);">
-                <span style="font-size: 0.78rem; color: var(--text-3);">Showing <strong id="testimony-count">0</strong></span>
+                <span style="font-size: 0.78rem; color: var(--text-3);">Showing <strong id="testimony-count">0</strong> &middot; <span title="The order is shuffled once a day, so every voice reaches the top of the page over time instead of whoever was added last never being read.">in a daily-shuffled order</span></span>
             </div>
 
             <div id="testimony-lang-bar" class="testimony-toolbar" style="margin-bottom: 1.5rem;"></div>


### PR DESCRIPTION
You were right, and it took looking at the render order to see why.

The count said **250**, the language chips gained Nepali, the data on disk was correct — and the page opened on **exactly the same quotes it always had**. The wall renders in file order, and the 108 field-collected entries were appended to the end:

```
positions of the 108 new entries: first at index 142 of 250 — last at 249
```

Every one of them sat past the fold. Anyone opening the page saw no change. "Not updated" was a fair reading — the visible page genuinely wasn't.

The homepage card and the panel intro *were* both correct (`250 people, 14 languages`, verified live), which is exactly what made this hard to spot: every number was right and the page still looked identical.

## The fix

A wall of testimony should not have a permanent bottom. Ordering is now shuffled from a **date-derived seed**:

- Every voice reaches the top of the page over time, instead of whoever was added last never being read.
- The order **holds steady through a single day**, so a quote someone saw an hour ago is still where it was, and can be sent to somebody else.
- Search, the language filter and the counts are untouched.

I chose a daily shuffle over "newest first" deliberately. Newest-first would just invert the problem — the original 142 would become the permanently unread ones. These are people's accounts of their own lives; none of them should be structurally unreachable.

## Verification

In a real browser after the change:

```
total: 250 | 250 testimonies · 107 cities · 14 languages
first eight:  FIELD (Patna, 10 Aug 2025) · older · older · older
              FIELD (Sri Ganganagar) · older · older · FIELD (Raipur)
field-collected in the opening eight: 3   (was 0)
search "Byrnihat" -> 3 results           (filtering unaffected)
```

Three in eight is about what 108 of 250 should give.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrdFeNisKU6a67xYKiaE6)_